### PR TITLE
README: update version matrix for v0.8.1-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ versioning](#daemon-versions-packaged-with-lit).
 
 | LiT              | LND          |
 |------------------|--------------|
+| **v0.8.1-alpha** | v0.15.1-beta |
 | **v0.8.0-alpha** | v0.15.1-beta |
 | **v0.7.1-alpha** | v0.14.3-beta |
 | **v0.7.0-alpha** | v0.14.3-beta |
@@ -126,6 +127,7 @@ The following table shows the supported combinations:
 
 | LiT              | LND          | Loop         | Faraday      | Pool         |
 |------------------|--------------|--------------|--------------|--------------|
+| **v0.8.1-alpha** | v0.15.2-beta | v0.20.1-beta | v0.2.8-alpha | v0.5.8-alpha |
 | **v0.8.0-alpha** | v0.15.1-beta | v0.20.1-beta | v0.2.8-alpha | v0.5.8-alpha |
 | **v0.7.1-alpha** | v0.15.0-beta | v0.19.1-beta | v0.2.8-alpha | v0.5.7-alpha |
 | **v0.7.0-alpha** | v0.15.0-beta | v0.19.1-beta | v0.2.8-alpha | v0.5.7-alpha |


### PR DESCRIPTION
Updates the readme after the recent emergency update was pushed out.