### PR TITLE
multi: persist remote static key for handshakev2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,4 +34,6 @@ require (
 	gopkg.in/macaroon.v2 v2.1.0
 )
 
+replace github.com/lightninglabs/lightning-node-connect => github.com/ellemouton/lightning-node-connect v0.1.5-alpha.0.20220321121554-214be2e1be66
+
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/dvyukov/go-fuzz v0.0.0-20210602112143-b1f3d6f4ef4e h1:qTP1telKJHlToHl
 github.com/dvyukov/go-fuzz v0.0.0-20210602112143-b1f3d6f4ef4e/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 github.com/elazarl/go-bindata-assetfs v1.0.1 h1:m0kkaHRKEu7tUIUFVwhGGGYClXvyl4RE03qmvRTNfbw=
 github.com/elazarl/go-bindata-assetfs v1.0.1/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
+github.com/ellemouton/lightning-node-connect v0.1.5-alpha.0.20220321121554-214be2e1be66 h1:ufoiX9ZbA90H7lotSuekcEAI004BIthQFX0JRdvocKM=
+github.com/ellemouton/lightning-node-connect v0.1.5-alpha.0.20220321121554-214be2e1be66/go.mod h1:jxSnezQYIvhNXqjyyiMEmdpOURrdVaujPZV6zGCVi8o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -610,8 +612,6 @@ github.com/lightninglabs/faraday v0.2.7-alpha h1:lpSUk3RFfgr4/OCx1OdJ2AMHCAiTObK
 github.com/lightninglabs/faraday v0.2.7-alpha/go.mod h1:77P9EctYhneIXLvm9a6ylV9LCht/rj7j8mLwXpBgxB8=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf h1:HZKvJUHlcXI/f/O0Avg7t8sqkPo78HFzjmeYFl6DPnc=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQPeIQxPf6Jf9rM8R+B4rKBqLA2AjttNxkFBL2Plk=
-github.com/lightninglabs/lightning-node-connect v0.1.7-alpha.0.20220215190639-abe533aa98b8 h1:jjfS+6eQkqxO4gdxp33/ccO1ImhX3dt8AqRnQ58HkiQ=
-github.com/lightninglabs/lightning-node-connect v0.1.7-alpha.0.20220215190639-abe533aa98b8/go.mod h1:jxSnezQYIvhNXqjyyiMEmdpOURrdVaujPZV6zGCVi8o=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2 h1:Er1miPZD2XZwcfE4xoS5AILqP1mj7kqnhbBSxW9BDxY=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2/go.mod h1:antQGRDRJiuyQF6l+k6NECCSImgCpwaZapATth2Chv4=
 github.com/lightninglabs/lndclient v0.11.0-4/go.mod h1:8/cTKNwgL87NX123gmlv3Xh6p1a7pvzu+40Un3PhHiI=

--- a/itest/litd_mode_integrated_test.go
+++ b/itest/litd_mode_integrated_test.go
@@ -3,7 +3,6 @@ package itest
 import (
 	"bytes"
 	"context"
-	"crypto/sha512"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -769,20 +768,18 @@ func connectMailbox(ctx context.Context,
 	copy(mnemonicWords[:], connectPhrase)
 	password := mailbox.PasswordMnemonicToEntropy(mnemonicWords)
 
-	sid := sha512.Sum512(password[:])
-
 	privKey, err := btcec.NewPrivateKey(btcec.S256())
 	if err != nil {
 		return nil, err
 	}
 	ecdh := &keychain.PrivKeyECDH{PrivKey: privKey}
 
-	transportConn, err := mailbox.NewClient(ctx, sid)
+	transportConn, err := mailbox.NewClient(ctx, ecdh, nil, password[:])
 	if err != nil {
 		return nil, err
 	}
 
-	noiseConn := mailbox.NewNoiseGrpcConn(ecdh, nil, password[:])
+	noiseConn := mailbox.NewNoiseGrpcConn(ecdh, nil, nil, password[:], nil)
 
 	dialOpts := []grpc.DialOption{
 		grpc.WithContextDialer(transportConn.Dial),

--- a/log.go
+++ b/log.go
@@ -3,6 +3,7 @@ package terminal
 import (
 	"github.com/btcsuite/btclog"
 	"github.com/lightninglabs/faraday"
+	"github.com/lightninglabs/lightning-node-connect/mailbox"
 	"github.com/lightninglabs/lightning-terminal/session"
 	"github.com/lightninglabs/loop/loopd"
 	"github.com/lightninglabs/pool"
@@ -57,6 +58,7 @@ func SetupLoggers(root *build.RotatingLogWriter, intercept signal.Interceptor) {
 	// Add the lightning-terminal root logger.
 	lnd.AddSubLogger(root, Subsystem, intercept, UseLogger)
 	lnd.AddSubLogger(root, session.Subsystem, intercept, session.UseLogger)
+	lnd.AddSubLogger(root, mailbox.Subsystem, intercept, mailbox.UseLogger)
 
 	// Add daemon loggers to lnd's root logger.
 	faraday.SetupLoggers(root, intercept)

--- a/session/store.go
+++ b/session/store.go
@@ -3,7 +3,6 @@ package session
 import (
 	"bytes"
 	"errors"
-
 	"github.com/btcsuite/btcd/btcec"
 	"go.etcd.io/bbolt"
 )

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -141,7 +141,9 @@ func (s *sessionRpcServer) resumeSession(sess *session.Session) error {
 		return nil
 	}
 
-	sessionClosedSub, err := s.sessionServer.StartSession(sess, authData)
+	sessionClosedSub, err := s.sessionServer.StartSession(
+		sess, authData, s.db.StoreSession,
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In this commit, we update the go mod to point to the version of LNC that
contains the logic for handshake version 2. This requires that we pass
in a call back that LNC can call to persist the remote static key once
it is received. This then needs to be provided each time we start up the
session again.

depends on https://github.com/lightninglabs/lightning-node-connect/pull/35