### PR TITLE
config: fix empty default remote lnd admin mac path

### DIFF
--- a/config.go
+++ b/config.go
@@ -65,6 +65,7 @@ const (
 	defaultRemotePoolRpcServer    = "localhost:12010"
 	defaultLndChainSubDir         = "chain"
 	defaultLndChain               = "bitcoin"
+	defaultLndMacaroon            = "admin.macaroon"
 )
 
 var (
@@ -103,6 +104,13 @@ var (
 	// its Let's Encrypt files.
 	defaultLetsEncryptDir = filepath.Join(
 		defaultLitDir, defaultLetsEncryptSubDir,
+	)
+
+	// defaultRemoteLndMacaroonPath is the default path we assume for a
+	// local lnd node to store its admin.macaroon file at.
+	defaultRemoteLndMacaroonPath = filepath.Join(
+		lndDefaultConfig.DataDir, defaultLndChainSubDir,
+		defaultLndChain, defaultNetwork, defaultLndMacaroon,
 	)
 )
 
@@ -248,7 +256,7 @@ func defaultConfig() *Config {
 			LitMaxLogFileSize: defaultMaxLogFileSize,
 			Lnd: &RemoteDaemonConfig{
 				RPCServer:    defaultRemoteLndRpcServer,
-				MacaroonPath: lndDefaultConfig.AdminMacPath,
+				MacaroonPath: defaultRemoteLndMacaroonPath,
 				TLSCertPath:  lndDefaultConfig.TLSCertPath,
 			},
 			Faraday: &RemoteDaemonConfig{
@@ -526,7 +534,7 @@ func validateRemoteModeConfig(cfg *Config) error {
 	// specify --network=testnet for example if everything else is using
 	// the defaults.
 	if cfg.Network != defaultNetwork &&
-		r.Lnd.MacaroonPath == defaultLndCfg.AdminMacPath {
+		r.Lnd.MacaroonPath == defaultRemoteLndMacaroonPath {
 
 		r.Lnd.MacaroonPath = filepath.Join(
 			defaultLndCfg.DataDir, defaultLndChainSubDir,


### PR DESCRIPTION
Partially reverts c917e91f and fixes #195: The default remote lnd admin
macaroon path we added in c917e91f was a mistake since by default that
value isn't set until we call lnd.ValidateConfig() which we never do in
the remote mode.
We fix this by providing a sane default value for the admin macaroon
again.