### PR TITLE
ui+connect: minor connect view styling updates

### DIFF
--- a/app/src/components/connect/SessionRow.tsx
+++ b/app/src/components/connect/SessionRow.tsx
@@ -16,7 +16,7 @@ export const ROW_HEIGHT = 60;
 
 const Styled = {
   Row: styled(Row)`
-    border-bottom: 0.5px solid ${props => props.theme.colors.darkGray};
+    border-bottom: 0.5px solid ${props => props.theme.colors.lightBlue};
 
     &:last-child {
       border-bottom-width: 0;
@@ -47,7 +47,7 @@ const Styled = {
     }
   `,
   CloseIcon: styled(Close)`
-    color: ${props => props.theme.colors.pink};
+    color: ${props => props.theme.colors.lightningRed};
   `,
 };
 

--- a/app/src/components/theme.tsx
+++ b/app/src/components/theme.tsx
@@ -44,6 +44,7 @@ const theme: Theme = {
     gradient: 'linear-gradient(325.53deg, #252F4A 0%, #46547B 100%);',
     lightBlue: '#384770',
     paleBlue: '#2E3A5C',
+    lightningRed: '#EF4444',
   },
 };
 

--- a/app/src/emotion-theme.d.ts
+++ b/app/src/emotion-theme.d.ts
@@ -40,6 +40,7 @@ declare module '@emotion/react' {
       gradient: string;
       lightBlue: string;
       paleBlue: string;
+      lightningRed: string;
     };
   }
 }


### PR DESCRIPTION
The day has arrived, PRs for litd! 

Starting small though.

ui+common: adds `lightningRed` theme color
ui+connect: switches pink for new red color + updates bottom border color

Before:
<img width="1143" alt="Screen Shot 2022-08-03 at 7 50 30 PM" src="https://user-images.githubusercontent.com/6250771/182752545-cef416a3-59a2-4996-be7a-2e7eb122a505.png">

After:
<img width="1140" alt="Screen Shot 2022-08-03 at 7 48 53 PM" src="https://user-images.githubusercontent.com/6250771/182752418-63c8e75d-a747-47c3-bda7-d8084badfb44.png">
