### PR TITLE
Prepare for LiT v0.3.3-alpha

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm64
           tags: "${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}"
           build-args: checkout=${{ env.RELEASE_VERSION }}
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Lightning Terminal is backwards compatible with `lnd` back to version v0.11.1-be
 
 | LiT              | LND          |
 | ---------------- | ------------ |
+| **v0.3.3-alpha** | v0.11.1-beta | 
 | **v0.3.2-alpha** | v0.11.1-beta | 
 | **v0.3.1-alpha** | v0.11.1-beta |
 | **v0.3.0-alpha** | v0.11.1-beta |
@@ -75,6 +76,7 @@ Lightning Terminal is backwards compatible with `lnd` back to version v0.11.1-be
 
 | LiT              | LND          | Loop        | Faraday      | Pool          |
 | ---------------- | ------------ | ----------- | ------------ |---------------|
+| **v0.3.3-alpha** | v0.11.1-beta | v0.11.2-beta | v0.2.2-alpha | v0.3.4-alpha |
 | **v0.3.2-alpha** | v0.11.1-beta | v0.11.1-beta | v0.2.2-alpha | v0.3.4-alpha |
 | **v0.3.1-alpha** | v0.11.1-beta | v0.11.1-beta | v0.2.2-alpha | v0.3.3-alpha |
 | **v0.3.0-alpha** | v0.11.1-beta | v0.11.0-beta | v0.2.2-alpha | v0.3.2-alpha |

--- a/doc/compile.md
+++ b/doc/compile.md
@@ -83,8 +83,6 @@ To compile the proto files into JS/TS code, follow the following steps:
    work properly.
    
    > Note: if you are running on a Mac, you only need to perform step 1
-1. Update the version of `lnd` and/or `loop` at the top of the [build-protos.js](../src/scripts/build-protos.js)
-   file.
 1. Run the following command to download the proto files from each repo and compile the
    JS/TS code using the updated protos.
    ```shell script

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/lightninglabs/aperture v0.1.3-beta
 	github.com/lightninglabs/faraday v0.2.2-alpha
 	github.com/lightninglabs/lndclient v0.11.0-3
-	github.com/lightninglabs/loop v0.11.1-beta
+	github.com/lightninglabs/loop v0.11.2-beta
 	github.com/lightninglabs/pool v0.3.4-alpha
 	github.com/lightningnetwork/lnd v0.11.1-beta
 	github.com/lightningnetwork/lnd/cert v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/lightninglabs/lndclient v0.11.0-0/go.mod h1:8/cTKNwgL87NX123gmlv3Xh6p
 github.com/lightninglabs/lndclient v0.11.0-3 h1:x8co3UOeaUwh0iBFNeaPaqJsg8gvlgV/+fQHp2MT9eI=
 github.com/lightninglabs/lndclient v0.11.0-3/go.mod h1:8/cTKNwgL87NX123gmlv3Xh6p1a7pvzu+40Un3PhHiI=
 github.com/lightninglabs/lndclient v0.11.0-3/go.mod h1:8/cTKNwgL87NX123gmlv3Xh6p1a7pvzu+40Un3PhHiI=
-github.com/lightninglabs/loop v0.11.1-beta h1:FN2MJBn3MIFLxjdyOCqyVSSopFMHQDX5HtqNBdx4svE=
-github.com/lightninglabs/loop v0.11.1-beta/go.mod h1:xZfGG0AbxwAoarGGLeEl8TEzGm/Wz81L8IN51iqWn3M=
+github.com/lightninglabs/loop v0.11.2-beta h1:duhmf2G/yQbLnAc0vYvzxkm86gDTRswlvtstmO6MAZA=
+github.com/lightninglabs/loop v0.11.2-beta/go.mod h1:xZfGG0AbxwAoarGGLeEl8TEzGm/Wz81L8IN51iqWn3M=
 github.com/lightninglabs/neutrino v0.11.0/go.mod h1:CuhF0iuzg9Sp2HO6ZgXgayviFTn1QHdSTJlMncK80wg=
 github.com/lightninglabs/neutrino v0.11.1-0.20200316235139-bffc52e8f200 h1:j4iZ1XlUAPQmW6oSzMcJGILYsRHNs+4O3Gk+2Ms5Dww=
 github.com/lightninglabs/neutrino v0.11.1-0.20200316235139-bffc52e8f200/go.mod h1:MlZmoKa7CJP3eR1s5yB7Rm5aSyadpKkxqAwLQmog7N0=


### PR DESCRIPTION
With this PR we prepare to release a minor version of LiT that contains the following changes:
- Only build docker images for 64bit ARM, remove the 32bit target to be in sync with the `lnd` images.
- Update Loop to `v0.11.2-beta`.
- Extract `lnd` and `poold` versions from `go.mod` when compiling proto files.