### PR TITLE
New release: v0.7.0-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ If you’d prefer to compile from source code please follow [these instructions]
 
 ## Compatibility
 
-Lightning Terminal is backwards compatible with `lnd` back to version v0.13.3-beta.
+Lightning Terminal is backwards compatible with `lnd` back to version v0.14.3-beta.
 
 | LiT              | LND          |
-|------------------| ------------ |
+|------------------|--------------|
+| **v0.7.0-alpha** | v0.14.3-beta |
 | **v0.6.7-alpha** | v0.13.3-beta |
 | **v0.6.6-alpha** | v0.13.3-beta |
 | **v0.6.5-alpha** | v0.13.3-beta |
@@ -116,7 +117,8 @@ The following table shows the supported combinations:
 ## Daemon Versions packaged with LiT
 
 | LiT              | LND          | Loop         | Faraday      | Pool         |
-|------------------|--------------|--------------| ------------ |--------------|
+|------------------|--------------|--------------|--------------|--------------|
+| **v0.7.0-alpha** | v0.15.0-beta | v0.19.1-beta | v0.2.8-alpha | v0.5.7-alpha |
 | **v0.6.7-alpha** | v0.14.3-beta | v0.18.0-beta | v0.2.7-alpha | v0.5.6-alpha |
 | **v0.6.6-alpha** | v0.14.3-beta | v0.18.0-beta | v0.2.7-alpha | v0.5.6-alpha |
 | **v0.6.5-alpha** | v0.14.2-beta | v0.15.1-beta | v0.2.7-alpha | v0.5.5-alpha |

--- a/terminal.go
+++ b/terminal.go
@@ -120,7 +120,7 @@ var (
 	// to run LiT in remote mode.
 	minimalCompatibleVersion = &verrpc.Version{
 		AppMajor: 0,
-		AppMinor: 13,
+		AppMinor: 14,
 		AppPatch: 3,
 		BuildTags: []string{
 			"signrpc", "walletrpc", "chainrpc", "invoicesrpc",

--- a/version.go
+++ b/version.go
@@ -22,8 +22,8 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	appMajor uint = 0
-	appMinor uint = 6
-	appPatch uint = 7
+	appMinor uint = 7
+	appPatch uint = 0
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.


### PR DESCRIPTION
Because Loop requires a new version, we also need to bump the overall
minimum required version of lnd in LiT to `v0.14.3-beta`.