### PR TITLE
pool+accounts: minor account section updates

### DIFF
--- a/app/src/components/pool/account/AccountSummary.tsx
+++ b/app/src/components/pool/account/AccountSummary.tsx
@@ -70,6 +70,12 @@ const AccountSummary: React.FC = () => {
           <StatusBadge pending={account.isPending}>{account.stateLabel}</StatusBadge>
         </SummaryItem>
         <SummaryItem>
+          <span>{l('traderKey')}</span>
+          <Tip overlay={account.traderKey} capitalize={false}>
+            <span>{account.traderKeyEllipsed}</span>
+          </Tip>
+        </SummaryItem>
+        <SummaryItem>
           <span>{l('fundingTxn')}</span>
           <Tip overlay={account.fundingTxnId} capitalize={false}>
             <span>

--- a/app/src/components/pool/account/AccountSummary.tsx
+++ b/app/src/components/pool/account/AccountSummary.tsx
@@ -122,14 +122,25 @@ const AccountSummary: React.FC = () => {
             </SummaryItem>
           </>
         ) : (
-          <Button
-            primary
-            ghost
-            disabled={account.stateLabel !== 'Open'}
-            onClick={accountSectionView.showFundAccount}
-          >
-            {l('fundAccount')}
-          </Button>
+          <SummaryItem>
+            <Button
+              danger
+              ghost
+              compact
+              disabled={account.stateLabel !== 'Open'}
+              onClick={accountSectionView.showCloseAccount}
+            >
+              {l('close')}
+            </Button>
+            <Button
+              primary
+              ghost
+              disabled={account.stateLabel !== 'Open'}
+              onClick={accountSectionView.showFundAccount}
+            >
+              {l('fundAccount')}
+            </Button>
+          </SummaryItem>
         )}
       </Actions>
     </>

--- a/app/src/i18n/locales/en-US.json
+++ b/app/src/i18n/locales/en-US.json
@@ -95,6 +95,7 @@
   "cmps.pool.account.AccountSummary.expiresIn": "Expires in",
   "cmps.pool.account.AccountSummary.expiresHeight": "{{remaining}} blocks (Height #{{height}})",
   "cmps.pool.account.AccountSummary.accountStatus": "Account Status",
+  "cmps.pool.account.AccountSummary.traderKey": "Trader Key",
   "cmps.pool.account.AccountSummary.fundingTxn": "Funding Transaction",
   "cmps.pool.account.AccountSummary.currentBalance": "Current Balance",
   "cmps.pool.account.AccountSummary.openOrdersCount": "Open Orders",

--- a/app/src/store/models/account.ts
+++ b/app/src/store/models/account.ts
@@ -22,6 +22,11 @@ export default class Account {
     this.update(poolAccount);
   }
 
+  /** the first and last 6 chars of the trader key */
+  get traderKeyEllipsed() {
+    return ellipseInside(this.traderKey, 4);
+  }
+
   /** the first and last 6 chars of the funding txn id */
   get fundingTxnIdEllipsed() {
     return ellipseInside(this.fundingTxnId, 4);


### PR DESCRIPTION
This PR just makes a couple minor updates to the account section:
1. Display a button to close the account. Previously, the user needed to wait until the account was about to expire to close it. Now, the account can be closed at any time.
2. Display the account/trader key in the account section as this is useful when troubleshooting Pool account issues.

![image](https://user-images.githubusercontent.com/1356600/109375005-57917280-7887-11eb-8228-ee60dc2c6588.png)
