### PR TITLE
multi: add some litd client helpers

### DIFF
--- a/itest/litd_mode_integrated_test.go
+++ b/itest/litd_mode_integrated_test.go
@@ -974,7 +974,7 @@ func bakeSuperMacaroon(cfg *LitNodeConfig, readOnly bool) (string, error) {
 	lndAdminCtx := macaroonContext(ctxt, lndAdminMacBytes)
 	lndConn := lnrpc.NewLightningClient(rawConn)
 
-	permsMgr, err := perms.NewManager()
+	permsMgr, err := perms.NewManager(false)
 	if err != nil {
 		return "", err
 	}

--- a/litclient/jsoncallbacks.go
+++ b/litclient/jsoncallbacks.go
@@ -1,0 +1,44 @@
+package litclient
+
+import (
+	"context"
+
+	"github.com/lightninglabs/faraday/frdrpc"
+	"github.com/lightninglabs/loop/looprpc"
+	"github.com/lightninglabs/pool/poolrpc"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/autopilotrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/chainrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/verrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/watchtowerrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/wtclientrpc"
+	"google.golang.org/grpc"
+)
+
+// StubPackageRegistration defines the signature of a function that maps JSON
+// method URIs to the function that should be called to handle the method.
+type StubPackageRegistration func(map[string]func(context.Context,
+	*grpc.ClientConn, string, func(string, error)))
+
+// Registrations defines a list of StubPackageRegistrations that a lit client
+// will have access to when using Lit.
+var Registrations = []StubPackageRegistration{
+	lnrpc.RegisterLightningJSONCallbacks,
+	lnrpc.RegisterStateJSONCallbacks,
+	autopilotrpc.RegisterAutopilotJSONCallbacks,
+	chainrpc.RegisterChainNotifierJSONCallbacks,
+	invoicesrpc.RegisterInvoicesJSONCallbacks,
+	routerrpc.RegisterRouterJSONCallbacks,
+	signrpc.RegisterSignerJSONCallbacks,
+	verrpc.RegisterVersionerJSONCallbacks,
+	walletrpc.RegisterWalletKitJSONCallbacks,
+	watchtowerrpc.RegisterWatchtowerJSONCallbacks,
+	wtclientrpc.RegisterWatchtowerClientJSONCallbacks,
+	looprpc.RegisterSwapClientJSONCallbacks,
+	poolrpc.RegisterTraderJSONCallbacks,
+	frdrpc.RegisterFaradayServerJSONCallbacks,
+}

--- a/perms/permissions.go
+++ b/perms/permissions.go
@@ -135,8 +135,12 @@ type Manager struct {
 }
 
 // NewManager constructs a new Manager instance and collects any of the fixed
-// permissions.
-func NewManager() (*Manager, error) {
+// permissions. If withAllSubServers is true, then all the LND sub-server
+// permissions will be added to the available permissions set regardless of
+// whether LND was compiled with those sub-servers. If it is not set, however,
+// then OnLNDBuildTags can be used to specify the exact sub-servers that LND
+// was compiled with and then only the corresponding permissions will be added.
+func NewManager(withAllSubServers bool) (*Manager, error) {
 	permissions := make(map[subServerName]map[string][]bakery.Op)
 	permissions[faradayPerms] = faraday.RequiredPermissions
 	permissions[loopPerms] = loop.RequiredPermissions
@@ -166,8 +170,11 @@ func NewManager() (*Manager, error) {
 
 			// If this sub-server is one that we know is
 			// automatically compiled in LND then we add it to our
-			// map of active permissions.
-			if lndAutoCompiledSubServers[name] {
+			// map of active permissions. We also add the permission
+			// if withAllSubServers is true.
+			if withAllSubServers ||
+				lndAutoCompiledSubServers[name] {
+
 				permissions[lndPerms][key] = value
 			}
 		}

--- a/terminal.go
+++ b/terminal.go
@@ -212,7 +212,7 @@ func (g *LightningTerminal) Run() error {
 	defer g.errQueue.Stop()
 
 	// Construct a new Manager.
-	g.permsMgr, err = perms.NewManager()
+	g.permsMgr, err = perms.NewManager(false)
 	if err != nil {
 		return fmt.Errorf("could not create permissions manager")
 	}


### PR DESCRIPTION
This PR does 2 things: 

1. Adds a `litclient` package and adds and exports a list of JSON callbacks that a client connecting to lit should register. 
2. Adds a `withAllSubServers` param to perms.NewManager. This is useful for a client who wants to get a list of all possible permissions available to it without knowing which sub-servers LND was compiled with. This will lead to some false positives if the client tries to call the method of a sub-server that was not compiled within LND.

required for https://github.com/lightninglabs/lightning-node-connect/pull/66