### PR TITLE
Fix error handling with stateless init

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ If you’d prefer to compile from source code please follow [these instructions]
 Lightning Terminal is backwards compatible with `lnd` back to version v0.13.3-beta.
 
 | LiT              | LND          |
-| ---------------- | ------------ |
+|------------------| ------------ |
+| **v0.6.1-alpha** | v0.13.3-beta |
 | **v0.6.0-alpha** | v0.13.3-beta |
 | **v0.5.2-alpha** | v0.12.0-beta |
 | **v0.5.1-alpha** | v0.12.0-beta |
@@ -86,8 +87,8 @@ Lightning Terminal is backwards compatible with `lnd` back to version v0.13.3-be
 ## Daemon Versions packaged with LiT
 
 | LiT              | LND          | Loop        | Faraday      | Pool          |
-| ---------------- | ------------ | ----------- | ------------ |---------------|
-| **v0.6.0-alpha** | v0.14.1-beta | v0.15.1-beta | v0.2.7-alpha | v0.5.2-alpha |
+|------------------| ------------ | ----------- | ------------ |---------------|
+| **v0.6.1-alpha** | v0.14.1-beta | v0.15.1-beta | v0.2.7-alpha | v0.5.2-alpha |
 | **v0.5.3-alpha** | v0.13.3-beta | v0.14.1-beta | v0.2.6-alpha | v0.5.0-alpha |
 | **v0.5.2-alpha** | v0.13.3-beta | v0.14.1-beta | v0.2.6-alpha | v0.5.0-alpha |
 | **v0.5.1-alpha** | v0.13.0-beta | v0.14.1-beta | v0.2.6-alpha | v0.5.0-alpha |

--- a/app/src/components/connect/ConnectPage.tsx
+++ b/app/src/components/connect/ConnectPage.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Redirect } from 'react-router';
 import { observer } from 'mobx-react-lite';
 import styled from '@emotion/styled';
 import nodeConnectSvg from 'assets/images/lightning-node-connect.svg';
@@ -12,7 +11,7 @@ import SessionList from './SessionList';
 
 const Styled = {
   Wrapper: styled.section`
-    padding: 80px 0 0 80px;
+    padding-top: 80px;
   `,
   DisplayLarge: styled.div`
     font-family: ${props => props.theme.fonts.open.semiBold};
@@ -33,11 +32,7 @@ const Styled = {
 
 const ConnectPage: React.FC = () => {
   const { l } = usePrefixedTranslation('cmps.connect.ConnectPage');
-  const { appView, sessionStore } = useStore();
-
-  if (!appView.showLightningConnect) {
-    return <Redirect to="/loop" />;
-  }
+  const { sessionStore } = useStore();
 
   const { Wrapper, DisplayLarge, Description, Divider } = Styled;
   return !sessionStore.hasMultiple ? (

--- a/app/src/components/layout/NavMenu.tsx
+++ b/app/src/components/layout/NavMenu.tsx
@@ -84,13 +84,7 @@ const NavMenu: React.FC = () => {
         <NavItem page="history" onClick={appView.goToHistory} />
         <NavItem page="pool" badge={l('common.preview')} onClick={appView.goToPool} />
         <NavItem page="settings" onClick={appView.goToSettings} />
-        {appView.showLightningConnect && (
-          <NavItem
-            page="connect"
-            badge={l('common.beta')}
-            onClick={appView.goToConnect}
-          />
-        )}
+        <NavItem page="connect" badge={l('common.beta')} onClick={appView.goToConnect} />
       </Nav>
     </>
   );

--- a/app/src/store/views/appView.ts
+++ b/app/src/store/views/appView.ts
@@ -39,13 +39,6 @@ export default class AppView {
     }
   }
 
-  /** determines if the Lightning Node Connect UI should be visible */
-  get showLightningConnect() {
-    const devOverride = !!localStorage.getItem('i-want-lnc');
-    /** the unix timestamp (ms) when Lightning Node Connect should become visible */
-    return devOverride || Date.now() > 1638288000000; // Nov 30 2021 11:00am EST
-  }
-
   /** Change to the Auth page */
   gotoAuth() {
     this.goTo(`${PUBLIC_URL}/`);

--- a/rpc_proxy.go
+++ b/rpc_proxy.go
@@ -33,6 +33,24 @@ const (
 	HeaderMacaroon = "Macaroon"
 )
 
+// proxyErr is an error type that adds more context to an error occurring in the
+// proxy.
+type proxyErr struct {
+	wrapped      error
+	proxyContext string
+}
+
+// Error returns the error message as a string, including the proxy's context.
+func (e *proxyErr) Error() string {
+	return fmt.Sprintf("proxy error with context %s: %v", e.proxyContext,
+		e.wrapped)
+}
+
+// Unwrap returns the wrapped error.
+func (e *proxyErr) Unwrap() error {
+	return e.wrapped
+}
+
 // newRpcProxy creates a new RPC proxy that can take any native gRPC, grpc-web
 // or REST request and delegate (and convert if necessary) it to the correct
 // component.

--- a/terminal.go
+++ b/terminal.go
@@ -706,9 +706,16 @@ func (g *LightningTerminal) ValidateMacaroon(ctx context.Context,
 				"syncing")
 		}
 
-		return g.faradayServer.ValidateMacaroon(
+		err = g.faradayServer.ValidateMacaroon(
 			ctx, requiredPermissions, fullMethod,
 		)
+		if err != nil {
+			return &proxyErr{
+				proxyContext: "faraday",
+				wrapped: fmt.Errorf("invalid macaroon: %v",
+					err),
+			}
+		}
 
 	case isLoopURI(fullMethod):
 		// In remote mode we just pass through the request, the remote
@@ -723,9 +730,16 @@ func (g *LightningTerminal) ValidateMacaroon(ctx context.Context,
 				"syncing")
 		}
 
-		return g.loopServer.ValidateMacaroon(
+		err = g.loopServer.ValidateMacaroon(
 			ctx, requiredPermissions, fullMethod,
 		)
+		if err != nil {
+			return &proxyErr{
+				proxyContext: "loop",
+				wrapped: fmt.Errorf("invalid macaroon: %v",
+					err),
+			}
+		}
 
 	case isPoolURI(fullMethod):
 		// In remote mode we just pass through the request, the remote
@@ -740,14 +754,26 @@ func (g *LightningTerminal) ValidateMacaroon(ctx context.Context,
 				"syncing")
 		}
 
-		return g.poolServer.ValidateMacaroon(
+		err = g.poolServer.ValidateMacaroon(
 			ctx, requiredPermissions, fullMethod,
 		)
+		if err != nil {
+			return &proxyErr{
+				proxyContext: "pool",
+				wrapped: fmt.Errorf("invalid macaroon: %v",
+					err),
+			}
+		}
 
 	case isLitURI(fullMethod):
-		_, err := g.rpcProxy.convertBasicAuth(ctx, fullMethod)
+		wrap := fmt.Errorf("invalid basic auth")
+		_, err := g.rpcProxy.convertBasicAuth(ctx, fullMethod, wrap)
 		if err != nil {
-			return err
+			return &proxyErr{
+				proxyContext: "lit",
+				wrapped: fmt.Errorf("invalid auth: %v",
+					err),
+			}
 		}
 	}
 


### PR DESCRIPTION
This is a follow-up commit that fixes an issue introduced with stateless
init where an error would be interpreted incorrectly.

This will bump the version in the README to `v0.6.1-alpha`.