### PR TITLE
doc: add included daemon versions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ only need to download one executable and run one command to get LiT up and runni
 include the CLI binaries `lncli`, `loop` and `frcli` for convenience in the downloadable
 archives as well.
 
+### Daemon Versions packaged with LiT
+
+| LiT              | LND         | Loop        | Faraday      |
+| ---------------- | ----------- | ----------- | ------------ |
+| **v0.1.0-alpha** | v0.6.3-beta | v0.6.5-beta | v0.2.0-alpha |
+
 ## Usage
 
 Read the [Walkthrough](doc/WALKTHROUGH.md) document to learn more about how to use


### PR DESCRIPTION
This PR just adds a list of which versions of LND, Loop, and Faraday are included with LiT.