### PR TITLE
loop: increase maximum miner fee to reduce swap failures

### DIFF
--- a/app/src/api/loop.ts
+++ b/app/src/api/loop.ts
@@ -91,7 +91,8 @@ class LoopApi extends BaseApi<LoopEvents> {
     const req = new LOOP.LoopInRequest();
     req.setAmt(amount.toString());
     req.setMaxSwapFee(quote.swapFee.toString());
-    req.setMaxMinerFee(quote.minerFee.toString());
+    // mimic the behavior of loop CLI to avoid swap failures due to rising chain fees
+    req.setMaxMinerFee(quote.minerFee.mul(250).toString());
     req.setInitiator(LOOP_INITIATOR);
     if (lastHop) req.setLastHop(b64(lastHop));
     if (confTarget) req.setHtlcConfTarget(confTarget);
@@ -113,7 +114,8 @@ class LoopApi extends BaseApi<LoopEvents> {
     const req = new LOOP.LoopOutRequest();
     req.setAmt(amount.toString());
     req.setMaxSwapFee(quote.swapFee.toString());
-    req.setMaxMinerFee(quote.minerFee.toString());
+    // mimic the behavior of loop CLI to avoid swap failures due to rising chain fees
+    req.setMaxMinerFee(quote.minerFee.mul(250).toString());
     req.setMaxPrepayAmt(quote.prepayAmount.toString());
     req.setMaxSwapRoutingFee(this._calcRoutingFee(amount).toString());
     req.setMaxPrepayRoutingFee(this._calcRoutingFee(quote.prepayAmount).toString());


### PR DESCRIPTION
This PR increases the maximum miner fee to mimic the behavior of the `loop` CLI [main.go](https://github.com/lightninglabs/loop/blob/master/cmd/loop/main.go#L263). The `MaxMinerFee` value should be set higher in order to reduce the chances of a swap failure when onchain fees increase after the swap is initiated.

Closes #307, closes #303  