### PR TITLE
mod+tools: add dummy import for CLI dependencies

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -335,6 +335,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200122045848-3419fae592fc h1:yUaosFVTJwnltaHbSNC3i82I92quFs+OFPRl8kNMVwo=

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,13 @@
+// +build tools
+
+package terminal
+
+import (
+	// This is a workaround to make sure go mod keeps around the 
+	// dependencies in the go.sum file that we only use during compilation
+	// of the CLI binaries that are delivered together with LiT.
+	_ "github.com/lightninglabs/faraday/cmd/frcli"
+	_ "github.com/lightninglabs/loop/cmd/loop"
+	_ "github.com/lightninglabs/pool/cmd/pool"
+	_ "github.com/lightningnetwork/lnd/cmd/lncli"
+)


### PR DESCRIPTION
With go 1.16 something changed in how the content of go.sum is
calculated. The "go mod tidy" command now removes dependencies for
packages that aren't directly referenced through the main package.
Therefore if we compile another binary (such as the CLI binaries we ship
together with LiT) some of their dependencies might have been pruned
from go.sum. To avoid that, we add dummy imports for those packages
under a build tag that we don't actually use. The "tools" tag seems to
be the idiomatic tag for such tooling depencencies.

Thanks for reporting this, @jamaljsr!