### PR TITLE
rpc: Increase the default connection timeout to LND

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	defaultServerTimeout  = 10 * time.Second
-	defaultConnectTimeout = 5 * time.Second
+	defaultConnectTimeout = 15 * time.Second
 	defaultStartupTimeout = 5 * time.Second
 )
 


### PR DESCRIPTION
I was getting the below errors when trying to use LiT:

```
$ litd --uipassword=test1234 --remote.lnd.rpcserver=node:10009 --remote.lnd.tlscertpath=~/.lnd/node/tls.cert  --remote.lnd.macaroonpath=~/.lnd/node/admin.macaroon
2021-08-13 08:57:20.611 [INF] LITD: Dialing lnd gRPC server at node:10009
2021-08-13 08:57:20.627 [INF] LITD: Listening for http_tls on: 127.0.0.1:8443
2021-08-13 08:57:25.622 [WRN] GRPC: grpc: addrConn.createTransport failed to connect to {node:10009  <nil> 0 <nil>}. Err: connection error: desc = "transport: Error while dialing dial tcp: i/o timeout". Reconnecting...
----------------------------------------------------------
 Lightning Terminal (LiT) by Lightning Labs

 Operating mode      remote
 Node status         online
 Alias               node
 Version             0.13.1-beta commit=v0.13.1-beta
 Web interface       127.0.0.1:8443 (open https://127.0.0.1:8443 in your browser)
----------------------------------------------------------
2021-08-13 08:57:31.352 [INF] LNDC: Creating lnd connection to node:10009
2021-08-13 08:57:31.354 [INF] LNDC: Connected to lnd
2021-08-13 08:57:31.354 [INF] LNDC: Waiting for lnd to unlock
2021-08-13 08:57:36.360 [ERR] LITD: Could not start subservers: rpc error: code = DeadlineExceeded desc = context deadline exceeded
2021-08-13 08:57:36.365 [INF] SGNL: Received shutdown request.
2021-08-13 08:57:36.366 [INF] SGNL: Shutting down...
2021-08-13 08:57:36.366 [INF] SGNL: Gracefully shutting down.
rpc error: code = DeadlineExceeded desc = context deadline exceeded
```

I could never get it to actually start up despite it obviously could talk to my node (it go the alias and version).

After some investigation I realized it was hitting the default timeout for the gRPC connections to LND. This node is fairly large so some RPC responses take a while to return. The default 5 seconds was not long enough.

I did a test with increasing it to 15 seconds and it worked no problem. I'm proposing we increase the default timeout for LND connections to 15 seconds as I'm sure other are or will hit this problem. 