### PR TITLE
add sorting of the channel and history lists

### DIFF
--- a/app/src/__tests__/components/history/HistoryPage.spec.tsx
+++ b/app/src/__tests__/components/history/HistoryPage.spec.tsx
@@ -8,8 +8,9 @@ import HistoryPage from 'components/history/HistoryPage';
 describe('HistoryPage', () => {
   let store: Store;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     store = createStore();
+    await store.swapStore.fetchSwaps();
   });
 
   const render = () => {
@@ -35,9 +36,35 @@ describe('HistoryPage', () => {
     expect(getByText('Updated')).toBeInTheDocument();
   });
 
-  it('should export channels', () => {
+  it('should export loop history', () => {
     const { getByText } = render();
     fireEvent.click(getByText('download.svg'));
     expect(saveAs).toBeCalledWith(expect.any(Blob), 'swaps.csv');
+  });
+
+  it('should sort the history list', () => {
+    const { getByText, store } = render();
+    expect(store.settingsStore.historySort.field).toBe('lastUpdateTime');
+    expect(store.settingsStore.historySort.descending).toBe(true);
+
+    fireEvent.click(getByText('Status'));
+    expect(store.settingsStore.historySort.field).toBe('stateLabel');
+
+    fireEvent.click(getByText('Type'));
+    expect(store.settingsStore.historySort.field).toBe('typeName');
+
+    fireEvent.click(getByText('Amount'));
+    expect(store.settingsStore.historySort.field).toBe('amount');
+
+    fireEvent.click(getByText('Created'));
+    expect(store.settingsStore.historySort.field).toBe('initiationTime');
+
+    fireEvent.click(getByText('Updated'));
+    expect(store.settingsStore.historySort.field).toBe('lastUpdateTime');
+    expect(store.settingsStore.historySort.descending).toBe(false);
+
+    fireEvent.click(getByText('Updated'));
+    expect(store.settingsStore.historySort.field).toBe('lastUpdateTime');
+    expect(store.settingsStore.historySort.descending).toBe(true);
   });
 });

--- a/app/src/__tests__/components/loop/LoopPage.spec.tsx
+++ b/app/src/__tests__/components/loop/LoopPage.spec.tsx
@@ -173,5 +173,40 @@ describe('LoopPage component', () => {
       expect(getByText('Review Loop amount and fee')).toBeInTheDocument();
       expect(store.buildSwapStore.processingTimeout).toBeUndefined();
     });
+
+    it('should sort the channel list', () => {
+      const { getByText, store } = render();
+      expect(getByText('Capacity')).toBeInTheDocument();
+      expect(store.settingsStore.channelSort.field).toBeUndefined();
+      expect(store.settingsStore.channelSort.descending).toBe(true);
+
+      fireEvent.click(getByText('Can Receive'));
+      expect(store.settingsStore.channelSort.field).toBe('remoteBalance');
+
+      fireEvent.click(getByText('Can Send'));
+      expect(store.settingsStore.channelSort.field).toBe('localBalance');
+
+      fireEvent.click(getByText('In Fee %'));
+      expect(store.settingsStore.channelSort.field).toBe('remoteFeeRate');
+
+      fireEvent.click(getByText('Uptime %'));
+      expect(store.settingsStore.channelSort.field).toBe('uptimePercent');
+
+      fireEvent.click(getByText('Peer/Alias'));
+      expect(store.settingsStore.channelSort.field).toBe('aliasLabel');
+
+      fireEvent.click(getByText('Capacity'));
+      expect(store.settingsStore.channelSort.field).toBe('capacity');
+      expect(store.settingsStore.channelSort.descending).toBe(false);
+
+      fireEvent.click(getByText('Capacity'));
+      expect(store.settingsStore.channelSort.field).toBe('capacity');
+      expect(store.settingsStore.channelSort.descending).toBe(true);
+
+      expect(getByText('slash.svg')).toBeInTheDocument();
+      fireEvent.click(getByText('slash.svg'));
+      expect(store.settingsStore.channelSort.field).toBeUndefined();
+      expect(store.settingsStore.channelSort.descending).toBe(true);
+    });
   });
 });

