### PR TITLE
Support super macaroon in remote lnd mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,29 @@ Lightning Terminal is backwards compatible with `lnd` back to version v0.13.3-be
 | **v0.3.0-alpha** | v0.11.1-beta |
 | **v0.2.0-alpha** | v0.11.0-beta |
 
+LiT offers two main operating modes, one in which [`lnd` is running inside the
+LiT process (called "lnd integrated mode", set by `lnd-mode=integrated` config
+option)](doc/config-lnd-integrated.md) and one in which [`lnd` is running in
+a standalone process on the same or remote machine (called "lnd remote mode",
+set by `lnd-mode=remote` config option)](doc/config-lnd-remote.md).
+
+In addition to those main modes, the individual bundled daemons (Faraday, Loop
+and Pool) can be toggled to be integrated or remote as well. This offers a
+large number of possible configuration combinations, of which not all are
+fully supported due to technical reasons.
+
+The following table shows the supported combinations:
+
+|                                        | `lnd-mode=integrated` | `lnd-mode=remote` |
+|----------------------------------------|-----------------------|-------------------|
+| `faraday-mode=integrated`              | X                     | X                 |
+| `loop-mode=integrated`                 | X                     | X                 |
+| `pool-mode=integrated`                 | X                     | X                 |
+| `faraday-mode=remote`                  |                       | X                 |
+| `loop-mode=remote`                     |                       | X                 |
+| `pool-mode=remote`                     |                       | X                 |
+| `lnd` running in "stateless init" mode | X                     |                   |
+
 ## Daemon Versions packaged with LiT
 
 | LiT              | LND          | Loop        | Faraday      | Pool         |

