### PR TITLE
chore: exclude dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
       # Allow both direct and indirect updates for production packages.
       # Ignores packages listed in devDependencies
       - dependency-type: 'production'
+    # exclude dependabot version updates
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Replaces #400 

This dependabot config option  instructs the bot to not open PR for *version* updates. As mentioned in the [docs](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file), it will only open PRs for *security* updates. They also should only be for production dependencies.