--- a/app/src/assets/icons/arrow-down.svg
+++ b/app/src/assets/icons/arrow-down.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-arrow-down">
+  <line x1="12" y1="5" x2="12" y2="19"></line>
+  <polyline points="19 12 12 19 5 12"></polyline>
+</svg>

--- a/app/src/assets/icons/arrow-up.svg
+++ b/app/src/assets/icons/arrow-up.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-arrow-up">
+  <line x1="12" y1="19" x2="12" y2="5"></line>
+  <polyline points="5 12 12 5 19 12"></polyline>
+</svg>

--- a/app/src/assets/icons/slash.svg
+++ b/app/src/assets/icons/slash.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-slash">
+  <circle cx="12" cy="12" r="10"></circle>
+  <line x1="4.93" y1="4.93" x2="19.07" y2="19.07"></line>
+</svg>

--- a/app/src/components/base/icons.tsx
+++ b/app/src/components/base/icons.tsx
@@ -1,5 +1,7 @@
+import { ReactComponent as ArrowDownIcon } from 'assets/icons/arrow-down.svg';
 import { ReactComponent as ArrowLeftIcon } from 'assets/icons/arrow-left.svg';
 import { ReactComponent as ArrowRightIcon } from 'assets/icons/arrow-right.svg';
+import { ReactComponent as ArrowUpIcon } from 'assets/icons/arrow-up.svg';
 import { ReactComponent as BitcoinIcon } from 'assets/icons/bitcoin.svg';
 import { ReactComponent as BoltIcon } from 'assets/icons/bolt.svg';
 import { ReactComponent as CheckIcon } from 'assets/icons/check.svg';
@@ -16,10 +18,11 @@ import { ReactComponent as MaximizeIcon } from 'assets/icons/maximize.svg';
 import { ReactComponent as MenuIcon } from 'assets/icons/menu.svg';
 import { ReactComponent as MinimizeIcon } from 'assets/icons/minimize.svg';
 import { ReactComponent as RefreshIcon } from 'assets/icons/refresh-cw.svg';
+import { ReactComponent as CancelIcon } from 'assets/icons/slash.svg';
 import { styled } from 'components/theme';
 
 interface IconProps {
-  size?: 'small' | 'medium' | 'large';
+  size?: 'x-small' | 'small' | 'medium' | 'large';
   onClick?: () => void;
 }
 
@@ -38,6 +41,13 @@ const Icon = styled.span<IconProps>`
       background-color: ${props.theme.colors.offWhite}; 
     }
   `}