--- a/cmd/litcli/main.go
+++ b/cmd/litcli/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -210,7 +211,7 @@ func getAuthContext(cliCtx *cli.Context) context.Context {
 	ctxb := context.Background()
 	md := metadata.MD{}
 
-	md.Set("macaroon", "no-macaroons-for-litcli")
+	md.Set("macaroon", hex.EncodeToString(terminal.EmptyMacaroonBytes))
 	md.Set("authorization", fmt.Sprintf("Basic %s", basicAuth))
 
 	return metadata.NewOutgoingContext(ctxb, md)

--- a/itest/litd_mode_integrated_test.go
+++ b/itest/litd_mode_integrated_test.go
@@ -138,6 +138,7 @@ var (
 		supportsUIPasswordOnLndPort bool
 		supportsUIPasswordOnLitPort bool
 		grpcWebURI                  string
+		restWebURI                  string
 	}{{
 		name:                        "lnrpc",
 		macaroonFn:                  lndMacaroonFn,
@@ -148,6 +149,7 @@ var (
 		supportsUIPasswordOnLndPort: false,
 		supportsUIPasswordOnLitPort: true,
 		grpcWebURI:                  "/lnrpc.Lightning/GetInfo",
+		restWebURI:                  "/v1/getinfo",
 	}, {
 		name:                        "frdrpc",
 		macaroonFn:                  faradayMacaroonFn,
@@ -158,6 +160,7 @@ var (
 		supportsUIPasswordOnLndPort: false,
 		supportsUIPasswordOnLitPort: true,
 		grpcWebURI:                  "/frdrpc.FaradayServer/RevenueReport",
+		restWebURI:                  "/v1/faraday/revenue",
 	}, {
 		name:                        "looprpc",
 		macaroonFn:                  loopMacaroonFn,
@@ -168,6 +171,7 @@ var (
 		supportsUIPasswordOnLndPort: false,
 		supportsUIPasswordOnLitPort: true,
 		grpcWebURI:                  "/looprpc.SwapClient/ListSwaps",
+		restWebURI:                  "/v1/loop/swaps",
 	}, {
 		name:                        "poolrpc",
 		macaroonFn:                  poolMacaroonFn,
@@ -178,6 +182,7 @@ var (
 		supportsUIPasswordOnLndPort: false,
 		supportsUIPasswordOnLitPort: true,
 		grpcWebURI:                  "/poolrpc.Trader/GetInfo",
+		restWebURI:                  "/v1/pool/info",
 	}, {
 		name:                        "litrpc",
 		macaroonFn:                  nil,
@@ -321,6 +326,27 @@ func testModeIntegrated(net *NetworkHarness, t *harnessTest) {
 					ttt, cfg.LitAddr(), cfg.TLSCertPath,
 					superMacFile,
 					endpoint.requestFn,
+					endpoint.successPattern,
+				)
+			})
+		}
+	})
+
+	t.t.Run("REST auth", func(tt *testing.T) {
+		cfg := net.Alice.Cfg
+
+		for _, endpoint := range endpoints {
+			endpoint := endpoint
+
+			if endpoint.restWebURI == "" {
+				continue
+			}
+
+			tt.Run(endpoint.name+" lit port", func(ttt *testing.T) {
+				runRESTAuthTest(
+					ttt, cfg.LitAddr(), cfg.UIPassword,
+					endpoint.macaroonFn(cfg),
+					endpoint.restWebURI,
 					endpoint.successPattern,
 				)
 			})
@@ -513,6 +539,58 @@ func runGRPCWebAuthTest(t *testing.T, hostPort, uiPassword, grpcWebURI string) {
 	require.Contains(t, body, "grpc-status: 0")
 }
 
+// runRESTAuthTest tests authentication of the given REST interface.
+func runRESTAuthTest(t *testing.T, hostPort, uiPassword, macaroonPath, restURI,
+	successPattern string) {
+
+	basicAuth := base64.StdEncoding.EncodeToString(
+		[]byte(fmt.Sprintf("%s:%s", uiPassword, uiPassword)),
+	)
+	basicAuthHeader := http.Header{
+		"authorization": []string{fmt.Sprintf("Basic %s", basicAuth)},
+	}
+	url := fmt.Sprintf("https://%s%s", hostPort, restURI)
+
+	// First test a REST call without authorization, which should fail.
+	body, responseHeader, err := callURL(url, "GET", nil, nil, false)
+	require.NoError(t, err)
+
+	require.Equal(
+		t, "application/grpc",
+		responseHeader.Get("grpc-metadata-content-type"),
+	)
+	require.Equal(
+		t, "application/json",
+		responseHeader.Get("content-type"),
+	)
+	require.Contains(
+		t, body,
+		"expected 1 macaroon, got 0",
+	)
+
+	// Now add the UI password which should make the request succeed.
+	body, responseHeader, err = callURL(
+		url, "GET", nil, basicAuthHeader, false,
+	)
+	require.NoError(t, err)
+	require.Contains(t, body, successPattern)
+
+	// And finally, try with the given macaroon.
+	macBytes, err := ioutil.ReadFile(macaroonPath)
+	require.NoError(t, err)
+
+	macaroonHeader := http.Header{
+		"grpc-metadata-macaroon": []string{
+			hex.EncodeToString(macBytes),
+		},
+	}
+	body, responseHeader, err = callURL(
+		url, "GET", nil, macaroonHeader, false,
+	)
+	require.NoError(t, err)
+	require.Contains(t, body, successPattern)
+}
+
 // getURL retrieves the body of a given URL, ignoring any TLS certificate the
 // server might present.
 func getURL(url string) (string, error) {
@@ -538,7 +616,15 @@ func getURL(url string) (string, error) {
 func postURL(url string, postBody []byte, header http.Header) (string,
 	http.Header, error) {
 
-	req, err := http.NewRequest("POST", url, bytes.NewReader(postBody))
+	return callURL(url, "POST", postBody, header, true)
+}
+
+// callURL does a HTTP call to the given URL, ignoring any TLS certificate the
+// server might present.
+func callURL(url, method string, postBody []byte, header http.Header,
+	expectOk bool) (string, http.Header, error) {
+
+	req, err := http.NewRequest(method, url, bytes.NewReader(postBody))
 	if err != nil {
 		return "", nil, err
 	}
@@ -552,7 +638,7 @@ func postURL(url string, postBody []byte, header http.Header) (string,
 		return "", nil, err
 	}
 
-	if resp.StatusCode != 200 {
+	if expectOk && resp.StatusCode != 200 {
 		return "", nil, fmt.Errorf("request failed, got status code "+
 			"%d (%s)", resp.StatusCode, resp.Status)
 	}

--- a/itest/litd_mode_remote_test.go
+++ b/itest/litd_mode_remote_test.go
@@ -118,4 +118,25 @@ func testModeRemote(net *NetworkHarness, t *harnessTest) {
 			})
 		}
 	})
+
+	t.t.Run("REST auth", func(tt *testing.T) {
+		cfg := net.Bob.Cfg
+
+		for _, endpoint := range endpoints {
+			endpoint := endpoint
+
+			if endpoint.restWebURI == "" {
+				continue
+			}
+
+			tt.Run(endpoint.name+" lit port", func(ttt *testing.T) {
+				runRESTAuthTest(
+					ttt, cfg.LitAddr(), cfg.UIPassword,
+					endpoint.macaroonFn(cfg),
+					endpoint.restWebURI,
+					endpoint.successPattern,
+				)
+			})
+		}
+	})
 }

--- a/itest/litd_mode_remote_test.go
+++ b/itest/litd_mode_remote_test.go
@@ -2,6 +2,7 @@ package itest
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/btcsuite/btcutil"
@@ -86,6 +87,33 @@ func testModeRemote(net *NetworkHarness, t *harnessTest) {
 				runGRPCWebAuthTest(
 					ttt, cfg.LitAddr(), cfg.UIPassword,
 					endpoint.grpcWebURI,
+				)
+			})
+		}
+	})
+
+	t.t.Run("gRPC super macaroon auth check", func(tt *testing.T) {
+		cfg := net.Bob.Cfg
+
+		superMacFile, err := bakeSuperMacaroon(cfg, true)
+		require.NoError(tt, err)
+
+		defer func() {
+			_ = os.Remove(superMacFile)
+		}()
+
+		for _, endpoint := range endpoints {
+			endpoint := endpoint
+			tt.Run(endpoint.name+" lit port", func(ttt *testing.T) {
+				if !endpoint.supportsMacAuthOnLitPort {
+					return
+				}
+
+				runGRPCAuthTest(
+					ttt, cfg.LitAddr(), cfg.LitTLSCertPath,
+					superMacFile,
+					endpoint.requestFn,
+					endpoint.successPattern,
 				)
 			})
 		}

--- a/itest/litd_node.go
+++ b/itest/litd_node.go
@@ -109,6 +109,7 @@ func (cfg *LitNodeConfig) GenArgs() []string {
 			fmt.Sprintf("--loop.loopdir=%s", cfg.LoopDir),
 			fmt.Sprintf("--pool.basedir=%s", cfg.PoolDir),
 			fmt.Sprintf("--uipassword=%s", cfg.UIPassword),
+			"--enablerest",
 			"--restcors=*",
 		}
 	)
@@ -139,7 +140,7 @@ func (cfg *LitNodeConfig) GenArgs() []string {
 
 		return litArgs
 	}
-	
+
 	// All arguments so far were for lnd. Let's namespace them now so we can
 	// add args for the other daemons and LiT itself afterwards.
 	litArgs = append(litArgs, cfg.LitArgs...)

--- a/rpc_proxy.go
+++ b/rpc_proxy.go
@@ -33,6 +33,15 @@ const (
 	HeaderMacaroon = "Macaroon"
 )
 
+var (
+	// EmptyMacaroonBytes is the byte representation of an empty but
+	// formally valid macaroon.
+	EmptyMacaroonBytes, _ = hex.DecodeString(
+		"020205656d7074790000062062083e2ea599285ac29350abb4ea21fd7c5a" +
+			"15aca8b4c0d38e6c058829369e50",
+	)
+)
+
 // proxyErr is an error type that adds more context to an error occurring in the
 // proxy.
 type proxyErr struct {
@@ -499,7 +508,7 @@ func (p *rpcProxy) basicAuthToMacaroon(basicAuth, requestURI string,
 		}
 
 	case isLitURI(requestURI):
-		return []byte("no-macaroons-for-litcli"), nil
+		return EmptyMacaroonBytes, nil
 
 	default:
 		return nil, fmt.Errorf("unknown gRPC web request: %v",

--- a/rpc_proxy.go
+++ b/rpc_proxy.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
+	"github.com/lightninglabs/lightning-terminal/session"
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/macaroons"
 	grpcProxy "github.com/mwitkow/grpc-proxy/proxy"
@@ -64,6 +65,7 @@ func (e *proxyErr) Unwrap() error {
 // or REST request and delegate (and convert if necessary) it to the correct
 // component.
 func newRpcProxy(cfg *Config, validator macaroons.MacaroonValidator,
+	superMacValidator session.SuperMacaroonValidator,
 	permissionMap map[string][]bakery.Op,
 	bufListener *bufconn.Listener) *rpcProxy {
 
@@ -80,10 +82,11 @@ func newRpcProxy(cfg *Config, validator macaroons.MacaroonValidator,
 	// need to be addressed with a custom director that just takes care of a
 	// few HTTP header fields.
 	p := &rpcProxy{
-		cfg:          cfg,
-		basicAuth:    basicAuth,
-		macValidator: validator,
-		bufListener:  bufListener,
+		cfg:               cfg,
+		basicAuth:         basicAuth,
+		macValidator:      validator,
+		superMacValidator: superMacValidator,
+		bufListener:       bufListener,
 	}
 	p.grpcServer = grpc.NewServer(
 		// From the grpxProxy doc: This codec is *crucial* to the
@@ -156,8 +159,9 @@ type rpcProxy struct {
 	cfg       *Config
 	basicAuth string
 
-	macValidator macaroons.MacaroonValidator
-	bufListener  *bufconn.Listener
+	macValidator      macaroons.MacaroonValidator
+	superMacValidator session.SuperMacaroonValidator
+	bufListener       *bufconn.Listener
 
 	superMacaroon string
 

--- a/session/macaroon.go
+++ b/session/macaroon.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"strconv"
@@ -17,6 +18,11 @@ var (
 	// root key to clearly mark it as such.
 	SuperMacaroonRootKeyPrefix = [4]byte{0xFF, 0xEE, 0xDD, 0xCC}
 )
+
+// SuperMacaroonValidator is a function type for validating a super macaroon.
+type SuperMacaroonValidator func(ctx context.Context,
+	superMacaroon []byte, requiredPermissions []bakery.Op,
+	fullMethod string) error
 
 // NewSuperMacaroonRootKeyID returns a new macaroon root key ID that has the
 // prefix to mark it as a super macaroon root key.

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -124,7 +124,7 @@ func (s *sessionRpcServer) resumeSession(sess *session.Session) error {
 		readOnly := sess.Type == session.TypeMacaroonReadonly
 		mac, err := s.superMacBaker(
 			ctx, sess.MacaroonRootKey, &session.MacaroonRecipe{
-				Permissions: getAllPermissions(readOnly),
+				Permissions: GetAllPermissions(readOnly),
 			},
 		)
 		if err != nil {

--- a/subserver_permissions.go
+++ b/subserver_permissions.go
@@ -73,9 +73,9 @@ func getAllMethodPermissions() map[string][]bakery.Op {
 	return result
 }
 
-// getAllPermissions retrieves all the permissions needed to bake a super
+// GetAllPermissions retrieves all the permissions needed to bake a super
 // macaroon.
-func getAllPermissions(readOnly bool) []bakery.Op {
+func GetAllPermissions(readOnly bool) []bakery.Op {
 	dedupMap := make(map[string]map[string]bool)
 
 	for _, methodPerms := range getAllMethodPermissions() {

--- a/terminal.go
+++ b/terminal.go
@@ -229,7 +229,7 @@ func (g *LightningTerminal) Run() error {
 		superMacBaker: func(ctx context.Context, rootKeyID uint64,
 			recipe *session.MacaroonRecipe) (string, error) {
 
-			return bakeSuperMacaroon(
+			return BakeSuperMacaroon(
 				ctx, g.basicClient, rootKeyID,
 				recipe.Permissions, recipe.Caveats,
 			)
@@ -504,11 +504,11 @@ func (g *LightningTerminal) startSubservers() error {
 		// Create a super macaroon that can be used to control lnd,
 		// faraday, loop, and pool, all at the same time.
 		ctx := context.Background()
-		superMacaroon, err := bakeSuperMacaroon(
+		superMacaroon, err := BakeSuperMacaroon(
 			ctx, g.basicClient, session.NewSuperMacaroonRootKeyID(
 				[4]byte{},
 			),
-			getAllPermissions(false), nil,
+			GetAllPermissions(false), nil,
 		)
 		if err != nil {
 			return err
@@ -1129,9 +1129,9 @@ func (g *LightningTerminal) createRESTProxy() error {
 	return nil
 }
 
-// bakeSuperMacaroon uses the lnd client to bake a macaroon that can include
+// BakeSuperMacaroon uses the lnd client to bake a macaroon that can include
 // permissions for multiple daemons.
-func bakeSuperMacaroon(ctx context.Context, lnd lnrpc.LightningClient,
+func BakeSuperMacaroon(ctx context.Context, lnd lnrpc.LightningClient,
 	rootKeyID uint64, perms []bakery.Op, caveats []macaroon.Caveat) (string,
 	error) {
 

--- a/terminal.go
+++ b/terminal.go
@@ -194,7 +194,8 @@ func (g *LightningTerminal) Run() error {
 	g.loopServer = loopd.New(g.cfg.Loop, nil)
 	g.poolServer = pool.NewServer(g.cfg.Pool)
 	g.rpcProxy = newRpcProxy(
-		g.cfg, g, getAllMethodPermissions(), bufRpcListener,
+		g.cfg, g, g.validateSuperMacaroon, getAllMethodPermissions(),
+		bufRpcListener,
 	)
 
 	// Create an instance of the local Terminal Connect session store DB.


### PR DESCRIPTION
Part of https://github.com/lightninglabs/lightning-node-connect/issues/17.

Depends on https://github.com/lightninglabs/lightning-terminal/pull/294 and https://github.com/lightninglabs/lightning-terminal/pull/292, only the last 9 commits are new.

Can be tested locally by baking a super macaroon with:

```
lncli bakemacaroon --save_to /tmp/readonly.supermacaroon --root_key_id 18441921392371826688 --allow_external_permissions offchain:read swap:read insights:read suggestions:read auth:read rates:read order:read peers:read message:read recommendation:read info:read report:read auction:read onchain:read account:read invoices:read terms:read macaroon:read audit:read
```

And then interact with one of the daemons:

```
pool --rpcserver localhost:8443 --tlscertpath ~/.lit/tls.cert --macaroonpath /tmp/readonly.supermacaroon getinfo
```
