### PR TITLE
Update golang to 1.15.5 for security update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine as builder
+FROM golang:1.15.5-alpine as builder
 
 # Copy in the local repository to build from.
 COPY . /go/src/github.com/lightninglabs/lightning-terminal


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/NpBGTTmKzpM/m/fLguyiM2CAAJ

Geth has made this change a high priority. Unsure if LND is affected. I have built LIT docker with 1.15.5 and it seems to run ok.  (havent tested lnd, pool, loop) - running to a remote lnd.