### PR TITLE
docs: Match and pass /litrpc.* locations in nginx

### DIFF
--- a/doc/example-nginx.conf
+++ b/doc/example-nginx.conf
@@ -39,17 +39,7 @@ http {
             proxy_pass https://172.17.0.1:8443/;
         }
 
-        location ~* ^/lnrpc.Lightning/ {
-            # This cannot have a slash at the end!
-            proxy_pass https://$lnd_backend;
-        }
-
-        location ~* ^/looprpc.SwapClient/ {
-            # This cannot have a slash at the end!
-            proxy_pass https://$lnd_backend;
-        }
-
-        location ~* ^/poolrpc.Trader/ {
+        location ~* ^/(ln|loop|pool|lit)rpc\. {
             # This cannot have a slash at the end!
             proxy_pass https://$lnd_backend;
         }


### PR DESCRIPTION
```
Also escape the "." for more precise regex matching
```

Not matching /litrpc.* locations results in lost grpc calls, which looks like this to the user:
![image](https://user-images.githubusercontent.com/3445290/148144423-a748140a-d0dd-4333-9807-6183ec860010.png)
