### PR TITLE
multi: use filepath instead of path to work on Windows

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -620,7 +619,7 @@ func validateRemoteModeConfig(cfg *Config) error {
 		r.Lnd.MacaroonPath = filepath.Join(
 			defaultLndCfg.DataDir, defaultLndChainSubDir,
 			defaultLndChain, cfg.Network,
-			path.Base(defaultLndCfg.AdminMacPath),
+			filepath.Base(defaultLndCfg.AdminMacPath),
 		)
 	}
 

--- a/itest/server_harness.go
+++ b/itest/server_harness.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"path"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -57,8 +57,8 @@ func (s *serverHarness) start() error {
 		return err
 	}
 
-	s.certFile = path.Join(tempDirName, "proxy.cert")
-	keyFile := path.Join(tempDirName, "proxy.key")
+	s.certFile = filepath.Join(tempDirName, "proxy.cert")
+	keyFile := filepath.Join(tempDirName, "proxy.key")
 	creds, err := genCertPair(s.certFile, keyFile)
 	if err != nil {
 		return err

--- a/terminal.go
+++ b/terminal.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -216,7 +215,7 @@ func (g *LightningTerminal) Run() error {
 	)
 	g.sessionRpcServer, err = newSessionRPCServer(&sessionRpcServerConfig{
 		basicAuth: g.rpcProxy.basicAuth,
-		dbDir:     path.Join(g.cfg.LitDir, g.cfg.Network),
+		dbDir:     filepath.Join(g.cfg.LitDir, g.cfg.Network),
 		grpcOptions: []grpc.ServerOption{
 			grpc.CustomCodec(grpcProxy.Codec()), // nolint: staticcheck,
 			grpc.ChainStreamInterceptor(
@@ -424,7 +423,7 @@ func (g *LightningTerminal) startSubservers() error {
 		hex.EncodeToString(macData),
 	))
 	clientOptions = append(
-		clientOptions, lndclient.MacFilename(path.Base(macPath)),
+		clientOptions, lndclient.MacFilename(filepath.Base(macPath)),
 	)
 
 	// If we're in integrated mode, we can retrieve the macaroon string
@@ -447,7 +446,7 @@ func (g *LightningTerminal) startSubservers() error {
 		// subservers have the same requirements.
 		var err error
 		g.basicClient, err = lndclient.NewBasicClient(
-			host, tlsPath, path.Dir(macPath), string(network),
+			host, tlsPath, filepath.Dir(macPath), string(network),
 			clientOptions...,
 		)
 		return err
@@ -571,7 +570,7 @@ func (g *LightningTerminal) startSubservers() error {
 
 	g.macaroonService, err = lndclient.NewMacaroonService(
 		&lndclient.MacaroonServiceConfig{
-			DBPath:           path.Join(g.cfg.LitDir, g.cfg.Network),
+			DBPath:           filepath.Join(g.cfg.LitDir, g.cfg.Network),
 			MacaroonLocation: "litd",
 			StatelessInit:    !createDefaultMacaroons,
 			RequiredPerms:    litPermissions,
@@ -1352,8 +1351,8 @@ func (g *LightningTerminal) showStartupInfo() error {
 		// alias. But the wallet might be locked.
 		host, network, tlsPath, macPath, _ := g.cfg.lndConnectParams()
 		basicClient, err := lndclient.NewBasicClient(
-			host, tlsPath, path.Dir(macPath), string(network),
-			lndclient.MacFilename(path.Base(macPath)),
+			host, tlsPath, filepath.Dir(macPath), string(network),
+			lndclient.MacFilename(filepath.Base(macPath)),
 		)
 		if err != nil {
 			return fmt.Errorf("error querying remote node: %v", err)


### PR DESCRIPTION
This commit fixes an issue with file system paths on Windows. The path package is only intended to be used with URIs or non file system paths. For anything OS dependent, filepath should be used instead.