### PR TITLE
docker: fix build by removing unused python install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ ARG public_url=""
 #      be mitigated by switching to HTTP and increasing the network timeout.
 #      See https://github.com/yarnpkg/yarn/issues/5259 for more info.
 RUN apk add --no-cache --update alpine-sdk \
-  python \
   git \
   && git clone https://github.com/lightninglabs/lightning-terminal /go/src/github.com/lightninglabs/lightning-terminal \
   && cd /go/src/github.com/lightninglabs/lightning-terminal \


### PR DESCRIPTION
We bumped the NodeJS version which also pulled in a new version of Alpine that no longer knows the `python` package (it's now explicitly called `python3`).
But since we don't require the binary any longer anyway, we remove it.