### PR TITLE
pool+orders: fix number input being truncated

### DIFF
--- a/app/src/components/common/FormInputNumber.tsx
+++ b/app/src/components/common/FormInputNumber.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode, useCallback, useMemo } from 'react';
+import { formatSats } from 'util/formatters';
 import FormInput from './FormInput';
 
 interface Props {
@@ -27,7 +28,10 @@ const FormInputNumber: React.FC<Props> = ({
     [onChange],
   );
 
-  const valueText = useMemo(() => (!value ? '' : value.toLocaleString()), [value]);
+  const valueText = useMemo(
+    () => (!value ? '' : formatSats(value, { withSuffix: false })),
+    [value],
+  );
 
   return (
     <FormInput

--- a/app/src/util/formatters.ts
+++ b/app/src/util/formatters.ts
@@ -22,14 +22,14 @@ const defaultFormatSatsOptions = {
  * @param sats the numeric value in satoshis
  * @param options the format options
  */
-export const formatSats = (sats: Big, options?: FormatSatsOptions) => {
+export const formatSats = (sats: Big | number, options?: FormatSatsOptions) => {
   const { unit, withSuffix, lang } = Object.assign({}, defaultFormatSatsOptions, options);
   const { suffix, denominator, decimals } = Units[unit];
   const formatter = Intl.NumberFormat(lang, {
     minimumFractionDigits: decimals,
     maximumFractionDigits: decimals,
   });
-  let text = formatter.format(+sats.div(denominator));
+  let text = formatter.format(+Big(sats).div(denominator));
   if (withSuffix) text = `${text} ${suffix}`;
   return text;
 };


### PR DESCRIPTION
This PR fixes an issue where the number inputs in the Pool order form would truncate values incorrectly when the browser's language is not English.

![input](https://user-images.githubusercontent.com/1356600/113901371-c920e280-979c-11eb-81b9-357c28a5814b.gif)
