### PR TITLE
multi: revoke expired sessions

### DIFF
--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -105,7 +105,8 @@ func (s *sessionRpcServer) resumeSession(sess *session.Session) error {
 	}
 
 	authData := []byte("Authorization: Basic " + s.basicAuth)
-	return s.sessionServer.StartSession(sess, authData)
+	_, err := s.sessionServer.StartSession(sess, authData)
+	return err
 }
 
 // ListSessions returns all sessions known to the session store.

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec"
@@ -20,6 +21,17 @@ type sessionRpcServer struct {
 
 	db            *session.DB
 	sessionServer *session.Server
+
+	quit chan struct{}
+
+	stopOnce sync.Once
+}
+
+// stop cleans up any sessionRpcServer resources.
+func (s *sessionRpcServer) stop() {
+	s.stopOnce.Do(func() {
+		close(s.quit)
+	})
 }
 
 // AddSession adds and starts a new Terminal Connect session.

--- a/terminal.go
+++ b/terminal.go
@@ -227,6 +227,7 @@ func (g *LightningTerminal) Run() error {
 		basicAuth:     g.rpcProxy.basicAuth,
 		db:            g.sessionDB,
 		sessionServer: g.sessionServer,
+		quit:          make(chan struct{}),
 	}
 
 	// Now start up all previously created sessions.
@@ -838,6 +839,7 @@ func (g *LightningTerminal) shutdown() error {
 		}
 	}
 
+	g.sessionRpcServer.stop()
 	if err := g.sessionDB.Close(); err != nil {
 		log.Errorf("Error closing session DB: %v", err)
 		returnErr = err


### PR DESCRIPTION
Ensure that expired sessions are revoked.

- when `resumeSession` is called but session is expired, it is revoked. 
- if the session is not yet expired, a timeout goroutine is used to ensure that it is stoped and revoked after expiry.
- the first commit adds the ability to subscribe to a session being stopped manually so that the above goroutine can exit when it is no longer needed