### PR TITLE
mod: bump lnc to version with fixed int overflow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.12.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/lightninglabs/faraday v0.2.7-alpha
-	github.com/lightninglabs/lightning-node-connect v0.1.7-alpha
+	github.com/lightninglabs/lightning-node-connect v0.1.7-alpha.0.20220215190639-abe533aa98b8
 	github.com/lightninglabs/lndclient v0.14.0-7
 	github.com/lightninglabs/loop v0.15.1-beta
 	github.com/lightninglabs/pool v0.5.4-alpha.0.20220114202858-525fe156d240

--- a/go.sum
+++ b/go.sum
@@ -610,8 +610,8 @@ github.com/lightninglabs/faraday v0.2.7-alpha h1:lpSUk3RFfgr4/OCx1OdJ2AMHCAiTObK
 github.com/lightninglabs/faraday v0.2.7-alpha/go.mod h1:77P9EctYhneIXLvm9a6ylV9LCht/rj7j8mLwXpBgxB8=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf h1:HZKvJUHlcXI/f/O0Avg7t8sqkPo78HFzjmeYFl6DPnc=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQPeIQxPf6Jf9rM8R+B4rKBqLA2AjttNxkFBL2Plk=
-github.com/lightninglabs/lightning-node-connect v0.1.7-alpha h1:M2g8Il/DWhRvwZIEBER1QVDeIj9OTM0+DE7fXrLqc10=
-github.com/lightninglabs/lightning-node-connect v0.1.7-alpha/go.mod h1:jxSnezQYIvhNXqjyyiMEmdpOURrdVaujPZV6zGCVi8o=
+github.com/lightninglabs/lightning-node-connect v0.1.7-alpha.0.20220215190639-abe533aa98b8 h1:jjfS+6eQkqxO4gdxp33/ccO1ImhX3dt8AqRnQ58HkiQ=
+github.com/lightninglabs/lightning-node-connect v0.1.7-alpha.0.20220215190639-abe533aa98b8/go.mod h1:jxSnezQYIvhNXqjyyiMEmdpOURrdVaujPZV6zGCVi8o=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2 h1:Er1miPZD2XZwcfE4xoS5AILqP1mj7kqnhbBSxW9BDxY=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2/go.mod h1:antQGRDRJiuyQF6l+k6NECCSImgCpwaZapATth2Chv4=
 github.com/lightninglabs/lndclient v0.11.0-4/go.mod h1:8/cTKNwgL87NX123gmlv3Xh6p1a7pvzu+40Un3PhHiI=


### PR DESCRIPTION
lnc refused to compile for 32 bit systems because we used the `math.MaxUInt32` value (which is bigger than `int` on 32bit systems).
