### PR TITLE
multi: support using a regex when specifying custom perms

### DIFF
--- a/cmd/litcli/sessions.go
+++ b/cmd/litcli/sessions.go
@@ -73,7 +73,11 @@ var addSessionCommand = cli.Command{
 				"this flag will only be used if the 'type' " +
 				"flag is set to 'custom'. This flag can be " +
 				"specified multiple times if multiple URIs " +
-				"should be included",
+				"should be included. Note that a regex can " +
+				"also be specified which will then result in " +
+				"all URIs matching the regex to be included. " +
+				"For example, '/lnrpc\\..*' will result in " +
+				"all `lnrpc` permissions being included.",
 		},
 	},
 }

--- a/itest/litd_mode_integrated_test.go
+++ b/itest/litd_mode_integrated_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lightninglabs/lightning-node-connect/mailbox"
 	terminal "github.com/lightninglabs/lightning-terminal"
 	"github.com/lightninglabs/lightning-terminal/litrpc"
+	"github.com/lightninglabs/lightning-terminal/perms"
 	"github.com/lightninglabs/lightning-terminal/session"
 	"github.com/lightninglabs/loop/looprpc"
 	"github.com/lightninglabs/pool/poolrpc"
@@ -945,7 +946,7 @@ func bakeSuperMacaroon(cfg *LitNodeConfig, readOnly bool) (string, error) {
 	lndAdminCtx := macaroonContext(ctxt, lndAdminMacBytes)
 	lndConn := lnrpc.NewLightningClient(rawConn)
 
-	permsMgr, err := terminal.NewPermissionsManager()
+	permsMgr, err := perms.NewManager()
 	if err != nil {
 		return "", err
 	}

--- a/perms/permissions_test.go
+++ b/perms/permissions_test.go
@@ -1,0 +1,81 @@
+package perms
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+)
+
+// TestMatchRegexURI tests the behaviour of the MatchRegexURI method of the
+// Manager.
+func TestMatchRegexURI(t *testing.T) {
+	// Construct a new Manager with a predefined list of perms.
+	m := &Manager{
+		perms: map[string][]bakery.Op{
+			"/lnrpc.WalletUnlocker/GenSeed":    {},
+			"/lnrpc.WalletUnlocker/InitWallet": {},
+			"/lnrpc.Lightning/SendCoins": {{
+				Entity: "onchain",
+				Action: "write",
+			}},
+			"/litrpc.Sessions/AddSession": {{
+				Entity: "sessions",
+				Action: "write",
+			}},
+			"/litrpc.Sessions/ListSessions": {{
+				Entity: "sessions",
+				Action: "read",
+			}},
+			"/litrpc.Sessions/RevokeSession": {{
+				Entity: "sessions",
+				Action: "write",
+			}},
+		},
+	}
+
+	// Assert that a full URI is not considered a wild card.
+	uris, isRegex := m.MatchRegexURI("/litrpc.Sessions/RevokeSession")
+	require.False(t, isRegex)
+	require.Empty(t, uris)
+
+	// Assert that an invalid URI is also caught as such.
+	uris, isRegex = m.MatchRegexURI("***")
+	require.False(t, isRegex)
+	require.Nil(t, uris)
+
+	// Assert that the function correctly matches on a valid wild card for
+	// litrpc URIs.
+	uris, isRegex = m.MatchRegexURI("/litrpc.Sessions/.*")
+	require.True(t, isRegex)
+	require.ElementsMatch(t, uris, []string{
+		"/litrpc.Sessions/AddSession",
+		"/litrpc.Sessions/ListSessions",
+		"/litrpc.Sessions/RevokeSession",
+	})
+
+	// Assert that the function correctly matches on a valid wild card for
+	// lnd URIs. First we check that we can specify that only the
+	// "WalletUnlocker" methods should be included.
+	uris, isRegex = m.MatchRegexURI("/lnrpc.WalletUnlocker/.*")
+	require.True(t, isRegex)
+	require.ElementsMatch(t, uris, []string{
+		"/lnrpc.WalletUnlocker/GenSeed",
+		"/lnrpc.WalletUnlocker/InitWallet",
+	})
+
+	// Now we check that we can include all the `lnrpc` methods.
+	uris, isRegex = m.MatchRegexURI("/lnrpc\\..*")
+	require.True(t, isRegex)
+	require.ElementsMatch(t, uris, []string{
+		"/lnrpc.WalletUnlocker/GenSeed",
+		"/lnrpc.WalletUnlocker/InitWallet",
+		"/lnrpc.Lightning/SendCoins",
+	})
+
+	// Assert that the function does not return any URIs for a wild card
+	// URI that does not match on any of its perms.
+	uris, isRegex = m.MatchRegexURI("/poolrpc.Trader/.*")
+	require.True(t, isRegex)
+	require.Empty(t, uris)
+}

