### PR TITLE
multi: update pool, fix docs, fix timeout issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Lightning Terminal is backwards compatible with `lnd` back to version v0.11.1-be
 
 | LiT              | LND          |
 | ---------------- | ------------ |
+| **v0.3.1-alpha** | v0.11.1-beta |
 | **v0.3.0-alpha** | v0.11.1-beta |
 | **v0.2.0-alpha** | v0.11.0-beta |
 
@@ -73,6 +74,7 @@ Lightning Terminal is backwards compatible with `lnd` back to version v0.11.1-be
 
 | LiT              | LND          | Loop        | Faraday      | Pool          |
 | ---------------- | ------------ | ----------- | ------------ |---------------|
+| **v0.3.1-alpha** | v0.11.1-beta | v0.11.1-beta | v0.2.2-alpha | v0.3.3-alpha |
 | **v0.3.0-alpha** | v0.11.1-beta | v0.11.0-beta | v0.2.2-alpha | v0.3.2-alpha |
 | **v0.2.0-alpha** | v0.11.1-beta | v0.10.0-beta | v0.2.1-alpha | n/a          |
 | **v0.1.1-alpha** | v0.11.0-beta | v0.8.1-beta | v0.2.0-alpha | n/a          |

--- a/doc/config-lnd-integrated.md
+++ b/doc/config-lnd-integrated.md
@@ -149,6 +149,10 @@ For `lnd`:
   After:
 
   ```text
+  # New flag to tell LiT to run its own lnd in integrated mode. We need to set
+  # this because "remote" is the new default value if we don't specify anything.
+  lnd-mode=integrated
+
   # Application Options
   lnd.alias=merchant
   

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/lightninglabs/faraday v0.2.2-alpha
 	github.com/lightninglabs/lndclient v0.11.0-3
 	github.com/lightninglabs/loop v0.11.1-beta
-	github.com/lightninglabs/pool v0.3.2-alpha
+	github.com/lightninglabs/pool v0.3.3-alpha
 	github.com/lightningnetwork/lnd v0.11.1-beta
 	github.com/lightningnetwork/lnd/cert v1.0.3
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/lightninglabs/loop v0.11.1-beta/go.mod h1:xZfGG0AbxwAoarGGLeEl8TEzGm/
 github.com/lightninglabs/neutrino v0.11.0/go.mod h1:CuhF0iuzg9Sp2HO6ZgXgayviFTn1QHdSTJlMncK80wg=
 github.com/lightninglabs/neutrino v0.11.1-0.20200316235139-bffc52e8f200 h1:j4iZ1XlUAPQmW6oSzMcJGILYsRHNs+4O3Gk+2Ms5Dww=
 github.com/lightninglabs/neutrino v0.11.1-0.20200316235139-bffc52e8f200/go.mod h1:MlZmoKa7CJP3eR1s5yB7Rm5aSyadpKkxqAwLQmog7N0=
-github.com/lightninglabs/pool v0.3.2-alpha h1:5wIXMBAPqxf7vQSRG/PUfrg47kfRssRGsBW+586Uk1k=
-github.com/lightninglabs/pool v0.3.2-alpha/go.mod h1:a955Z6GMXMUZWWbm0ytzVWKxU2uighi1h8PZrjFwmhI=
+github.com/lightninglabs/pool v0.3.3-alpha h1:WqCw+9jU6atIxlzau6r08xmiJB9CcWrwdpIgU+1/Zh8=
+github.com/lightninglabs/pool v0.3.3-alpha/go.mod h1:a955Z6GMXMUZWWbm0ytzVWKxU2uighi1h8PZrjFwmhI=
 github.com/lightninglabs/protobuf-hex-display v1.3.3-0.20191212020323-b444784ce75d h1:QWD/5MPnaZfUVP7P8wLa4M8Td2DI7XXHXt2vhVtUgGI=
 github.com/lightninglabs/protobuf-hex-display v1.3.3-0.20191212020323-b444784ce75d/go.mod h1:KDb67YMzoh4eudnzClmvs2FbiLG9vxISmLApUkCa4uI=
 github.com/lightningnetwork/lightning-onion v1.0.2-0.20200501022730-3c8c8d0b89ea h1:oCj48NQ8u7Vz+MmzHqt0db6mxcFZo3Ho7M5gCJauY/k=


### PR DESCRIPTION
This PR contains four independent changes that are too small to justify their own PRs:
1. Update Pool to version `v0.3.3-alpha`.
2. Mention the new `lnd-mode=integrated` flag in the docs where we describe the upgrade process from pre-0.3.0 versions.
3. Fix a connection timeout issue that caused long-running calls or streaming responses to be cut off after 10 seconds.
4. Bump versions in README.

Fixes #140, fixes #144.