### PR TITLE
loop: fix dismiss swap icon not working

### DIFF
--- a/app/src/store/stores/swapStore.ts
+++ b/app/src/store/stores/swapStore.ts
@@ -1,6 +1,7 @@
 import {
   autorun,
   entries,
+  IObservableArray,
   makeAutoObservable,
   observable,
   ObservableMap,
@@ -28,7 +29,7 @@ export default class SwapStore {
   swappedChannels: ObservableMap<string, string[]> = observable.map();
 
   /** the ids of failed swaps that have been dismissed */
-  dismissedSwapIds: string[] = [];
+  dismissedSwapIds: IObservableArray<string> = observable.array([]);
 
   constructor(store: Store) {
     makeAutoObservable(this, {}, { deep: false, autoBind: true });
@@ -192,7 +193,7 @@ export default class SwapStore {
     const swapState = this._store.storage.get<PersistentSwapState>('swapState');
     if (swapState) {
       this.swappedChannels = observable.map<string, string[]>(swapState.swappedChannels);
-      this.dismissedSwapIds = swapState.dismissedSwapIds;
+      this.dismissedSwapIds = observable.array(swapState.dismissedSwapIds);
       this._store.log.info('loaded swapState', swapState);
     }
   }


### PR DESCRIPTION
Closes #187 

This PR fixes a small bug which prevented the user from being able to dismiss failed swaps in the Processing Loops section. When clicking on the Dismiss icon, nothing would happen.

### Steps to test
1. Since the processing swaps list only displays swaps completed in the past 5 minutes, you'll first need to perform a swap. 2. Change the swap's `state` to failed by running `store.swapStore.sortedSwaps[0].state = 4` in the browser console
3. Click on the Expand icon in the Loop History tile to open the Processing Loops section 
4. Click on the Gray "X" icon to dismiss the failed Loop
5. Confirm the failed Loop disappears

![image](https://user-images.githubusercontent.com/1356600/109558458-73735f00-7aa7-11eb-92e2-a1a3244e4fb4.png)
