### PR TITLE
add insecure HTTP only listener option

### DIFF
--- a/config.go
+++ b/config.go
@@ -112,6 +112,7 @@ var (
 // daemon's short name.
 type Config struct {
 	HTTPSListen    string `long:"httpslisten" description:"The host:port to listen for incoming HTTP/2 connections on for the web UI only."`
+	HTTPListen     string `long:"insecure-httplisten" description:"The host:port to listen on with TLS disabled. This is dangerous to enable as credentials will be submitted without encryption. Should only be used in combination with Tor hidden services or other external encryption."`
 	UIPassword     string `long:"uipassword" description:"The password that must be entered when using the loop UI. use a strong password to protect your node from unauthorized access through the web UI."`
 	UIPasswordFile string `long:"uipassword_file" description:"Same as uipassword but instead of passing in the value directly, read the password from the specified file."`
 	UIPasswordEnv  string `long:"uipassword_env" description:"Same as uipassword but instead of passing in the value directly, read the password from the specified environment variable."`
@@ -329,7 +330,7 @@ func loadAndValidateConfig() (*Config, error) {
 	if err := pool.Validate(cfg.Pool); err != nil {
 		return nil, err
 	}
-	
+
 	cfg.Faraday.Network = cfg.network
 	if err := faraday.ValidateConfig(cfg.Faraday); err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/lightning-terminal/issues/162.

For uses of LiT through Tor connections that add their own layer of
transport security, it doesn't make sense to add TLS on top. We
therefore allow running an additional HTTP only listener.

@justinpobrien requesting review from you as well because this contains a potential security footgun if used improperly. Does the flag name `--insecure-httplisten` convey the danger of enabling this sufficiently?