### PR TITLE
tour: fix walkthrough link

### DIFF
--- a/app/src/components/tour/WelcomeStep.tsx
+++ b/app/src/components/tour/WelcomeStep.tsx
@@ -51,7 +51,7 @@ const WelcomeStep: React.FC<ReactourStepContentArgs> = props => {
       <p>
         {l('walkthrough1')}{' '}
         <a
-          href="https://github.com/lightninglabs/lightning-terminal/doc/WALKTHROUGH.md"
+          href="https://docs.lightning.engineering/intermediate-get-lit/walkthrough"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
Closes #166 

Updated the broken link in the tour's first step to point to the walkthrough in the GitBook docs website.