### PR TITLE
tour: update documentation link in the welcome step

### DIFF
--- a/app/src/components/tour/WelcomeStep.tsx
+++ b/app/src/components/tour/WelcomeStep.tsx
@@ -51,7 +51,7 @@ const WelcomeStep: React.FC<ReactourStepContentArgs> = props => {
       <p>
         {l('walkthrough1')}{' '}
         <a
-          href="https://docs.lightning.engineering/lightning-network-tools/lightning-terminal/get-lit"
+          href="https://docs.lightning.engineering/lightning-network-tools/lightning-terminal"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
This is a small PR to update the link in the Welcome step of the tour on the Loop page.