+
+  ${props =>
+    props.size === 'x-small' &&
+    `
+      width: 16px;
+      height: 16px;
+    `}
 
   ${props =>
     props.size === 'small' &&
@@ -61,10 +71,13 @@ const Icon = styled.span<IconProps>`
     `}
 `;
 
+export const ArrowLeft = Icon.withComponent(ArrowLeftIcon);
 export const ArrowRight = Icon.withComponent(ArrowRightIcon);
+export const ArrowUp = Icon.withComponent(ArrowUpIcon);
+export const ArrowDown = Icon.withComponent(ArrowDownIcon);
+export const Cancel = Icon.withComponent(CancelIcon);
 export const Clock = Icon.withComponent(ClockIcon);
 export const Download = Icon.withComponent(DownloadIcon);
-export const ArrowLeft = Icon.withComponent(ArrowLeftIcon);
 export const Bolt = Icon.withComponent(BoltIcon);
 export const Bitcoin = Icon.withComponent(BitcoinIcon);
 export const Check = Icon.withComponent(CheckIcon);

--- a/app/src/components/common/SortableHeader.tsx
+++ b/app/src/components/common/SortableHeader.tsx
@@ -1,0 +1,62 @@
+import React, { useCallback } from 'react';
+import { SortParams } from 'types/state';
+import { ArrowDown, ArrowUp, HeaderFour } from 'components/base';
+import { styled } from 'components/theme';
+
+const Styled = {
+  HeaderFour: styled(HeaderFour)<{ selected: boolean }>`
+    ${props =>
+      props.selected &&
+      `
+      color: ${props.theme.colors.white};
+    `}
+
+    &:hover {
+      cursor: pointer;
+      color: ${props => props.theme.colors.white};
+    }
+  `,
+  Icon: styled.span`
+    display: inline-block;
+    margin-left: 6px;
+
+    svg {
+      padding: 0;
+    }
+  `,
+};
+
+interface Props<T> {
+  field: keyof T;
+  sort: SortParams<T>;
+  onSort: (field: SortParams<T>['field'], descending: boolean) => void;
+}
+
+const SortableHeader = <T,>({
+  field,
+  sort,
+  onSort,
+  children,
+}: React.PropsWithChildren<Props<T>>) => {
+  const selected = field === sort.field;
+  const SortIcon = sort.descending ? ArrowDown : ArrowUp;
+
+  const handleSortClick = useCallback(() => {
+    const descending = selected ? !sort.descending : false;
+    onSort(field, descending);
+  }, [selected, sort.descending, field, onSort]);
+
+  const { HeaderFour, Icon } = Styled;
+  return (
+    <HeaderFour selected={selected} onClick={handleSortClick}>
+      {children}
+      {selected && (
+        <Icon>
+          <SortIcon size="x-small" />
+        </Icon>
+      )}
+    </HeaderFour>
+  );
+};
+
+export default SortableHeader;

--- a/app/src/components/history/HistoryRow.tsx
+++ b/app/src/components/history/HistoryRow.tsx
@@ -1,8 +1,10 @@
 import React, { CSSProperties } from 'react';
 import { observer } from 'mobx-react-lite';
 import { usePrefixedTranslation } from 'hooks';
+import { useStore } from 'store';
 import { Swap } from 'store/models';
-import { Column, HeaderFour, Row } from 'components/base';
+import { Column, Row } from 'components/base';
+import SortableHeader from 'components/common/SortableHeader';
 import Unit from 'components/common/Unit';
 import SwapDot from 'components/loop/SwapDot';
 import { styled } from 'components/theme';
@@ -43,30 +45,64 @@ const Styled = {
   `,
 };
 
