### PR TITLE
session_rpcserver+litrpc: allow custom session with all read-only perms

### DIFF
--- a/litrpc/lit-sessions.pb.go
+++ b/litrpc/lit-sessions.pb.go
@@ -216,9 +216,17 @@ type MacaroonPermission struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The entity a permission grants access to.
+	// The entity a permission grants access to. If a entity is set to the
+	// "uri" keyword then the action entry should be one of the special cases
+	// described in the comment for action.
 	Entity string `protobuf:"bytes,1,opt,name=entity,proto3" json:"entity,omitempty"`
-	// The action that is granted.
+	// The action that is granted. If entity is set to "uri", then action must
+	// be set to either:
+	//  - a particular URI to which access should be granted.
+	//  - a URI regex, in which case access will be granted to each URI that
+	//    matches the regex.
+	//  - the "***readonly***" keyword. This will result in the access being
+	//    granted to all read-only endpoints.
 	Action string `protobuf:"bytes,2,opt,name=action,proto3" json:"action,omitempty"`
 }
 

--- a/litrpc/lit-sessions.proto
+++ b/litrpc/lit-sessions.proto
@@ -36,10 +36,18 @@ message AddSessionRequest {
 }
 
 message MacaroonPermission {
-    // The entity a permission grants access to.
+    // The entity a permission grants access to. If a entity is set to the
+    // "uri" keyword then the action entry should be one of the special cases
+    // described in the comment for action.
     string entity = 1;
 
-    // The action that is granted.
+    // The action that is granted. If entity is set to "uri", then action must
+    // be set to either:
+    //  - a particular URI to which access should be granted.
+    //  - a URI regex, in which case access will be granted to each URI that
+    //    matches the regex.
+    //  - the "***readonly***" keyword. This will result in the access being
+    //    granted to all read-only endpoints.
     string action = 2;
 }
 

--- a/perms/permissions_test.go
+++ b/perms/permissions_test.go
@@ -78,4 +78,10 @@ func TestMatchRegexURI(t *testing.T) {
 	uris, isRegex = m.MatchRegexURI("/poolrpc.Trader/.*")
 	require.True(t, isRegex)
 	require.Empty(t, uris)
+
+	// Assert that the read-only permission's keyword is not seen as a valid
+	// regex.
+	uris, isRegex = m.MatchRegexURI("***readonly***")
+	require.False(t, isRegex)
+	require.Empty(t, uris)
 }


### PR DESCRIPTION
A special case is added to the creation of a custom session to 
allow the user to specify custom URIs as well as the permissions 
for all read-only endpoints. To use this option when creating a 
custom session, a user should set the `entity` of the macaroon 
permission to `"uri"` and the `action` to `"***readonly***"`
The reason for the using the three '*'s in the string is to ensure 
that the string never collides with a valid URI or a valid regex. 

`litcli` example:
```
litcli  s a --label=test --type=custom --uri=/lnrpc.Lightning/ListChannels --uri="/lnrpc.State/.*" --uri="***readonly***"
```

Fixes #456