### PR TITLE
multi: persist remote static key for handshakev2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.12.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/lightninglabs/faraday v0.2.7-alpha
-	github.com/lightninglabs/lightning-node-connect v0.1.7-alpha.0.20220215190639-abe533aa98b8
+	github.com/lightninglabs/lightning-node-connect v0.1.9-alpha
 	github.com/lightninglabs/lndclient v0.14.0-8
 	github.com/lightninglabs/loop v0.15.1-beta
 	github.com/lightninglabs/pool v0.5.5-alpha

--- a/go.sum
+++ b/go.sum
@@ -610,8 +610,8 @@ github.com/lightninglabs/faraday v0.2.7-alpha h1:lpSUk3RFfgr4/OCx1OdJ2AMHCAiTObK
 github.com/lightninglabs/faraday v0.2.7-alpha/go.mod h1:77P9EctYhneIXLvm9a6ylV9LCht/rj7j8mLwXpBgxB8=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf h1:HZKvJUHlcXI/f/O0Avg7t8sqkPo78HFzjmeYFl6DPnc=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQPeIQxPf6Jf9rM8R+B4rKBqLA2AjttNxkFBL2Plk=
-github.com/lightninglabs/lightning-node-connect v0.1.7-alpha.0.20220215190639-abe533aa98b8 h1:jjfS+6eQkqxO4gdxp33/ccO1ImhX3dt8AqRnQ58HkiQ=
-github.com/lightninglabs/lightning-node-connect v0.1.7-alpha.0.20220215190639-abe533aa98b8/go.mod h1:jxSnezQYIvhNXqjyyiMEmdpOURrdVaujPZV6zGCVi8o=
+github.com/lightninglabs/lightning-node-connect v0.1.9-alpha h1:ri3tgMegrxffg7w+hrC2vzdler5xJp/G74gI/7uCVgU=
+github.com/lightninglabs/lightning-node-connect v0.1.9-alpha/go.mod h1:jxSnezQYIvhNXqjyyiMEmdpOURrdVaujPZV6zGCVi8o=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2 h1:Er1miPZD2XZwcfE4xoS5AILqP1mj7kqnhbBSxW9BDxY=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2/go.mod h1:antQGRDRJiuyQF6l+k6NECCSImgCpwaZapATth2Chv4=
 github.com/lightninglabs/lndclient v0.11.0-4/go.mod h1:8/cTKNwgL87NX123gmlv3Xh6p1a7pvzu+40Un3PhHiI=

