### PR TITLE
Add full REST support

### DIFF
--- a/config.go
+++ b/config.go
@@ -120,6 +120,7 @@ var (
 type Config struct {
 	HTTPSListen    string `long:"httpslisten" description:"The host:port to listen for incoming HTTP/2 connections on for the web UI only."`
 	HTTPListen     string `long:"insecure-httplisten" description:"The host:port to listen on with TLS disabled. This is dangerous to enable as credentials will be submitted without encryption. Should only be used in combination with Tor hidden services or other external encryption."`
+	EnableREST     bool   `long:"enablerest" description:"Also allow REST requests to be made to the main HTTP(s) port(s) configured above."`
 	UIPassword     string `long:"uipassword" description:"The password that must be entered when using the loop UI. use a strong password to protect your node from unauthorized access through the web UI."`
 	UIPasswordFile string `long:"uipassword_file" description:"Same as uipassword but instead of passing in the value directly, read the password from the specified file."`
 	UIPasswordEnv  string `long:"uipassword_env" description:"Same as uipassword but instead of passing in the value directly, read the password from the specified environment variable."`

--- a/config.go
+++ b/config.go
@@ -118,12 +118,13 @@ var (
 // all config items of its enveloping subservers, each prefixed with their
 // daemon's short name.
 type Config struct {
-	HTTPSListen    string `long:"httpslisten" description:"The host:port to listen for incoming HTTP/2 connections on for the web UI only."`
-	HTTPListen     string `long:"insecure-httplisten" description:"The host:port to listen on with TLS disabled. This is dangerous to enable as credentials will be submitted without encryption. Should only be used in combination with Tor hidden services or other external encryption."`
-	EnableREST     bool   `long:"enablerest" description:"Also allow REST requests to be made to the main HTTP(s) port(s) configured above."`
-	UIPassword     string `long:"uipassword" description:"The password that must be entered when using the loop UI. use a strong password to protect your node from unauthorized access through the web UI."`
-	UIPasswordFile string `long:"uipassword_file" description:"Same as uipassword but instead of passing in the value directly, read the password from the specified file."`
-	UIPasswordEnv  string `long:"uipassword_env" description:"Same as uipassword but instead of passing in the value directly, read the password from the specified environment variable."`
+	HTTPSListen    string   `long:"httpslisten" description:"The host:port to listen for incoming HTTP/2 connections on for the web UI only."`
+	HTTPListen     string   `long:"insecure-httplisten" description:"The host:port to listen on with TLS disabled. This is dangerous to enable as credentials will be submitted without encryption. Should only be used in combination with Tor hidden services or other external encryption."`
+	EnableREST     bool     `long:"enablerest" description:"Also allow REST requests to be made to the main HTTP(s) port(s) configured above."`
+	RestCORS       []string `long:"restcors" description:"Add an ip:port/hostname to allow cross origin access from. To allow all origins, set as \"*\"."`
+	UIPassword     string   `long:"uipassword" description:"The password that must be entered when using the loop UI. use a strong password to protect your node from unauthorized access through the web UI."`
+	UIPasswordFile string   `long:"uipassword_file" description:"Same as uipassword but instead of passing in the value directly, read the password from the specified file."`
+	UIPasswordEnv  string   `long:"uipassword_env" description:"Same as uipassword but instead of passing in the value directly, read the password from the specified environment variable."`
 
 	LetsEncrypt       bool   `long:"letsencrypt" description:"Use Let's Encrypt to create a TLS certificate for the UI instead of using lnd's TLS certificate. Port 80 must be free to listen on and must be reachable from the internet for this to work."`
 	LetsEncryptHost   string `long:"letsencrypthost" description:"The host name to create a Let's Encrypt certificate for."`

--- a/rpc_proxy.go
+++ b/rpc_proxy.go
@@ -87,7 +87,7 @@ func newRpcProxy(cfg *Config, validator macaroons.MacaroonValidator,
 // it is handled there. If not, the director will forward the call to either a
 // local or remote lnd instance.
 //
-//    any RPC or REST call
+//    any RPC or grpc-web call
 //        |
 //        V
 //    +---+----------------------+
@@ -245,8 +245,6 @@ func (p *rpcProxy) isHandling(resp http.ResponseWriter,
 
 		return true
 	}
-
-	// TODO(guggero): Handle REST calls as well.
 
 	return false
 }


### PR DESCRIPTION
Fixes #213.
Fixes #214.

This PR adds a new top level flag (`--enablerest`) or config item (`enablerest=true`) that enables REST calls to be made to the main HTTP(S) listener.
With this the main HTTP(S) listener can now handle native gRPC, grpc-web, REST and static file requests for all daemons (lnd, faraday, loop, pool) independent of whether they run in integrated or remote mode.
Lightning Terminal becomes the ultimate lnd&friends reverse proxy.

