### PR TITLE
Update protos build script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,4 @@
 # that, generated. This will make sure the JS (and TS types for that matter)
 # will not show up in the repository's language statistics.
 
-app/src/types/generated* linguist-generated
+app/src/types/generated/** linguist-generated

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,11 +36,6 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
 
-      - name: setup protoc
-        uses: arduino/setup-protoc@master
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: get yarn cache dir
         id: yarn-cache-dir
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -114,11 +109,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '~${{ matrix.go_version }}'
-
-      - name: setup protoc
-        uses: arduino/setup-protoc@master
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build backend binary
         run: make build

--- a/app/scripts/build-protos.js
+++ b/app/scripts/build-protos.js
@@ -1,10 +1,21 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const util = require('util');
+const https = require('https');
 const exec = util.promisify(require('child_process').exec);
 const { promises: fs } = require('fs');
 const { join, sep } = require('path');
 const { platform } = require('os');
 const appPath = join(__dirname, '..');
+
+/** Specify the versions of LND and Loop protos to download */
+const LND_VERSION = 'v0.11.1-beta';
+const LOOP_VERSION = 'v0.11.2-beta';
+
+/** mapping of proto files to the github url to download each from */
+const protoSources = {
+  lnd: `lightningnetwork/lnd/${LND_VERSION}/lnrpc/rpc.proto`,
+  loop: `lightninglabs/loop/${LOOP_VERSION}/looprpc/client.proto`,
+};
 
 /** list of proto files and patches to apply */
 const filePatches = {
@@ -15,10 +26,32 @@ const filePatches = {
 };
 
 /**
+ * Downloads the *.proto files into the `../proto` dir
+ */
+const download = async () => {
+  console.log('\nDownloading proto files...');
+  for ([name, urlPath] of Object.entries(protoSources)) {
+    const url = `https://raw.githubusercontent.com/${urlPath}`;
+    const filePath = join(appPath, '..', 'proto', `${name}.proto`);
+    console.log(`${url}`);
+    console.log(` -> ${filePath}`);
+    const content = await new Promise((resolve, reject) => {
+      https.get(url, res => {
+        let data = '';
+        res.on('data', chunk => (data += chunk));
+        res.on('error', err => reject(err));
+        res.on('end', () => resolve(data));
+      });
+    });
+    await fs.writeFile(filePath, content);
+  }
+};
+
+/**
  * Executes the `protoc` compiler to convert *.proto files into TS & JS code
  */
 const generate = async () => {
-  console.log('Compiling protobuf definitions');
+  console.log('\nCompiling protobuf definitions...');
   await fs.mkdir('./src/types/generated', { recursive: true });
 
   const protocGen = join(
@@ -37,11 +70,10 @@ const generate = async () => {
   ].join(' ');
 
   console.log(protocCmd);
-  const { stdout, stderr } = await exec(protocCmd, { cwd: appPath });
+  const { stderr } = await exec(protocCmd, { cwd: appPath });
   if (stderr) {
     throw new Error(`exec stderr:\n${stderr}`);
   }
-  console.log(stdout);
 };
 
 /**
@@ -50,7 +82,7 @@ const generate = async () => {
  * Example: prepends `var proto = { lnrpc: {} };` to lnd_pb.js
  */
 const patch = async () => {
-  console.log('Patching generated JS files');
+  console.log('\nPatching generated JS files');
 
   for (const filename of Object.keys(filePatches)) {
     const patch = [
@@ -78,6 +110,7 @@ const patch = async () => {
  */
 const main = async () => {
   try {
+    await download();
     await generate();
     await patch();
   } catch (error) {

--- a/app/src/types/generated/lnd_pb.d.ts
+++ b/app/src/types/generated/lnd_pb.d.ts
@@ -2023,6 +2023,9 @@ export class OpenChannelRequest extends jspb.Message {
   getRemoteMaxValueInFlightMsat(): number;
   setRemoteMaxValueInFlightMsat(value: number): void;
 
+  getRemoteMaxHtlcs(): number;
+  setRemoteMaxHtlcs(value: number): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): OpenChannelRequest.AsObject;
   static toObject(includeInstance: boolean, msg: OpenChannelRequest): OpenChannelRequest.AsObject;
@@ -2049,6 +2052,7 @@ export namespace OpenChannelRequest {
     closeAddress: string,
     fundingShim?: FundingShim.AsObject,
     remoteMaxValueInFlightMsat: number,
+    remoteMaxHtlcs: number,
   }
 }
 
@@ -2328,6 +2332,11 @@ export class FundingPsbtFinalize extends jspb.Message {
   getPendingChanId_asB64(): string;
   setPendingChanId(value: Uint8Array | string): void;
 
+  getFinalRawTx(): Uint8Array | string;
+  getFinalRawTx_asU8(): Uint8Array;
+  getFinalRawTx_asB64(): string;
+  setFinalRawTx(value: Uint8Array | string): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): FundingPsbtFinalize.AsObject;
   static toObject(includeInstance: boolean, msg: FundingPsbtFinalize): FundingPsbtFinalize.AsObject;
@@ -2342,6 +2351,7 @@ export namespace FundingPsbtFinalize {
   export type AsObject = {
     signedPsbt: Uint8Array | string,
     pendingChanId: Uint8Array | string,
+    finalRawTx: Uint8Array | string,
   }
 }
 
@@ -4486,6 +4496,9 @@ export class AbandonChannelRequest extends jspb.Message {
   getChannelPoint(): ChannelPoint | undefined;
   setChannelPoint(value?: ChannelPoint): void;
 
+  getPendingFundingShimOnly(): boolean;
+  setPendingFundingShimOnly(value: boolean): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): AbandonChannelRequest.AsObject;
   static toObject(includeInstance: boolean, msg: AbandonChannelRequest): AbandonChannelRequest.AsObject;
@@ -4499,6 +4512,7 @@ export class AbandonChannelRequest extends jspb.Message {
 export namespace AbandonChannelRequest {
   export type AsObject = {
     channelPoint?: ChannelPoint.AsObject,
+    pendingFundingShimOnly: boolean,
   }
 }
 
@@ -5247,6 +5261,63 @@ export namespace BakeMacaroonResponse {
   }
 }
 
+export class MacaroonPermissionList extends jspb.Message {
+  clearPermissionsList(): void;
+  getPermissionsList(): Array<MacaroonPermission>;
+  setPermissionsList(value: Array<MacaroonPermission>): void;
+  addPermissions(value?: MacaroonPermission, index?: number): MacaroonPermission;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): MacaroonPermissionList.AsObject;
+  static toObject(includeInstance: boolean, msg: MacaroonPermissionList): MacaroonPermissionList.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: MacaroonPermissionList, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): MacaroonPermissionList;
+  static deserializeBinaryFromReader(message: MacaroonPermissionList, reader: jspb.BinaryReader): MacaroonPermissionList;
+}
+
+export namespace MacaroonPermissionList {
+  export type AsObject = {
+    permissionsList: Array<MacaroonPermission.AsObject>,
+  }
+}
+
+export class ListPermissionsRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListPermissionsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ListPermissionsRequest): ListPermissionsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListPermissionsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListPermissionsRequest;
+  static deserializeBinaryFromReader(message: ListPermissionsRequest, reader: jspb.BinaryReader): ListPermissionsRequest;
+}
+
+export namespace ListPermissionsRequest {
+  export type AsObject = {
+  }
+}
+
+export class ListPermissionsResponse extends jspb.Message {
+  getMethodPermissionsMap(): jspb.Map<string, MacaroonPermissionList>;
+  clearMethodPermissionsMap(): void;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListPermissionsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ListPermissionsResponse): ListPermissionsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListPermissionsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListPermissionsResponse;
+  static deserializeBinaryFromReader(message: ListPermissionsResponse, reader: jspb.BinaryReader): ListPermissionsResponse;
+}
+
+export namespace ListPermissionsResponse {
+  export type AsObject = {
+    methodPermissionsMap: Array<[string, MacaroonPermissionList.AsObject]>,
+  }
+}
+
 export class Failure extends jspb.Message {
   getCode(): Failure.FailureCodeMap[keyof Failure.FailureCodeMap];
   setCode(value: Failure.FailureCodeMap[keyof Failure.FailureCodeMap]): void;
@@ -5398,6 +5469,66 @@ export namespace ChannelUpdate {
     feeRate: number,
     htlcMaximumMsat: number,
     extraOpaqueData: Uint8Array | string,
+  }
+}
+
+export class MacaroonId extends jspb.Message {
+  getNonce(): Uint8Array | string;
+  getNonce_asU8(): Uint8Array;
+  getNonce_asB64(): string;
+  setNonce(value: Uint8Array | string): void;
+
+  getStorageid(): Uint8Array | string;
+  getStorageid_asU8(): Uint8Array;
+  getStorageid_asB64(): string;
+  setStorageid(value: Uint8Array | string): void;
+
+  clearOpsList(): void;
+  getOpsList(): Array<Op>;
+  setOpsList(value: Array<Op>): void;
+  addOps(value?: Op, index?: number): Op;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): MacaroonId.AsObject;
+  static toObject(includeInstance: boolean, msg: MacaroonId): MacaroonId.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: MacaroonId, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): MacaroonId;
+  static deserializeBinaryFromReader(message: MacaroonId, reader: jspb.BinaryReader): MacaroonId;
+}
+
+export namespace MacaroonId {
+  export type AsObject = {
+    nonce: Uint8Array | string,
+    storageid: Uint8Array | string,
+    opsList: Array<Op.AsObject>,
+  }
+}
+
+export class Op extends jspb.Message {
+  getEntity(): string;
+  setEntity(value: string): void;
+
+  clearActionsList(): void;
+  getActionsList(): Array<string>;
+  setActionsList(value: Array<string>): void;
+  addActions(value: string, index?: number): string;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Op.AsObject;
+  static toObject(includeInstance: boolean, msg: Op): Op.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Op, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Op;
+  static deserializeBinaryFromReader(message: Op, reader: jspb.BinaryReader): Op;
+}
+
+export namespace Op {
+  export type AsObject = {
+    entity: string,
+    actionsList: Array<string>,
   }
 }
 

