### PR TITLE
docker: add protoc to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --no-cache --update alpine-sdk \
     bash \
     binutils \
     tar \
+    protobuf-dev \
 && touch ~/.bashrc \
 && curl -sfSLO https://unofficial-builds.nodejs.org/download/release/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64-musl.tar.xz \
 && tar -xf node-${NODE_VERSION}-linux-x64-musl.tar.xz -C /usr --strip 1 \

--- a/app/scripts/build-protos.js
+++ b/app/scripts/build-protos.js
@@ -82,6 +82,7 @@ const main = async () => {
     await patch();
   } catch (error) {
     console.error(error);
+    process.exit(1);
   }
 };
 


### PR DESCRIPTION
This PR fixes the docker build which was previously broken by #81. 

`protoc` needs to be installed in the image for the app to compile the proto files during the build.