### PR TITLE
ui+sessions: improve when expiry label displays Never

### DIFF
--- a/app/src/store/models/session.ts
+++ b/app/src/store/models/session.ts
@@ -66,7 +66,10 @@ export default class Session {
 
   /** The date this session will expire as formatted string */
   get expiryLabel() {
-    return this.expiry.getTime() === MAX_DATE.getTime()
+    // consider any expiry past the year 9000 to be never. This
+    // factors in expiry values set in different time zones
+    const minDate = new Date(MAX_DATE.getFullYear() - 999, 0, 1);
+    return this.expiry.getTime() > minDate.getTime()
       ? 'Never'
       : formatDate(this.expiry, 'MMM d, yyyy h:mm a');
   }


### PR DESCRIPTION
Based on #358 

This PR fixes a minor UI issue where the Expiry label displays the far off date values instead of "Never. This occurs when the session was created by a user in a different time zone.

![image](https://user-images.githubusercontent.com/1356600/175644031-ce536814-5b96-4873-b5d3-faec2db7ef76.png)