--- a/app/src/types/generated/lnd_pb.js
+++ b/app/src/types/generated/lnd_pb.js
@@ -114,10 +114,14 @@ goog.exportSymbol('proto.lnrpc.ListPaymentsRequest', null, global);
 goog.exportSymbol('proto.lnrpc.ListPaymentsResponse', null, global);
 goog.exportSymbol('proto.lnrpc.ListPeersRequest', null, global);
 goog.exportSymbol('proto.lnrpc.ListPeersResponse', null, global);
+goog.exportSymbol('proto.lnrpc.ListPermissionsRequest', null, global);
+goog.exportSymbol('proto.lnrpc.ListPermissionsResponse', null, global);
 goog.exportSymbol('proto.lnrpc.ListUnspentRequest', null, global);
 goog.exportSymbol('proto.lnrpc.ListUnspentResponse', null, global);
 goog.exportSymbol('proto.lnrpc.MPPRecord', null, global);
+goog.exportSymbol('proto.lnrpc.MacaroonId', null, global);
 goog.exportSymbol('proto.lnrpc.MacaroonPermission', null, global);
+goog.exportSymbol('proto.lnrpc.MacaroonPermissionList', null, global);
 goog.exportSymbol('proto.lnrpc.MultiChanBackup', null, global);
 goog.exportSymbol('proto.lnrpc.NetworkInfo', null, global);
 goog.exportSymbol('proto.lnrpc.NetworkInfoRequest', null, global);
@@ -131,6 +135,7 @@ goog.exportSymbol('proto.lnrpc.NodeMetricsRequest', null, global);
 goog.exportSymbol('proto.lnrpc.NodeMetricsResponse', null, global);
 goog.exportSymbol('proto.lnrpc.NodePair', null, global);
 goog.exportSymbol('proto.lnrpc.NodeUpdate', null, global);
