### PR TITLE
Add version labels to the UI

### DIFF
--- a/app/src/components/layout/Layout.tsx
+++ b/app/src/components/layout/Layout.tsx
@@ -106,6 +106,24 @@ const Styled = {
   Fluid: styled.div`
     height: 100%;
   `,
+  Versions: styled.div`
+    position: absolute;
+    font-size: ${props => props.theme.sizes.xs};
+    bottom: 0;
+    padding: 15px;
+  `,
+};
+
+const VersionInfo = () => {
+  const { nodeStore } = useStore();
+  const { Versions } = Styled;
+  const shortVersion = nodeStore.version.split(' commit=')[0];
+
+  return (
+    <Versions>
+      <div title={nodeStore.version}>{`LND: v${shortVersion}`}</div>
+    </Versions>
+  );
 };
 
 export const Layout: React.FC = ({ children }) => {
@@ -123,6 +141,7 @@ export const Layout: React.FC = ({ children }) => {
         </Hamburger>
         <Aside collapsed={!settingsStore.sidebarVisible}>
           <Sidebar />
+          <VersionInfo />
         </Aside>
         <Content collapsed={!settingsStore.sidebarVisible} fullWidth={appView.fullWidth}>
           <Fluid className="container-fluid">{children}</Fluid>

--- a/app/src/store/stores/nodeStore.ts
+++ b/app/src/store/stores/nodeStore.ts
@@ -18,6 +18,8 @@ export default class NodeStore {
    */
   private _knownTxns: string[] = [];
 
+  /** the version of the LND node */
+  version = '';
   /** the pubkey of the LND node */
   pubkey = '';
   /** the alias of the LND node */
@@ -71,6 +73,7 @@ export default class NodeStore {
     try {
       const info = await this._store.api.lnd.getInfo();
       runInAction(() => {
+        this.version = info.version;
         this.pubkey = info.identityPubkey;
         this.alias = info.alias;
         this.blockHeight = info.blockHeight;


### PR DESCRIPTION
I saw a few issues (#203, #421, #421) involving version numbers in the UI so I started to look into it to see what might be involved

I was able to get something basic rendered in the sidebar because `lnd.getInfo` just happened to return the version number already... 

![Screen Shot 2022-10-27 at 4 19 29 PM](https://user-images.githubusercontent.com/4914611/198389945-b379212a-dcbe-4fd6-982e-c5c13bd196ee.png)
![Screen Shot 2022-10-27 at 4 26 47 PM](https://user-images.githubusercontent.com/4914611/198391079-bfe48077-2510-4542-89e1-1220f043ecb5.png)



however it gets trickier from here

I don't think it's exactly as easy to do for the LiT version number since the `app/src/api/lit.ts` only has `litcli session` GRPC calls implemented so far. But obviously `litcli --v` returns the version so maybe that approach could work...

![Screen Shot 2022-10-27 at 4 22 16 PM](https://user-images.githubusercontent.com/4914611/198390318-1cb6e344-aadc-46c1-97d1-2ca8c9ecb139.png)

I stopped there since it started to get quite involved but will try to chip away at this and see if it can be done. 

Also wanted to see if there is a different approach anyone might recommend.. or if there is any design / code style feedback on the implemented LND version in 223ca0cb67cbbcb245109ecda5574fc00d16284e