### PR TITLE
cmd/litcli: change default session expiry to 3 months

### DIFF
--- a/cmd/litcli/sessions.go
+++ b/cmd/litcli/sessions.go
@@ -9,6 +9,12 @@ import (
 	"github.com/urfave/cli"
 )
 
+var (
+	// defaultSessionExpiry is the default time a session can be used for.
+	// The current value evaluates to 90 days.
+	defaultSessionExpiry = time.Hour * 24 * 90
+)
+
 var sessionCommands = []cli.Command{
 	{
 		Name:      "sessions",
@@ -38,7 +44,7 @@ var addSessionCommand = cli.Command{
 			Name: "expiry",
 			Usage: "number of seconds that the session should " +
 				"remain active",
-			Value: uint64(time.Hour.Seconds()),
+			Value: uint64(defaultSessionExpiry.Seconds()),
 		},
 		cli.StringFlag{
 			Name:  "mailboxserveraddr",


### PR DESCRIPTION
The default expiry of one hour was way too short for anything practical
and we increase it to 90 days which is almost three months.
The user can still override this value manually by specifying the flag.