+goog.exportSymbol('proto.lnrpc.Op', null, global);
 goog.exportSymbol('proto.lnrpc.OpenChannelRequest', null, global);
 goog.exportSymbol('proto.lnrpc.OpenStatusUpdate', null, global);
 goog.exportSymbol('proto.lnrpc.OutPoint', null, global);
@@ -14247,7 +14252,8 @@ proto.lnrpc.OpenChannelRequest.toObject = function(includeInstance, msg) {
     spendUnconfirmed: jspb.Message.getFieldWithDefault(msg, 12, false),
     closeAddress: jspb.Message.getFieldWithDefault(msg, 13, ""),
     fundingShim: (f = msg.getFundingShim()) && proto.lnrpc.FundingShim.toObject(includeInstance, f),
-    remoteMaxValueInFlightMsat: jspb.Message.getFieldWithDefault(msg, 15, 0)
+    remoteMaxValueInFlightMsat: jspb.Message.getFieldWithDefault(msg, 15, 0),
+    remoteMaxHtlcs: jspb.Message.getFieldWithDefault(msg, 16, 0)
   };
 
   if (includeInstance) {
@@ -14340,6 +14346,10 @@ proto.lnrpc.OpenChannelRequest.deserializeBinaryFromReader = function(msg, reade
     case 15:
       var value = /** @type {number} */ (reader.readUint64());
       msg.setRemoteMaxValueInFlightMsat(value);
+      break;
+    case 16:
+      var value = /** @type {number} */ (reader.readUint32());
+      msg.setRemoteMaxHtlcs(value);
       break;
     default:
       reader.skipField();
@@ -14466,6 +14476,13 @@ proto.lnrpc.OpenChannelRequest.serializeBinaryToWriter = function(message, write
   if (f !== 0) {
     writer.writeUint64(
       15,
+      f
+    );
+  }
+  f = message.getRemoteMaxHtlcs();
+  if (f !== 0) {
+    writer.writeUint32(
+      16,
       f
     );
   }
@@ -14722,6 +14739,21 @@ proto.lnrpc.OpenChannelRequest.prototype.getRemoteMaxValueInFlightMsat = functio
 /** @param {number} value */
 proto.lnrpc.OpenChannelRequest.prototype.setRemoteMaxValueInFlightMsat = function(value) {
   jspb.Message.setField(this, 15, value);
+};
+
+
+/**
+ * optional uint32 remote_max_htlcs = 16;
+ * @return {number}
+ */
+proto.lnrpc.OpenChannelRequest.prototype.getRemoteMaxHtlcs = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 16, 0));
+};
+
+
+/** @param {number} value */
+proto.lnrpc.OpenChannelRequest.prototype.setRemoteMaxHtlcs = function(value) {
+  jspb.Message.setField(this, 16, value);
 };
 
 