-export const HistoryRowHeader: React.FC = () => {
+const RowHeader: React.FC = () => {
   const { l } = usePrefixedTranslation('cmps.history.HistoryRowHeader');
+  const { settingsStore } = useStore();
+
   const { HeaderRow, ActionColumn, HeaderColumn } = Styled;
   return (
     <HeaderRow>
       <ActionColumn />
       <HeaderColumn cols={3}>
-        <HeaderFour>{l('status')}</HeaderFour>
+        <SortableHeader<Swap>
+          field="stateLabel"
+          sort={settingsStore.historySort}
+          onSort={settingsStore.setHistorySort}
+        >
+          {l('status')}
+        </SortableHeader>
       </HeaderColumn>
       <HeaderColumn>
-        <HeaderFour>{l('type')}</HeaderFour>
+        <SortableHeader<Swap>
+          field="typeName"
+          sort={settingsStore.historySort}
+          onSort={settingsStore.setHistorySort}
+        >
+          {l('type')}
+        </SortableHeader>
       </HeaderColumn>
       <HeaderColumn right>
-        <HeaderFour>{l('amount')}</HeaderFour>
+        <SortableHeader<Swap>
+          field="amount"
+          sort={settingsStore.historySort}
+          onSort={settingsStore.setHistorySort}
+        >
+          {l('amount')}
+        </SortableHeader>
       </HeaderColumn>
       <HeaderColumn right>
-        <HeaderFour>{l('created')}</HeaderFour>
+        <SortableHeader<Swap>
+          field="initiationTime"
+          sort={settingsStore.historySort}
+          onSort={settingsStore.setHistorySort}
+        >
+          {l('created')}
+        </SortableHeader>
       </HeaderColumn>
       <HeaderColumn right>
-        <HeaderFour>{l('updated')}</HeaderFour>
+        <SortableHeader<Swap>
+          field="lastUpdateTime"
+          sort={settingsStore.historySort}
+          onSort={settingsStore.setHistorySort}
+        >
+          {l('updated')}
+        </SortableHeader>
       </HeaderColumn>
     </HeaderRow>
   );
 };
+
+export const HistoryRowHeader = observer(RowHeader);
 
 interface Props {
   swap: Swap;

--- a/app/src/i18n/locales/en-US.json
+++ b/app/src/i18n/locales/en-US.json
@@ -23,6 +23,7 @@
   "cmps.loop.ChannelIcon.processing.in": "Loop In currently in progress",
   "cmps.loop.ChannelIcon.processing.out": "Loop Out currently in progress",
   "cmps.loop.ChannelIcon.processing.both": "Loop In and Loop Out currently in progress",
+  "cmps.loop.ChannelRowHeader.resetSort": "Reset Sorting",
   "cmps.loop.ChannelRowHeader.canReceive": "Can Receive",
   "cmps.loop.ChannelRowHeader.canSend": "Can Send",
   "cmps.loop.ChannelRowHeader.feeRate": "In Fee %",

--- a/app/src/store/models/swap.ts
+++ b/app/src/store/models/swap.ts
@@ -1,6 +1,7 @@
 import { action, computed, observable } from 'mobx';
 import { now } from 'mobx-utils';
 import * as LOOP from 'types/generated/loop_pb';
+import { SortParams } from 'types/state';
 import Big from 'big.js';
 import formatDate from 'date-fns/format';
 import { CsvColumns } from 'util/csv';
@@ -110,6 +111,30 @@ export default class Swap {
     this.initiationTime = loopSwap.initiationTime;
     this.lastUpdateTime = loopSwap.lastUpdateTime;
     this.state = loopSwap.state;
+  }
+
+  /**
+   * Compares a specific field of two swaps for sorting
+   * @param a the first swap to compare
+   * @param b the second swap to compare
+   * @param sortBy the field and direction to sort the two swaps by
+   * @returns a positive number if `a`'s field is greater than `b`'s,
+   * a negative number if `a`'s field is less than `b`'s, or zero otherwise
+   */
+  static compare(a: Swap, b: Swap, field: SortParams<Swap>['field']): number {
+    switch (field) {
+      case 'stateLabel':
+        return a.stateLabel.toLowerCase() > b.stateLabel.toLowerCase() ? 1 : -1;
+      case 'typeName':
+        return a.typeName.toLowerCase() > b.typeName.toLowerCase() ? 1 : -1;
+      case 'amount':
+        return +a.amount.sub(b.amount);
+      case 'initiationTime':
+        return a.initiationTime - b.initiationTime;
+      case 'lastUpdateTime':
+      default:
+        return a.lastUpdateTime - b.lastUpdateTime;
+    }
   }
 
   /**

--- a/app/src/store/stores/channelStore.ts
+++ b/app/src/store/stores/channelStore.ts
@@ -34,9 +34,11 @@ export default class ChannelStore {
    * an array of channels sorted by balance percent descending
    */
   @computed get sortedChannels() {
-    return values(this.channels)
+    const { field, descending } = this._store.settingsStore.channelSort;
+    const channels = values(this.channels)
       .slice()
-      .sort((a, b) => b.sortOrder - a.sortOrder);
+      .sort((a, b) => Channel.compare(a, b, field));
+    return descending ? channels.reverse() : channels;
   }
 
   /**

--- a/app/src/store/stores/settingsStore.ts
+++ b/app/src/store/stores/settingsStore.ts
@@ -2,7 +2,7 @@ import { action, autorun, observable, toJS } from 'mobx';
 import { SortParams } from 'types/state';
 import { BalanceMode, Unit } from 'util/constants';
 import { Store } from 'store';
-import { Channel } from 'store/models';
+import { Channel, Swap } from 'store/models';
 
 export interface PersistentSettings {
   sidebarVisible: boolean;
@@ -10,6 +10,7 @@ export interface PersistentSettings {
   balanceMode: BalanceMode;
   tourAutoShown: boolean;
   channelSort: SortParams<Channel>;
+  historySort: SortParams<Swap>;
 }
 
 export default class SettingsStore {
@@ -33,6 +34,12 @@ export default class SettingsStore {
   /** specifies the sorting field and direction for the channel list */
   @observable channelSort: SortParams<Channel> = {
     field: undefined,
+    descending: true,
+  };
+
+  /** specifies the sorting field and direction for the channel list */
+  @observable historySort: SortParams<Swap> = {
+    field: 'lastUpdateTime',
     descending: true,
   };
 
@@ -99,6 +106,17 @@ export default class SettingsStore {
   }
 
   /**
+   * Sets the sort field and direction that the swap history list should use
+   * @param field the swap field to sort by
+   * @param descending true of the order should be descending, otherwise false
+   */
+  @action.bound
+  setHistorySort(field: SortParams<Swap>['field'], descending: boolean) {
+    this.historySort = { field, descending };
+    this._store.log.info('updated history list sort order', toJS(this.historySort));
+  }
+
+  /**
    * initialized the settings and auto-save when a setting is changed
    */
   @action.bound
@@ -112,6 +130,7 @@ export default class SettingsStore {
           balanceMode: this.balanceMode,
           tourAutoShown: this.tourAutoShown,
           channelSort: toJS(this.channelSort),
+          historySort: toJS(this.historySort),
         };
         this._store.storage.set('settings', settings);
         this._store.log.info('saved settings to localStorage', settings);
@@ -133,6 +152,7 @@ export default class SettingsStore {
       this.balanceMode = settings.balanceMode;
       this.tourAutoShown = settings.tourAutoShown;
       if (settings.channelSort) this.channelSort = settings.channelSort;
+      if (settings.historySort) this.historySort = settings.historySort;
       this._store.log.info('loaded settings', settings);
     }
 

--- a/app/src/store/stores/swapStore.ts
+++ b/app/src/store/stores/swapStore.ts
@@ -37,9 +37,12 @@ export default class SwapStore {
 
   /** swaps sorted by created date descending */
   @computed get sortedSwaps() {
-    return values(this.swaps)
+    const { field, descending } = this._store.settingsStore.historySort;
+    const swaps = values(this.swaps)
       .slice()
-      .sort((a, b) => b.initiationTime - a.initiationTime);
+      .sort((a, b) => Swap.compare(a, b, field));
+
+    return descending ? swaps.reverse() : swaps;
   }
 
   /** the last two swaps */

--- a/app/src/types/state.ts
+++ b/app/src/types/state.ts
@@ -38,3 +38,8 @@ export interface Alert {
   /** the number of milliseconds before the toast closes automatically */
   ms?: number;
 }
+
+export interface SortParams<T> {
+  field?: keyof T;
+  descending: boolean;
+}


### PR DESCRIPTION
Closed #86 

This PR adds the ability to manually sort the channel and history lists by clicking on the column headers.

### Steps to Test
1. Go to the Terminal page
1. Click on the column headers (click twice on the same header to change the direction)
1. Confirm the channels are sorting in the correct order
1. Go to the Loop History page
1. Clicking on the column headers
1. Confirm the loops are sorting in the correct order