### PR TITLE
docker: create and push secondary image with path prefix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
-      - name: Build and push
+      - name: Build and push default image
         id: docker_build
         uses: lightninglabs/gh-actions/build-push-action@2021.01.25.00
         with:
@@ -42,5 +42,14 @@ jobs:
           tags: "${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}"
           build-args: checkout=${{ env.RELEASE_VERSION }}
 
+      - name: Build and push image with /lit path
+        id: docker_build2
+        uses: lightninglabs/gh-actions/build-push-action@2021.01.25.00
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: "${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}-path-prefix"
+          build-args: checkout=${{ env.RELEASE_VERSION }} public_url=/lit
+
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: echo ${{ steps.docker_build.outputs.digest }} ${{ steps.docker_build2.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ FROM node:12.17.0-alpine as nodejsbuilder
 # master by default.
 ARG checkout="master"
 
+# The public URL the static files should be served under. This must be empty to
+# work for the root path (/).
+ARG public_url=""
+
 # There seem to be multiple problems when using yarn for a build inside of a
 # docker image:
 #   1. For building and installing node-gyp, python is required. This seems to
@@ -25,7 +29,7 @@ RUN apk add --no-cache --update alpine-sdk \
   && npm config set registry "http://registry.npmjs.org" \
   && yarn config set registry "http://registry.npmjs.org" \
   && yarn install --frozen-lockfile --network-timeout 1000000 \
-  && yarn build
+  && PUBLIC_URL=$public_url yarn build
 
 # The first stage is already done and all static assets should now be generated
 # in the app/build sub directory.
@@ -46,7 +50,7 @@ ENV GO111MODULE on
 RUN apk add --no-cache --update alpine-sdk \
     make \
   && cd /go/src/github.com/lightninglabs/lightning-terminal \
-  && make go-install \
+  && make go-install PUBLIC_URL=$public_url \
   && make go-install-cli
 
 # Start a new, final image to reduce size.

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ GOACC_BIN := $(GO_BIN)/go-acc
 
 COMMIT := $(shell git describe --abbrev=40 --dirty --tags)
 COMMIT_HASH := $(shell git rev-parse HEAD)
+PUBLIC_URL := 
 
 LOOP_COMMIT := $(shell cat go.mod | \
 		grep $(LOOP_PKG) | \
@@ -57,6 +58,7 @@ make_ldflags = $(2) -X $(LND_PKG)/build.Commit=lightning-terminal-$(COMMIT) \
 	-X $(LND_PKG)/build.CommitHash=$(COMMIT_HASH) \
 	-X $(LND_PKG)/build.GoVersion=$(GOVERSION) \
 	-X $(LND_PKG)/build.RawTags=$(shell echo $(1) | sed -e 's/ /,/g') \
+	-X $(PKG).appFilesPrefix=$(PUBLIC_URL) \
 	-X $(LOOP_PKG).Commit=$(LOOP_COMMIT) \
 	-X $(POOL_PKG).Commit=$(POOL_COMMIT)
 

--- a/doc/custom-path.md
+++ b/doc/custom-path.md
@@ -1,0 +1,44 @@
+# Using a custom path for LiT
+
+If required LiT can be built to be accessed through a custom path (e.g. `/lit/`)
+in the browser instead of the default root path (`/`).
+
+To build LiT with a custom path, run the following command:
+
+```shell
+⛰  make PUBLIC_URL=/my-custom-path
+```
+
+**Make sure to not include a `/` at the end of the path.** To revert to the
+original, root path, set the variable to empty (`make PUBLIC_URL=`) or leave
+it out completely.
+
+## Docker image built with a path prefix
+
+There is a docker image that's automatically built with the prefix `/lit`
+available on Docker Hub. Just append `-path-prefix` to any version tag (after
+`v0.5.2-alpha`). For example:
+
+```shell
+# Default image.
+⛰  docker pull lightninglabs/lightning-terminal:v0.5.3-alpha
+
+# Image with /lit path prefix.
+⛰  docker pull lightninglabs/lightning-terminal:v0.5.3-alpha-path-prefix
+```
+
+## Use with nginx reverse proxy
+
+There is [an example nginx](example-nginx.conf) config file that demonstrates
+how rewrite rules can be set up to run LiT under the `/lit` path prefix (and
+internally forward all `grpc-web` requests to the LiT proxy while still
+forwarding "native" gRPC requests to the `lnd` instance that's also running
+behind the nginx reverse proxy).
+
+The example reverse proxy can be run with:
+
+```shell
+⛰  cd docs
+⛰  docker run --name lit-nginx \
+      -v $(pwd)/example-nginx.conf:/etc/nginx/nginx.conf:ro -p 8081:80 -d nginx
+```

--- a/doc/example-nginx.conf
+++ b/doc/example-nginx.conf
@@ -1,0 +1,57 @@
+events {
+  worker_connections  1024;
+}
+
+http {
+    # Redirect all incoming grpc-web requests to the LiT proxy. Everything else
+    # goes directly to the internal lnd container. We use a temporary variable
+    # here so we can rewrite it to the actual host again in the next map
+    # directive.
+    map $content_type $tmp_backend {
+      "application/grpc-web+proto" "172.17.0.1:8443"; # LiT proxy.
+      default "localhost:10009"; # main LND
+    }
+
+    # Streaming grpc-web requests can be identified by the
+    # "Sec-WebSocket-Protocol: grpc-websockets" header field. So those requests
+    # also need to go to the LiT proxy.
+    map $http_sec_websocket_protocol $lnd_backend {
+      "grpc-websockets" "172.17.0.1:8443"; # LiT proxy.
+      default $tmp_backend; # Fall back to the value from the above map result.
+    }
+
+    # Make sure WebSockets are properly upgraded.
+    map $http_sec_websocket_protocol $lnd_connection {
+      "grpc-websockets" "upgrade";
+      default $http_connection;
+    }
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Origin  https://$lnd_backend;
+        proxy_set_header Connection $lnd_connection;
+
+        location /lit {
+            # This needs a slash at the end!
+            proxy_pass https://172.17.0.1:8443/;
+        }
+
+        location ~* ^/lnrpc.Lightning/ {
+            # This cannot have a slash at the end!
+            proxy_pass https://$lnd_backend;
+        }
+
+        location ~* ^/looprpc.SwapClient/ {
+            # This cannot have a slash at the end!
+            proxy_pass https://$lnd_backend;
+        }
+
+        location ~* ^/poolrpc.Trader/ {
+            # This cannot have a slash at the end!
+            proxy_pass https://$lnd_backend;
+        }
+    }
+}


### PR DESCRIPTION
Creates a secondary docker image with the tag `:v0.x.y-alpha-path-prefix` that is auto built and pushed to Docker Hub and assumes that LiT is being run under the custom URL path `/lit`.

An example nginx configuration for setting up a reverse proxy that responds to both LiT `grpc-web` requests and native `lnd` gRPC requests under the same domain (and therefore TLS cert) is included. This mainly addresses setups like BTCPayServer (see https://github.com/btcpayserver/btcpayserver-docker/pull/512).