@@ -16694,7 +16726,8 @@ proto.lnrpc.FundingPsbtFinalize.prototype.toObject = function(opt_includeInstanc
 proto.lnrpc.FundingPsbtFinalize.toObject = function(includeInstance, msg) {
   var f, obj = {
     signedPsbt: msg.getSignedPsbt_asB64(),
-    pendingChanId: msg.getPendingChanId_asB64()
+    pendingChanId: msg.getPendingChanId_asB64(),
+    finalRawTx: msg.getFinalRawTx_asB64()
   };
 
   if (includeInstance) {
@@ -16739,6 +16772,10 @@ proto.lnrpc.FundingPsbtFinalize.deserializeBinaryFromReader = function(msg, read
       var value = /** @type {!Uint8Array} */ (reader.readBytes());
       msg.setPendingChanId(value);
       break;
+    case 3:
+      var value = /** @type {!Uint8Array} */ (reader.readBytes());
+      msg.setFinalRawTx(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -16779,6 +16816,13 @@ proto.lnrpc.FundingPsbtFinalize.serializeBinaryToWriter = function(message, writ
   if (f.length > 0) {
     writer.writeBytes(
       2,
+      f
+    );
+  }
+  f = message.getFinalRawTx_asU8();
+  if (f.length > 0) {
+    writer.writeBytes(
+      3,
       f
     );
   }
@@ -16860,6 +16904,45 @@ proto.lnrpc.FundingPsbtFinalize.prototype.getPendingChanId_asU8 = function() {
 /** @param {!(string|Uint8Array)} value */
 proto.lnrpc.FundingPsbtFinalize.prototype.setPendingChanId = function(value) {
   jspb.Message.setField(this, 2, value);
+};
+
+
+/**
+ * optional bytes final_raw_tx = 3;
+ * @return {!(string|Uint8Array)}
+ */
+proto.lnrpc.FundingPsbtFinalize.prototype.getFinalRawTx = function() {
+  return /** @type {!(string|Uint8Array)} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
+};
+
+
+/**
+ * optional bytes final_raw_tx = 3;
+ * This is a type-conversion wrapper around `getFinalRawTx()`
+ * @return {string}
+ */
+proto.lnrpc.FundingPsbtFinalize.prototype.getFinalRawTx_asB64 = function() {
+  return /** @type {string} */ (jspb.Message.bytesAsB64(
+      this.getFinalRawTx()));
+};
+
+
+/**
+ * optional bytes final_raw_tx = 3;
+ * Note that Uint8Array is not supported on all browsers.
+ * @see http://caniuse.com/Uint8Array
+ * This is a type-conversion wrapper around `getFinalRawTx()`
+ * @return {!Uint8Array}
+ */
+proto.lnrpc.FundingPsbtFinalize.prototype.getFinalRawTx_asU8 = function() {
+  return /** @type {!Uint8Array} */ (jspb.Message.bytesAsU8(
+      this.getFinalRawTx()));
+};
+
+
+/** @param {!(string|Uint8Array)} value */
+proto.lnrpc.FundingPsbtFinalize.prototype.setFinalRawTx = function(value) {
+  jspb.Message.setField(this, 3, value);
 };
 
 
@@ -31964,7 +32047,8 @@ proto.lnrpc.AbandonChannelRequest.prototype.toObject = function(opt_includeInsta
  */
 proto.lnrpc.AbandonChannelRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
-    channelPoint: (f = msg.getChannelPoint()) && proto.lnrpc.ChannelPoint.toObject(includeInstance, f)
+    channelPoint: (f = msg.getChannelPoint()) && proto.lnrpc.ChannelPoint.toObject(includeInstance, f),
+    pendingFundingShimOnly: jspb.Message.getFieldWithDefault(msg, 2, false)
   };
 
   if (includeInstance) {
@@ -32006,6 +32090,10 @@ proto.lnrpc.AbandonChannelRequest.deserializeBinaryFromReader = function(msg, re
       reader.readMessage(value,proto.lnrpc.ChannelPoint.deserializeBinaryFromReader);
       msg.setChannelPoint(value);
       break;
+    case 2:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setPendingFundingShimOnly(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -32043,6 +32131,13 @@ proto.lnrpc.AbandonChannelRequest.serializeBinaryToWriter = function(message, wr
       proto.lnrpc.ChannelPoint.serializeBinaryToWriter
     );
   }
+  f = message.getPendingFundingShimOnly();
+  if (f) {
+    writer.writeBool(
+      2,
+      f
+    );
+  }
 };
 
 
@@ -32073,6 +32168,23 @@ proto.lnrpc.AbandonChannelRequest.prototype.clearChannelPoint = function() {
  */
 proto.lnrpc.AbandonChannelRequest.prototype.hasChannelPoint = function() {
   return jspb.Message.getField(this, 1) != null;
+};
+
+
+/**
+ * optional bool pending_funding_shim_only = 2;
+ * Note that Boolean fields may be set to 0/1 when serialized from a Java server.
+ * You should avoid comparisons like {@code val === true/false} in those cases.
+ * @return {boolean}
+ */
+proto.lnrpc.AbandonChannelRequest.prototype.getPendingFundingShimOnly = function() {
+  return /** @type {boolean} */ (jspb.Message.getFieldWithDefault(this, 2, false));
+};
+
+
+/** @param {boolean} value */
+proto.lnrpc.AbandonChannelRequest.prototype.setPendingFundingShimOnly = function(value) {
+  jspb.Message.setField(this, 2, value);
 };
 
 
@@ -37427,6 +37539,434 @@ proto.lnrpc.BakeMacaroonResponse.prototype.setMacaroon = function(value) {
  * @extends {jspb.Message}
  * @constructor
  */
+proto.lnrpc.MacaroonPermissionList = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.lnrpc.MacaroonPermissionList.repeatedFields_, null);
+};
+goog.inherits(proto.lnrpc.MacaroonPermissionList, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.lnrpc.MacaroonPermissionList.displayName = 'proto.lnrpc.MacaroonPermissionList';
+}
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.lnrpc.MacaroonPermissionList.repeatedFields_ = [1];
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.lnrpc.MacaroonPermissionList.prototype.toObject = function(opt_includeInstance) {
+  return proto.lnrpc.MacaroonPermissionList.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.lnrpc.MacaroonPermissionList} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.lnrpc.MacaroonPermissionList.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    permissionsList: jspb.Message.toObjectList(msg.getPermissionsList(),
+    proto.lnrpc.MacaroonPermission.toObject, includeInstance)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.lnrpc.MacaroonPermissionList}
+ */
+proto.lnrpc.MacaroonPermissionList.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.lnrpc.MacaroonPermissionList;
+  return proto.lnrpc.MacaroonPermissionList.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.lnrpc.MacaroonPermissionList} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.lnrpc.MacaroonPermissionList}
+ */
+proto.lnrpc.MacaroonPermissionList.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.lnrpc.MacaroonPermission;
+      reader.readMessage(value,proto.lnrpc.MacaroonPermission.deserializeBinaryFromReader);
+      msg.addPermissions(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.lnrpc.MacaroonPermissionList.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.lnrpc.MacaroonPermissionList.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.lnrpc.MacaroonPermissionList} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.lnrpc.MacaroonPermissionList.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getPermissionsList();
+  if (f.length > 0) {
+    writer.writeRepeatedMessage(
+      1,
+      f,
+      proto.lnrpc.MacaroonPermission.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * repeated MacaroonPermission permissions = 1;
+ * @return {!Array.<!proto.lnrpc.MacaroonPermission>}
+ */
+proto.lnrpc.MacaroonPermissionList.prototype.getPermissionsList = function() {
+  return /** @type{!Array.<!proto.lnrpc.MacaroonPermission>} */ (
+    jspb.Message.getRepeatedWrapperField(this, proto.lnrpc.MacaroonPermission, 1));
+};
+
+
+/** @param {!Array.<!proto.lnrpc.MacaroonPermission>} value */
+proto.lnrpc.MacaroonPermissionList.prototype.setPermissionsList = function(value) {
+  jspb.Message.setRepeatedWrapperField(this, 1, value);
+};
+
+
+/**
+ * @param {!proto.lnrpc.MacaroonPermission=} opt_value
+ * @param {number=} opt_index
+ * @return {!proto.lnrpc.MacaroonPermission}
+ */
+proto.lnrpc.MacaroonPermissionList.prototype.addPermissions = function(opt_value, opt_index) {
+  return jspb.Message.addToRepeatedWrapperField(this, 1, opt_value, proto.lnrpc.MacaroonPermission, opt_index);
+};
+
+
+proto.lnrpc.MacaroonPermissionList.prototype.clearPermissionsList = function() {
+  this.setPermissionsList([]);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.lnrpc.ListPermissionsRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.lnrpc.ListPermissionsRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.lnrpc.ListPermissionsRequest.displayName = 'proto.lnrpc.ListPermissionsRequest';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.lnrpc.ListPermissionsRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.lnrpc.ListPermissionsRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.lnrpc.ListPermissionsRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.lnrpc.ListPermissionsRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.lnrpc.ListPermissionsRequest}
+ */
+proto.lnrpc.ListPermissionsRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.lnrpc.ListPermissionsRequest;
+  return proto.lnrpc.ListPermissionsRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.lnrpc.ListPermissionsRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.lnrpc.ListPermissionsRequest}
+ */
+proto.lnrpc.ListPermissionsRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.lnrpc.ListPermissionsRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.lnrpc.ListPermissionsRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.lnrpc.ListPermissionsRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.lnrpc.ListPermissionsRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.lnrpc.ListPermissionsResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.lnrpc.ListPermissionsResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.lnrpc.ListPermissionsResponse.displayName = 'proto.lnrpc.ListPermissionsResponse';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.lnrpc.ListPermissionsResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.lnrpc.ListPermissionsResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.lnrpc.ListPermissionsResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.lnrpc.ListPermissionsResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    methodPermissionsMap: (f = msg.getMethodPermissionsMap()) ? f.toObject(includeInstance, proto.lnrpc.MacaroonPermissionList.toObject) : []
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.lnrpc.ListPermissionsResponse}
+ */
+proto.lnrpc.ListPermissionsResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.lnrpc.ListPermissionsResponse;
+  return proto.lnrpc.ListPermissionsResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.lnrpc.ListPermissionsResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.lnrpc.ListPermissionsResponse}
+ */
+proto.lnrpc.ListPermissionsResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = msg.getMethodPermissionsMap();
+      reader.readMessage(value, function(message, reader) {
+        jspb.Map.deserializeBinary(message, reader, jspb.BinaryReader.prototype.readString, jspb.BinaryReader.prototype.readMessage, proto.lnrpc.MacaroonPermissionList.deserializeBinaryFromReader);
+         });
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.lnrpc.ListPermissionsResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.lnrpc.ListPermissionsResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.lnrpc.ListPermissionsResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.lnrpc.ListPermissionsResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getMethodPermissionsMap(true);
+  if (f && f.getLength() > 0) {
+    f.serializeBinary(1, writer, jspb.BinaryWriter.prototype.writeString, jspb.BinaryWriter.prototype.writeMessage, proto.lnrpc.MacaroonPermissionList.serializeBinaryToWriter);
+  }
+};
+
+
+/**
+ * map<string, MacaroonPermissionList> method_permissions = 1;
+ * @param {boolean=} opt_noLazyCreate Do not create the map if
+ * empty, instead returning `undefined`
+ * @return {!jspb.Map<string,!proto.lnrpc.MacaroonPermissionList>}
+ */
+proto.lnrpc.ListPermissionsResponse.prototype.getMethodPermissionsMap = function(opt_noLazyCreate) {
+  return /** @type {!jspb.Map<string,!proto.lnrpc.MacaroonPermissionList>} */ (
+      jspb.Message.getMapField(this, 1, opt_noLazyCreate,
+      proto.lnrpc.MacaroonPermissionList));
+};
+
+
+proto.lnrpc.ListPermissionsResponse.prototype.clearMethodPermissionsMap = function() {
+  this.getMethodPermissionsMap().clear();
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
 proto.lnrpc.Failure = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
@@ -38329,6 +38869,466 @@ proto.lnrpc.ChannelUpdate.prototype.getExtraOpaqueData_asU8 = function() {
 /** @param {!(string|Uint8Array)} value */
 proto.lnrpc.ChannelUpdate.prototype.setExtraOpaqueData = function(value) {
   jspb.Message.setField(this, 12, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.lnrpc.MacaroonId = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.lnrpc.MacaroonId.repeatedFields_, null);
+};
+goog.inherits(proto.lnrpc.MacaroonId, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.lnrpc.MacaroonId.displayName = 'proto.lnrpc.MacaroonId';
+}
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.lnrpc.MacaroonId.repeatedFields_ = [3];
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.lnrpc.MacaroonId.prototype.toObject = function(opt_includeInstance) {
+  return proto.lnrpc.MacaroonId.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.lnrpc.MacaroonId} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.lnrpc.MacaroonId.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    nonce: msg.getNonce_asB64(),
+    storageid: msg.getStorageid_asB64(),
+    opsList: jspb.Message.toObjectList(msg.getOpsList(),
+    proto.lnrpc.Op.toObject, includeInstance)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.lnrpc.MacaroonId}
+ */
+proto.lnrpc.MacaroonId.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.lnrpc.MacaroonId;
+  return proto.lnrpc.MacaroonId.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.lnrpc.MacaroonId} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.lnrpc.MacaroonId}
+ */
+proto.lnrpc.MacaroonId.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {!Uint8Array} */ (reader.readBytes());
+      msg.setNonce(value);
+      break;
+    case 2:
+      var value = /** @type {!Uint8Array} */ (reader.readBytes());
+      msg.setStorageid(value);
+      break;
+    case 3:
+      var value = new proto.lnrpc.Op;
+      reader.readMessage(value,proto.lnrpc.Op.deserializeBinaryFromReader);
+      msg.addOps(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.lnrpc.MacaroonId.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.lnrpc.MacaroonId.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.lnrpc.MacaroonId} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.lnrpc.MacaroonId.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getNonce_asU8();
+  if (f.length > 0) {
+    writer.writeBytes(
+      1,
+      f
+    );
+  }
+  f = message.getStorageid_asU8();
+  if (f.length > 0) {
+    writer.writeBytes(
+      2,
+      f
+    );
+  }
+  f = message.getOpsList();
+  if (f.length > 0) {
+    writer.writeRepeatedMessage(
+      3,
+      f,
+      proto.lnrpc.Op.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * optional bytes nonce = 1;
+ * @return {!(string|Uint8Array)}
+ */
+proto.lnrpc.MacaroonId.prototype.getNonce = function() {
+  return /** @type {!(string|Uint8Array)} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/**
+ * optional bytes nonce = 1;
+ * This is a type-conversion wrapper around `getNonce()`
+ * @return {string}
+ */
+proto.lnrpc.MacaroonId.prototype.getNonce_asB64 = function() {
+  return /** @type {string} */ (jspb.Message.bytesAsB64(
+      this.getNonce()));
+};
+
+
+/**
+ * optional bytes nonce = 1;
+ * Note that Uint8Array is not supported on all browsers.
+ * @see http://caniuse.com/Uint8Array
+ * This is a type-conversion wrapper around `getNonce()`
+ * @return {!Uint8Array}
+ */
+proto.lnrpc.MacaroonId.prototype.getNonce_asU8 = function() {
+  return /** @type {!Uint8Array} */ (jspb.Message.bytesAsU8(
+      this.getNonce()));
+};
+
+
+/** @param {!(string|Uint8Array)} value */
+proto.lnrpc.MacaroonId.prototype.setNonce = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+/**
+ * optional bytes storageId = 2;
+ * @return {!(string|Uint8Array)}
+ */
+proto.lnrpc.MacaroonId.prototype.getStorageid = function() {
+  return /** @type {!(string|Uint8Array)} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/**
+ * optional bytes storageId = 2;
+ * This is a type-conversion wrapper around `getStorageid()`
+ * @return {string}
+ */
+proto.lnrpc.MacaroonId.prototype.getStorageid_asB64 = function() {
+  return /** @type {string} */ (jspb.Message.bytesAsB64(
+      this.getStorageid()));
+};
+
+
+/**
+ * optional bytes storageId = 2;
+ * Note that Uint8Array is not supported on all browsers.
+ * @see http://caniuse.com/Uint8Array
+ * This is a type-conversion wrapper around `getStorageid()`
+ * @return {!Uint8Array}
+ */
+proto.lnrpc.MacaroonId.prototype.getStorageid_asU8 = function() {
+  return /** @type {!Uint8Array} */ (jspb.Message.bytesAsU8(
+      this.getStorageid()));
+};
+
+
+/** @param {!(string|Uint8Array)} value */
+proto.lnrpc.MacaroonId.prototype.setStorageid = function(value) {
+  jspb.Message.setField(this, 2, value);
+};
+
+
+/**
+ * repeated Op ops = 3;
+ * @return {!Array.<!proto.lnrpc.Op>}
+ */
+proto.lnrpc.MacaroonId.prototype.getOpsList = function() {
+  return /** @type{!Array.<!proto.lnrpc.Op>} */ (
+    jspb.Message.getRepeatedWrapperField(this, proto.lnrpc.Op, 3));
+};
+
+
+/** @param {!Array.<!proto.lnrpc.Op>} value */
+proto.lnrpc.MacaroonId.prototype.setOpsList = function(value) {
+  jspb.Message.setRepeatedWrapperField(this, 3, value);
+};
+
+
+/**
+ * @param {!proto.lnrpc.Op=} opt_value
+ * @param {number=} opt_index
+ * @return {!proto.lnrpc.Op}
+ */
+proto.lnrpc.MacaroonId.prototype.addOps = function(opt_value, opt_index) {
+  return jspb.Message.addToRepeatedWrapperField(this, 3, opt_value, proto.lnrpc.Op, opt_index);
+};
+
+
+proto.lnrpc.MacaroonId.prototype.clearOpsList = function() {
+  this.setOpsList([]);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.lnrpc.Op = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.lnrpc.Op.repeatedFields_, null);
+};
+goog.inherits(proto.lnrpc.Op, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.lnrpc.Op.displayName = 'proto.lnrpc.Op';
+}
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.lnrpc.Op.repeatedFields_ = [2];
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.lnrpc.Op.prototype.toObject = function(opt_includeInstance) {
+  return proto.lnrpc.Op.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.lnrpc.Op} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.lnrpc.Op.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    entity: jspb.Message.getFieldWithDefault(msg, 1, ""),
+    actionsList: jspb.Message.getRepeatedField(msg, 2)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.lnrpc.Op}
+ */
+proto.lnrpc.Op.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.lnrpc.Op;
+  return proto.lnrpc.Op.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.lnrpc.Op} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.lnrpc.Op}
+ */
+proto.lnrpc.Op.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setEntity(value);
+      break;
+    case 2:
+      var value = /** @type {string} */ (reader.readString());
+      msg.addActions(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.lnrpc.Op.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.lnrpc.Op.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.lnrpc.Op} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.lnrpc.Op.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getEntity();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+  f = message.getActionsList();
+  if (f.length > 0) {
+    writer.writeRepeatedString(
+      2,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string entity = 1;
+ * @return {string}
+ */
+proto.lnrpc.Op.prototype.getEntity = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/** @param {string} value */
+proto.lnrpc.Op.prototype.setEntity = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+/**
+ * repeated string actions = 2;
+ * @return {!Array.<string>}
+ */
+proto.lnrpc.Op.prototype.getActionsList = function() {
+  return /** @type {!Array.<string>} */ (jspb.Message.getRepeatedField(this, 2));
+};
+
+
+/** @param {!Array.<string>} value */
+proto.lnrpc.Op.prototype.setActionsList = function(value) {
+  jspb.Message.setField(this, 2, value || []);
+};
+
+
+/**
+ * @param {!string} value
+ * @param {number=} opt_index
+ */
+proto.lnrpc.Op.prototype.addActions = function(value, opt_index) {
+  jspb.Message.addToRepeatedField(this, 2, value, opt_index);
+};
+
+
+proto.lnrpc.Op.prototype.clearActionsList = function() {
+  this.setActionsList([]);
 };
 
 

--- a/app/src/types/generated/lnd_pb_service.d.ts
+++ b/app/src/types/generated/lnd_pb_service.d.ts
@@ -508,6 +508,15 @@ type LightningBakeMacaroon = {
   readonly responseType: typeof lnd_pb.BakeMacaroonResponse;
 };
 
+type LightningListPermissions = {
+  readonly methodName: string;
+  readonly service: typeof Lightning;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof lnd_pb.ListPermissionsRequest;
+  readonly responseType: typeof lnd_pb.ListPermissionsResponse;
+};
+
 export class Lightning {
   static readonly serviceName: string;
   static readonly WalletBalance: LightningWalletBalance;
@@ -566,6 +575,7 @@ export class Lightning {
   static readonly RestoreChannelBackups: LightningRestoreChannelBackups;
   static readonly SubscribeChannelBackups: LightningSubscribeChannelBackups;
   static readonly BakeMacaroon: LightningBakeMacaroon;
+  static readonly ListPermissions: LightningListPermissions;
 }
 
 export type ServiceError = { message: string, code: number; metadata: grpc.Metadata }
@@ -1015,6 +1025,15 @@ export class LightningClient {
   bakeMacaroon(
     requestMessage: lnd_pb.BakeMacaroonRequest,
     callback: (error: ServiceError|null, responseMessage: lnd_pb.BakeMacaroonResponse|null) => void
+  ): UnaryResponse;
+  listPermissions(
+    requestMessage: lnd_pb.ListPermissionsRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: lnd_pb.ListPermissionsResponse|null) => void
+  ): UnaryResponse;
+  listPermissions(
+    requestMessage: lnd_pb.ListPermissionsRequest,
+    callback: (error: ServiceError|null, responseMessage: lnd_pb.ListPermissionsResponse|null) => void
   ): UnaryResponse;
 }
 

--- a/app/src/types/generated/loop_pb.d.ts
+++ b/app/src/types/generated/loop_pb.d.ts
@@ -644,6 +644,12 @@ export class LiquidityParameters extends jspb.Message {
   getAutoMaxInFlight(): number;
   setAutoMaxInFlight(value: number): void;
 
+  getMinSwapAmount(): number;
+  setMinSwapAmount(value: number): void;
+
+  getMaxSwapAmount(): number;
+  setMaxSwapAmount(value: number): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): LiquidityParameters.AsObject;
   static toObject(includeInstance: boolean, msg: LiquidityParameters): LiquidityParameters.AsObject;
@@ -669,6 +675,8 @@ export namespace LiquidityParameters {
     autoOutBudgetSat: number,
     autoOutBudgetStartSec: number,
     autoMaxInFlight: number,
+    minSwapAmount: number,
+    maxSwapAmount: number,
   }
 }
 

--- a/app/src/types/generated/loop_pb.js
+++ b/app/src/types/generated/loop_pb.js
@@ -4400,7 +4400,9 @@ proto.looprpc.LiquidityParameters.toObject = function(includeInstance, msg) {
     autoLoopOut: jspb.Message.getFieldWithDefault(msg, 10, false),
     autoOutBudgetSat: jspb.Message.getFieldWithDefault(msg, 11, 0),
     autoOutBudgetStartSec: jspb.Message.getFieldWithDefault(msg, 12, 0),
-    autoMaxInFlight: jspb.Message.getFieldWithDefault(msg, 13, 0)
+    autoMaxInFlight: jspb.Message.getFieldWithDefault(msg, 13, 0),
+    minSwapAmount: jspb.Message.getFieldWithDefault(msg, 14, 0),
+    maxSwapAmount: jspb.Message.getFieldWithDefault(msg, 15, 0)
   };
 
   if (includeInstance) {
@@ -4489,6 +4491,14 @@ proto.looprpc.LiquidityParameters.deserializeBinaryFromReader = function(msg, re
     case 13:
       var value = /** @type {number} */ (reader.readUint64());
       msg.setAutoMaxInFlight(value);
+      break;
+    case 14:
+      var value = /** @type {number} */ (reader.readUint64());
+      msg.setMinSwapAmount(value);
+      break;
+    case 15:
+      var value = /** @type {number} */ (reader.readUint64());
+      msg.setMaxSwapAmount(value);
       break;
     default:
       reader.skipField();
@@ -4608,6 +4618,20 @@ proto.looprpc.LiquidityParameters.serializeBinaryToWriter = function(message, wr
   if (f !== 0) {
     writer.writeUint64(
       13,
+      f
+    );
+  }
+  f = message.getMinSwapAmount();
+  if (f !== 0) {
+    writer.writeUint64(
+      14,
+      f
+    );
+  }
+  f = message.getMaxSwapAmount();
+  if (f !== 0) {
+    writer.writeUint64(
+      15,
       f
     );
   }
@@ -4824,6 +4848,36 @@ proto.looprpc.LiquidityParameters.prototype.getAutoMaxInFlight = function() {
 /** @param {number} value */
 proto.looprpc.LiquidityParameters.prototype.setAutoMaxInFlight = function(value) {
   jspb.Message.setField(this, 13, value);
+};
+
+
+/**
+ * optional uint64 min_swap_amount = 14;
+ * @return {number}
+ */
+proto.looprpc.LiquidityParameters.prototype.getMinSwapAmount = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 14, 0));
+};
+
+
+/** @param {number} value */
+proto.looprpc.LiquidityParameters.prototype.setMinSwapAmount = function(value) {
+  jspb.Message.setField(this, 14, value);
+};
+
+
+/**
+ * optional uint64 max_swap_amount = 15;
+ * @return {number}
+ */
+proto.looprpc.LiquidityParameters.prototype.getMaxSwapAmount = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 15, 0));
+};
+
+
+/** @param {number} value */
+proto.looprpc.LiquidityParameters.prototype.setMaxSwapAmount = function(value) {
+  jspb.Message.setField(this, 15, value);
 };
 
 

--- a/doc/compile.md
+++ b/doc/compile.md
@@ -6,7 +6,6 @@ installed on your machine.
 | Dependency                                          | Description                                                                                                                                                                          |
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [golang](https://golang.org/doc/install)            | LiT's backend web server is written in Go. The minimum version supported is Go v1.13.                                                                                                |
-| [protoc 3.4.0](https://github.com/lightningnetwork/lnd/tree/master/lnrpc#generate-protobuf-definitions) | Required to compile LND & Loop gRPC proto files at build time. Must be installed according to step 1 of the linked guide.  |
 | [nodejs](https://nodejs.org/en/download/)           | LiT's frontend is written in TypeScript and built on top of the React JS web framework. To bundle the assets into Javascript & CSS compatible with web browsers, NodeJS is required. |
 | [yarn](https://classic.yarnpkg.com/en/docs/install) | A popular package manager for NodeJS application dependencies.                                                                                                                        |
 
@@ -67,3 +66,37 @@ GitHub so you don't need to install any dependencies:
 ```shell script
 $ docker build -t lightninglabs/lightning-terminal --build-arg checkout=v0.3.2-alpha .
 ```
+
+### Compiling gRPC proto files
+
+When the gRPC protocol buffer definition files for `lnd` or `loop` are
+updated with new releases, the [generated](../src/types/generated/) JS/TS files should be
+updated as well. This should only be done when the versions of the daemons packaged in
+Terminal are updated.
+
+To compile the proto files into JS/TS code, follow the following steps:
+
+1. Install `protoc` **v3.4.0** if you do not already have it installed. Follow the
+   instructions in
+   [this guide](https://github.com/lightningnetwork/lnd/tree/master/lnrpc#generate-protobuf-definitions).
+   Be sure to install the specific **v3.4.0** version of `protoc`. Newer versions will not
+   work properly.
+   
+   > Note: if you are running on a Mac, you only need to perform step 1
+1. Update the version of `lnd` and/or `loop` at the top of the [build-protos.js](../src/scripts/build-protos.js)
+   file.
+1. Run the following command to download the proto files from each repo and compile the
+   JS/TS code using the updated protos.
+   ```shell script
+   $ cd app
+   $ yarn protos
+   ```
+1. Fix any typing, linting, or unit test failures introduced by the update. Run the
+   commands below to find and fix these errors in the app code.
+   ```shell script
+   $ cd app
+   $ yarn tsc
+   $ yarn lint
+   $ yarn test:ci
+   ```
+1. Once all errors have been resolved, commit your changes and open a PR

--- a/proto/lnd.proto
+++ b/proto/lnd.proto
@@ -235,8 +235,10 @@ service Lightning {
     /* lncli: `abandonchannel`
     AbandonChannel removes all channel state from the database except for a
     close summary. This method can be used to get rid of permanently unusable
-    channels due to bugs fixed in newer versions of lnd. Only available
-    when in debug builds of lnd.
+    channels due to bugs fixed in newer versions of lnd. This method can also be
+    used to remove externally funded channels where the funding transaction was
+    never broadcast. Only available for non-externally funded channels in dev
+    build.
     */
     rpc AbandonChannel (AbandonChannelRequest) returns (AbandonChannelResponse);
 
@@ -491,6 +493,13 @@ service Lightning {
     offline.
     */
     rpc BakeMacaroon (BakeMacaroonRequest) returns (BakeMacaroonResponse);
+
+    /* lncli: `listpermissions`
+    ListPermissions lists all RPC method URIs and their required macaroon
+    permissions to access them.
+    */
+    rpc ListPermissions (ListPermissionsRequest)
+        returns (ListPermissionsResponse);
 }
 
 message Utxo {
@@ -1672,6 +1681,12 @@ message OpenChannelRequest {
     the channel. It only applies to the remote party.
     */
     uint64 remote_max_value_in_flight_msat = 15;
+
+    /*
+    The maximum number of concurrent HTLCs we will allow the remote party to add
+    to the commitment transaction.
+    */
+    uint32 remote_max_htlcs = 16;
 }
 message OpenStatusUpdate {
     oneof update {
@@ -1817,12 +1832,19 @@ message FundingPsbtFinalize {
     /*
     The funded PSBT that contains all witness data to send the exact channel
     capacity amount to the PK script returned in the open channel message in a
-    previous step.
+    previous step. Cannot be set at the same time as final_raw_tx.
     */
     bytes signed_psbt = 1;
 
     // The pending channel ID of the channel to get the PSBT for.
     bytes pending_chan_id = 2;
+
+    /*
+    As an alternative to the signed PSBT with all witness data, the final raw
+    wire format transaction can also be specified directly. Cannot be set at the
+    same time as signed_psbt.
+    */
+    bytes final_raw_tx = 3;
 }
 
 message FundingTransitionMsg {
@@ -3039,6 +3061,8 @@ message DeleteAllPaymentsResponse {
 
 message AbandonChannelRequest {
     ChannelPoint channel_point = 1;
+
+    bool pending_funding_shim_only = 2;
 }
 
 message AbandonChannelResponse {
@@ -3333,6 +3357,21 @@ message BakeMacaroonResponse {
     string macaroon = 1;
 }
 
+message MacaroonPermissionList {
+    // A list of macaroon permissions.
+    repeated MacaroonPermission permissions = 1;
+}
+
+message ListPermissionsRequest {
+}
+message ListPermissionsResponse {
+    /*
+    A map between all RPC method URIs and their required macaroon permissions to
+    access them.
+    */
+    map<string, MacaroonPermissionList> method_permissions = 1;
+}
+
 message Failure {
     enum FailureCode {
         /*
@@ -3494,4 +3533,15 @@ message ChannelUpdate {
     network in a forwards compatible manner.
     */
     bytes extra_opaque_data = 12;
+}
+
+message MacaroonId {
+    bytes nonce = 1;
+    bytes storageId = 2;
+    repeated Op ops = 3;
+}
+
+message Op {
+    string entity = 1;
+    repeated string actions = 2;
 }

--- a/proto/loop.proto
+++ b/proto/loop.proto
@@ -808,6 +808,20 @@ message LiquidityParameters {
     flight at any point in time.
     */
     uint64 auto_max_in_flight = 13;
+
+    /*
+    The minimum amount, expressed in satoshis, that the autoloop client will
+    dispatch a swap for. This value is subject to the server-side limits
+    specified by the LoopOutTerms endpoint.
+    */
+    uint64 min_swap_amount = 14;
+
+    /*
+    The maximum amount, expressed in satoshis, that the autoloop client will
+    dispatch a swap for. This value is subject to the server-side limits
+    specified by the LoopOutTerms endpoint.
+    */
+    uint64 max_swap_amount = 15;
 }
 
 enum LiquidityRuleType {


### PR DESCRIPTION
As a follow up to #158 which removed the dependency on `protoc` at the machine level to compile from source, this PR makes a few updates:

- update the compile.md doc removing the `protoc` dependency
- update `yarn protos` script to download protos from github instead of needing to do this manually
- update the compile.md with instructions to compile the protos whenever we update the `lnd` and `loop` versions
- update the proto files to match the `lnd` and `loop` versions currently included with Terminal
- fix generated code being included in GitHub language stats
