### PR TITLE
ci: add yarn cache to backend CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,7 @@ jobs:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ matrix.node_version }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
+            ${{ runner.os }}-yarn-${{ matrix.node_version }}-${{ hashFiles('**/yarn.lock') }}
             ${{ runner.os }}-yarn-${{ matrix.node_version }}-
             ${{ runner.os }}-yarn-
 
@@ -89,6 +90,21 @@ jobs:
             ${{ runner.os }}-go-${{ matrix.go_version }}-${{ hashFiles('**/go.sum') }}
             ${{ runner.os }}-go-${{ matrix.go_version }}-
             ${{ runner.os }}-go-
+
+      - name: get yarn cache dir
+        id: yarn-cache-dir
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-yarn-12.x-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-12.x-${{ hashFiles('**/yarn.lock') }}
+            ${{ runner.os }}-yarn-12.x-
+            ${{ runner.os }}-yarn-
 
       - name: setup go v${{ matrix.go_version }}
         uses: actions/setup-go@v2


### PR DESCRIPTION
The backend CI build intermittently fails due to networking errors when fetching the yarn dependencies. This PR adds a build step to cache the dependencies which should reduce these flaky build failures.