### PR TITLE
README+version: bump version to v0.6.7-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Lightning Terminal is backwards compatible with `lnd` back to version v0.13.3-be
 
 | LiT              | LND          |
 |------------------| ------------ |
+| **v0.6.7-alpha** | v0.13.3-beta |
 | **v0.6.6-alpha** | v0.13.3-beta |
 | **v0.6.5-alpha** | v0.13.3-beta |
 | **v0.6.4-alpha** | v0.13.3-beta |
@@ -116,6 +117,7 @@ The following table shows the supported combinations:
 
 | LiT              | LND          | Loop         | Faraday      | Pool         |
 |------------------|--------------|--------------| ------------ |--------------|
+| **v0.6.7-alpha** | v0.14.3-beta | v0.18.0-beta | v0.2.7-alpha | v0.5.6-alpha |
 | **v0.6.6-alpha** | v0.14.3-beta | v0.18.0-beta | v0.2.7-alpha | v0.5.6-alpha |
 | **v0.6.5-alpha** | v0.14.2-beta | v0.15.1-beta | v0.2.7-alpha | v0.5.5-alpha |
 | **v0.6.4-alpha** | v0.14.2-beta | v0.15.1-beta | v0.2.7-alpha | v0.5.4-alpha |

--- a/version.go
+++ b/version.go
@@ -23,7 +23,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	appMajor uint = 0
 	appMinor uint = 6
-	appPatch uint = 5
+	appPatch uint = 7
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.


### PR DESCRIPTION
We forgot to bump the app version, so we bump everything to the next one to avoid confusion. Will create a new release and basically replace 0.6.6 with this one.