### PR TITLE
multi: change grub to litd, fix comments

### DIFF
--- a/log.go
+++ b/log.go
@@ -18,9 +18,9 @@ import (
 )
 
 var (
-	// log is a logger that is initialized with no output filters.  This means the
-	// package will not perform any logging by default until the caller requests
-	// it.
+	// log is a logger that is initialized with no output filters. This
+	// means the package will not perform any logging by default until the
+	// caller requests it.
 	log btclog.Logger
 )
 
@@ -50,7 +50,7 @@ func UseLogger(logger btclog.Logger) {
 
 // SetupLoggers initializes all package-global logger variables.
 func SetupLoggers(root *build.RotatingLogWriter) {
-	// Add the GrUB logger.
+	// Add the lightning-terminal root logger.
 	lnd.AddSubLogger(root, Subsystem, UseLogger)
 
 	// Add faraday loggers to lnd's root logger.

--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -12,7 +12,7 @@ windows-386 \
 windows-amd64 \
 windows-arm
 
-LND_RELEASE_TAGS = grub autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc
+LND_RELEASE_TAGS = litd autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc
 
 # By default we will build all systems. But with the 'sys' tag, a specific
 # system can be specified. This is useful to release for a subset of

--- a/terminal.go
+++ b/terminal.go
@@ -132,7 +132,7 @@ func (g *LightningTerminal) Run() error {
 	// port at a time because we can only pass in one pre-configured RPC
 	// listener into lnd.
 	if len(g.cfg.Lnd.RPCListeners) > 1 {
-		return fmt.Errorf("grub only supports one RPC listener at a " +
+		return fmt.Errorf("litd only supports one RPC listener at a " +
 			"time")
 	}
 	rpcAddr := g.cfg.Lnd.RPCListeners[0]


### PR DESCRIPTION
Found a few mentions of `grub` that should be renamed to `litd`.