### PR TITLE
docker+GitHub: add production Dockerfile and build automatically on tag push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,45 @@
+name: Docker image build
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  DOCKER_REPO: lightninglabs
+  DOCKER_IMAGE: lightning-terminal
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_API_KEY }}
+
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: "${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}"
+          build-args: checkout=${{ env.RELEASE_VERSION }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,13 @@ go-install:
 	@$(call print, "Installing lightning-terminal.")
 	$(GOINSTALL) -tags="$(LND_RELEASE_TAGS)" -ldflags "$(LDFLAGS)" $(PKG)/cmd/litd
 
+go-install-cli:
+	@$(call print, "Installing all CLI binaries.")
+	$(GOINSTALL) -trimpath -tags="$(LND_RELEASE_TAGS)" -ldflags "$(LDFLAGS)" github.com/lightningnetwork/lnd/cmd/lncli
+	$(GOINSTALL) -trimpath -ldflags "$(LDFLAGS)" github.com/lightninglabs/loop/cmd/loop
+	$(GOINSTALL) -trimpath github.com/lightninglabs/faraday/cmd/frcli
+	$(GOINSTALL) -trimpath github.com/lightninglabs/pool/cmd/pool
+
 app-build: yarn-install
 	@$(call print, "Building production app.")
 	cd app; yarn build

--- a/doc/compile.md
+++ b/doc/compile.md
@@ -6,7 +6,7 @@ installed on your machine.
 | Dependency                                          | Description                                                                                                                                                                          |
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [golang](https://golang.org/doc/install)            | LiT's backend web server is written in Go. The minimum version supported is Go v1.13.                                                                                                |
-| [protoc](https://grpc.io/docs/protoc-installation/) | Required to compile LND & Loop gRPC proto files at build time.                                                                                                                        |
+| [protoc 3.4.0](https://github.com/lightningnetwork/lnd/tree/master/lnrpc#generate-protobuf-definitions) | Required to compile LND & Loop gRPC proto files at build time. Must be installed according to step 1 of the linked guide.  |
 | [nodejs](https://nodejs.org/en/download/)           | LiT's frontend is written in TypeScript and built on top of the React JS web framework. To bundle the assets into Javascript & CSS compatible with web browsers, NodeJS is required. |
 | [yarn](https://classic.yarnpkg.com/en/docs/install) | A popular package manager for NodeJS application dependencies.                                                                                                                        |
 

--- a/doc/compile.md
+++ b/doc/compile.md
@@ -26,3 +26,44 @@ need to download those binaries from the
 [loop](https://github.com/lightninglabs/loop/releases),
 [pool](https://github.com/lightninglabs/pool/releases), and
 [faraday](https://github.com/lightninglabs/faraday/releases) repos manually.
+
+## Building a docker image
+
+There are two flavors of Dockerfiles available:
+ - `Dockerfile`: Used for production builds. Checks out the source code from
+   GitHub during build. The build argument `--build-arg checkout=v0.x.x-alpha`
+   can be used to specify what git tag or commit to check out before building.
+ - `dev.Dockerfile` Used for development or testing builds. Uses the local code
+   when building and allows local changes to be tested more easily.
+
+### Building a development docker image
+
+Follow the instructions of the [previous chapter](#compile-from-source-code) to
+install all necessary dependencies.
+
+Then, instead of `make install` run the following commands:
+
+```shell script
+$ docker build -f dev.Dockerfile -t my-lit-dev-image .
+```
+
+If successful, you can then run the docker image with:
+
+```shell script
+$ docker run -p 8443:8443 --rm --name litd my-lit-dev-image \
+  --httpslisten=0.0.0.0:8443 \
+  ... (your configuration flags here)
+```
+
+See the [execution section in the main README](../README.md#execution) to find
+out what configuration flags to use.
+
+### Building a production docker image
+
+To create a production build, you need to specify the git tag to create the
+image from. All local files will be ignored, everything is cloned and built from
+GitHub so you don't need to install any dependencies:
+
+```shell script
+$ docker build -t lightninglabs/lightning-terminal --build-arg checkout=v0.3.2-alpha .
+```


### PR DESCRIPTION
We add a new production `Dockerfile` and a GitHub workflow that is triggered whenever a new version tag is
pushed. It will trigger a docker image build for that version and automatically push it to the specified repo.

For this to work, the GitHub repository needs the following two secrets to be configured:

```
DOCKER_USERNAME: <the user to log into Docker Hub>
DOCKER_API_KEY: <an API key generated by Docker Hub for the above user>
```
