### PR TITLE
loop: increase max swap routing fee

### DIFF
--- a/app/src/api/loop.ts
+++ b/app/src/api/loop.ts
@@ -99,7 +99,7 @@ class LoopApi extends BaseApi<LoopEvents> {
     req.setMaxSwapFee(+quote.swapFee);
     req.setMaxMinerFee(+quote.minerFee);
     req.setMaxPrepayAmt(+quote.prepayAmount);
-    req.setMaxSwapRoutingFee(this._calcRoutingFee(+quote.swapFee));
+    req.setMaxSwapRoutingFee(this._calcRoutingFee(+amount));
     req.setMaxPrepayRoutingFee(this._calcRoutingFee(+quote.prepayAmount));
     req.setOutgoingChanSetList(chanIds);
     req.setSwapPublicationDeadline(deadline);


### PR DESCRIPTION
Currently, `MaxSwapRoutingFee` is set to 2% of the `SwapFee` instead of 2% of the swap `Amount`. This can cause Loop Out off-chain payments to fail more often than they should because the max fee is set very low.