### PR TITLE
ui+nav: fix Lightning Node Connect link with custom path

### DIFF
--- a/app/src/store/views/appView.ts
+++ b/app/src/store/views/appView.ts
@@ -80,7 +80,7 @@ export default class AppView {
 
   /** Change to the Connect page */
   goToConnect() {
-    this.goTo('/connect');
+    this.goTo(`${PUBLIC_URL}/connect`);
     this._store.settingsStore.autoCollapseSidebar();
     this._store.log.info('Go to the Connect page');
   }


### PR DESCRIPTION
Closes #299 

This PR is a small fix to the "Lightning Node Connect" link in the sidebar nav. It will now include the `PUBLIC_URL` env var.