--- a/itest/litd_mode_integrated_test.go
+++ b/itest/litd_mode_integrated_test.go
@@ -3,7 +3,6 @@ package itest
 import (
 	"bytes"
 	"context"
-	"crypto/sha512"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -764,11 +763,9 @@ func getServerCertificates(hostPort string) ([]*x509.Certificate, error) {
 func connectMailbox(ctx context.Context,
 	connectPhrase []string) (grpc.ClientConnInterface, error) {
 
-	var mnemonicWords [mailbox.NumPasswordWords]string
+	var mnemonicWords [mailbox.NumPassphraseWords]string
 	copy(mnemonicWords[:], connectPhrase)
-	password := mailbox.PasswordMnemonicToEntropy(mnemonicWords)
-
-	sid := sha512.Sum512(password[:])
+	passphrase := mailbox.PassphraseMnemonicToEntropy(mnemonicWords)
 
 	privKey, err := btcec.NewPrivateKey(btcec.S256())
 	if err != nil {
@@ -776,12 +773,14 @@ func connectMailbox(ctx context.Context,
 	}
 	ecdh := &keychain.PrivKeyECDH{PrivKey: privKey}
 
-	transportConn, err := mailbox.NewClient(ctx, sid)
+	connData := mailbox.NewConnData(ecdh, nil, passphrase[:], nil, nil, nil)
+
+	transportConn, err := mailbox.NewClient(ctx, connData)
 	if err != nil {
 		return nil, err
 	}
 
-	noiseConn := mailbox.NewNoiseGrpcConn(ecdh, nil, password[:])
+	noiseConn := mailbox.NewNoiseGrpcConn(connData)
 
 	dialOpts := []grpc.DialOption{
 		grpc.WithContextDialer(transportConn.Dial),

--- a/session/interface.go
+++ b/session/interface.go
@@ -47,7 +47,7 @@ type Session struct {
 	DevServer       bool
 	MacaroonRootKey uint64
 	MacaroonRecipe  *MacaroonRecipe
-	PairingSecret   [mailbox.NumPasswordBytes]byte
+	PairingSecret   [mailbox.NumPassphraseEntropyBytes]byte
 	LocalPrivateKey *btcec.PrivateKey
 	LocalPublicKey  *btcec.PublicKey
 	RemotePublicKey *btcec.PublicKey
@@ -58,7 +58,7 @@ func NewSession(label string, typ Type, expiry time.Time, serverAddr string,
 	devServer bool, perms []bakery.Op, caveats []macaroon.Caveat) (*Session,
 	error) {
 
-	_, pairingSecret, err := mailbox.NewPassword()
+	_, pairingSecret, err := mailbox.NewPassphraseEntropy()
 	if err != nil {
 		return nil, fmt.Errorf("error deriving pairing secret: %v", err)
 	}

--- a/session/server.go
+++ b/session/server.go
@@ -32,16 +32,27 @@ func newMailboxSession() *mailboxSession {
 }
 
 func (m *mailboxSession) start(session *Session,
-	serverCreator GRPCServerCreator, authData []byte) error {
+	serverCreator GRPCServerCreator, authData []byte,
+	onUpdate func(sess *Session) error) error {
 
 	tlsConfig := &tls.Config{}
 	if session.DevServer {
 		tlsConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
+	ecdh := &keychain.PrivKeyECDH{PrivKey: session.LocalPrivateKey}
+
+	keys := mailbox.NewConnData(
+		ecdh, session.RemotePublicKey, session.PairingSecret[:],
+		authData, func(key *btcec.PublicKey) error {
+			session.RemotePublicKey = key
+			return onUpdate(session)
+		}, nil,
+	)
+
 	// Start the mailbox gRPC server.
 	mailboxServer, err := mailbox.NewServer(
-		session.ServerAddr, session.PairingSecret[:],
+		session.ServerAddr, keys,
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time: 2 * time.Minute,
@@ -51,10 +62,7 @@ func (m *mailboxSession) start(session *Session,
 		return err
 	}
 
-	ecdh := &keychain.PrivKeyECDH{PrivKey: session.LocalPrivateKey}
-	noiseConn := mailbox.NewNoiseGrpcConn(
-		ecdh, authData, session.PairingSecret[:],
-	)
+	noiseConn := mailbox.NewNoiseGrpcConn(keys)
 	m.server = serverCreator(grpc.Creds(noiseConn))
 
 	m.wg.Add(1)
@@ -95,8 +103,8 @@ func NewServer(serverCreator GRPCServerCreator) *Server {
 	}
 }
 
-func (s *Server) StartSession(session *Session, authData []byte) (chan struct{},
-	error) {
+func (s *Server) StartSession(session *Session, authData []byte,
+	onUpdate func(sess *Session) error) (chan struct{}, error) {
 
 	s.activeSessionsMtx.Lock()
 	defer s.activeSessionsMtx.Unlock()
@@ -112,7 +120,9 @@ func (s *Server) StartSession(session *Session, authData []byte) (chan struct{},
 	sess := newMailboxSession()
 	s.activeSessions[id] = sess
 
-	return sess.quit, sess.start(session, s.serverCreator, authData)
+	return sess.quit, sess.start(
+		session, s.serverCreator, authData, onUpdate,
+	)
 }
 
 func (s *Server) StopSession(localPublicKey *btcec.PublicKey) error {

--- a/session/store.go
+++ b/session/store.go
@@ -3,7 +3,6 @@ package session
 import (
 	"bytes"
 	"errors"
-
 	"github.com/btcsuite/btcd/btcec"
 	"go.etcd.io/bbolt"
 )

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -141,7 +141,9 @@ func (s *sessionRpcServer) resumeSession(sess *session.Session) error {
 		return nil
 	}
 
-	sessionClosedSub, err := s.sessionServer.StartSession(sess, authData)
+	sessionClosedSub, err := s.sessionServer.StartSession(
+		sess, authData, s.db.StoreSession,
+	)
 	if err != nil {
 		return err
 	}
@@ -240,7 +242,7 @@ func marshalRPCSession(sess *session.Session) (*litrpc.Session, error) {
 		remotePubKey = sess.RemotePublicKey.SerializeCompressed()
 	}
 
-	mnemonic, err := mailbox.PasswordEntropyToMnemonic(sess.PairingSecret)
+	mnemonic, err := mailbox.PassphraseEntropyToMnemonic(sess.PairingSecret)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In this commit, we update the go mod to point to the version of LNC that
contains the logic for handshake version 2. This requires that we pass
in a call back that LNC can call to persist the remote static key once
it is received. This then needs to be provided each time we start up the
session again.

depends on https://github.com/lightninglabs/lightning-node-connect/pull/35