--- a/rpc_proxy.go
+++ b/rpc_proxy.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
+	"github.com/lightninglabs/lightning-terminal/perms"
 	"github.com/lightninglabs/lightning-terminal/session"
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/macaroons"
@@ -58,7 +59,7 @@ func (e *proxyErr) Unwrap() error {
 // component.
 func newRpcProxy(cfg *Config, validator macaroons.MacaroonValidator,
 	superMacValidator session.SuperMacaroonValidator,
-	permsMgr *PermissionsManager, bufListener *bufconn.Listener) *rpcProxy {
+	permsMgr *perms.Manager, bufListener *bufconn.Listener) *rpcProxy {
 
 	// The gRPC web calls are protected by HTTP basic auth which is defined
 	// by base64(username:password). Because we only have a password, we
@@ -146,7 +147,7 @@ func newRpcProxy(cfg *Config, validator macaroons.MacaroonValidator,
 type rpcProxy struct {
 	cfg       *Config
 	basicAuth string
-	permsMgr  *PermissionsManager
+	permsMgr  *perms.Manager
 
 	macValidator      macaroons.MacaroonValidator
 	superMacValidator session.SuperMacaroonValidator

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -143,12 +143,38 @@ func (s *sessionRpcServer) AddSession(_ context.Context,
 		}
 
 		for _, op := range req.MacaroonCustomPermissions {
-			if op.Entity == macaroons.PermissionEntityCustomURI {
-				_, ok := s.cfg.permMgr.URIPermissions(op.Action)
-				if !ok {
-					return nil, fmt.Errorf("URI %s is "+
-						"unknown to LiT", op.Action)
+			if op.Entity != macaroons.PermissionEntityCustomURI {
+				permissions = append(permissions, bakery.Op{
+					Entity: op.Entity,
+					Action: op.Action,
+				})
+
+				continue
+			}
+
+			// First check if this is a regex URI.
+			uris, isRegex := s.cfg.permMgr.MatchRegexURI(op.Action)
+			if isRegex {
+				// This is a regex URI, and so we add each of
+				// the matching URIs returned from the
+				// permissions' manager.
+				for _, uri := range uris {
+					permissions = append(
+						permissions, bakery.Op{
+							Entity: op.Entity,
+							Action: uri,
+						},
+					)
 				}
+				continue
+			}
+
+			// This is not a wild card URI, so just check that the
+			// permissions' manager is aware of this URI.
+			_, ok := s.cfg.permMgr.URIPermissions(op.Action)
+			if !ok {
+				return nil, fmt.Errorf("URI %s is unknown to "+
+					"LiT", op.Action)
 			}
 
 			permissions = append(permissions, bakery.Op{

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/lightning-node-connect/mailbox"
 	"github.com/lightninglabs/lightning-terminal/litrpc"
+	"github.com/lightninglabs/lightning-terminal/perms"
 	"github.com/lightninglabs/lightning-terminal/session"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"google.golang.org/grpc"
@@ -41,7 +42,7 @@ type sessionRpcServerConfig struct {
 	superMacBaker       func(ctx context.Context, rootKeyID uint64,
 		recipe *session.MacaroonRecipe) (string, error)
 	firstConnectionDeadline time.Duration
-	permMgr                 *PermissionsManager
+	permMgr                 *perms.Manager
 }
 
 // newSessionRPCServer creates a new sessionRpcServer using the passed config.

--- a/terminal.go
+++ b/terminal.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lightninglabs/faraday/frdrpc"
 	"github.com/lightninglabs/faraday/frdrpcserver"
 	"github.com/lightninglabs/lightning-terminal/litrpc"
+	"github.com/lightninglabs/lightning-terminal/perms"
 	"github.com/lightninglabs/lightning-terminal/queue"
 	mid "github.com/lightninglabs/lightning-terminal/rpcmiddleware"
 	"github.com/lightninglabs/lightning-terminal/session"
@@ -136,7 +137,7 @@ type LightningTerminal struct {
 
 	defaultImplCfg *lnd.ImplementationCfg
 
-	permsMgr *PermissionsManager
+	permsMgr *perms.Manager
 
 	// lndInterceptorChain is a reference to lnd's interceptor chain that
 	// guards all incoming calls. This is only set in integrated mode!
@@ -204,8 +205,8 @@ func (g *LightningTerminal) Run() error {
 	g.errQueue.Start()
 	defer g.errQueue.Stop()
 
-	// Construct a new PermissionsManager.
-	g.permsMgr, err = NewPermissionsManager()
+	// Construct a new Manager.
+	g.permsMgr, err = perms.NewManager()
 	if err != nil {
 		return fmt.Errorf("could not create permissions manager")
 	}
@@ -589,7 +590,7 @@ func (g *LightningTerminal) startSubservers() error {
 			DBPath:           filepath.Join(g.cfg.LitDir, g.cfg.Network),
 			MacaroonLocation: "litd",
 			StatelessInit:    !createDefaultMacaroons,
-			RequiredPerms:    litPermissions,
+			RequiredPerms:    perms.LitPermissions,
 			LndClient:        &g.lndClient.LndServices,
 			EphemeralKey:     lndclient.SharedKeyNUMS,
 			KeyLocator:       lndclient.SharedKeyLocator,


### PR DESCRIPTION
With this PR, you can now use the wild card character when specifying custom URIs that permissions should be added for in an LNC session. This allows you to do the following:

```
litcli s a --label=custom_perm_session  --type=custom --uri=/lnrpc.Lightning/ListChannels --uri="/poolrpc.Trader/*"
```

The above will create a session that has the perms to only access the `ListChannels` call of the `lnrpc.Lightning` but then also has the perms to access any URI that falls under the `poolrpc.Trader` service. 
`
Fixes #439