### PR TITLE
Standalone LiT client development

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "scripts": {
     "start": "BROWSER=none react-scripts start",
+    "develop": "REACT_APP_USE_SAMPLE_DATA=true yarn start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jest-environment-jsdom",
     "test:ci": "cross-env CI=true yarn test --coverage",

--- a/app/src/config.ts
+++ b/app/src/config.ts
@@ -14,3 +14,5 @@ const { protocol, hostname, port } = window.location;
 const host = `${protocol}//${hostname}:${port}`;
 // the GRPC server to make requests to
 export const DEV_HOST = process.env.REACT_APP_DEV_HOST || host;
+
+export const USE_SAMPLE_DATA = process.env.REACT_APP_USE_SAMPLE_DATA === 'true';

--- a/app/src/store/store.ts
+++ b/app/src/store/store.ts
@@ -1,5 +1,5 @@
 import { autorun, makeAutoObservable, runInAction } from 'mobx';
-import { IS_DEV, IS_TEST } from 'config';
+import { IS_DEV, IS_TEST, USE_SAMPLE_DATA } from 'config';
 import { createBrowserHistory, History } from 'history';
 import AppStorage from 'util/appStorage';
 import CsvExporter from 'util/csv';
@@ -200,6 +200,9 @@ export class Store {
  */
 export const createStore = (grpcClient?: GrpcClient, appStorage?: AppStorage) => {
   const grpc = grpcClient || new GrpcClient();
+  // Resolve api requests with sample data when running client in develop mode.
+  grpc.useSampleData = USE_SAMPLE_DATA;
+
   const storage = appStorage || new AppStorage();
   const lndApi = new LndApi(grpc);
   const loopApi = new LoopApi(grpc);


### PR DESCRIPTION
Implements a new script (`yarn develop`) that lets developers to do
LiT frontend client development without having to setup an `lnd` backend.
This script uses the mock responses configured in `sampleData` to resolve API
requests.

Limitations:
* The implementation depends on `sampleData` to be up-to-date as the APIs
  evolve.
* Currently it only supports `GET` requests.

Alternatives considered:
* Use `REACT_APP_DEV_HOST` to point to a `testnet` public server so as to avoid
  configuring and running `lnd`.
* Set up a webpack devserver to proxy responses to a node server running
  locally that in-turn reads mock responses configured as `<endpoint>.json`
  files, ex `GetInfo.json`, and sends it as response.