### PR TITLE
multi: add support for building without UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,10 +130,21 @@ go-build:
 	$(GOBUILD) -tags="$(LND_RELEASE_TAGS)" -ldflags "$(LDFLAGS)" -o litd-debug $(PKG)/cmd/litd
 	$(GOBUILD) -tags="$(LND_RELEASE_TAGS)" -ldflags "$(LDFLAGS)" -o litcli-debug $(PKG)/cmd/litcli
 
+
+go-build-noui:
+	@$(call print, "Building lightning-terminal without UI.")
+	$(GOBUILD) -tags="litd_no_ui $(LND_RELEASE_TAGS)" -ldflags "$(LDFLAGS)" -o litd-debug $(PKG)/cmd/litd
+	$(GOBUILD) -tags="litd_no_ui $(LND_RELEASE_TAGS)" -ldflags "$(LDFLAGS)" -o litcli-debug $(PKG)/cmd/litcli
+
 go-install:
 	@$(call print, "Installing lightning-terminal.")
 	$(GOINSTALL) -trimpath -tags="$(LND_RELEASE_TAGS)" -ldflags "$(LDFLAGS)" $(PKG)/cmd/litd
 	$(GOINSTALL) -trimpath -tags="$(LND_RELEASE_TAGS)" -ldflags "$(LDFLAGS)" $(PKG)/cmd/litcli
+
+go-install-noui:
+	@$(call print, "Installing lightning-terminal without UI.")
+	$(GOINSTALL) -tags="litd_no_ui $(LND_RELEASE_TAGS)" -ldflags "$(LDFLAGS)" $(PKG)/cmd/litd
+	$(GOINSTALL) -tags="litd_no_ui $(LND_RELEASE_TAGS)" -ldflags "$(LDFLAGS)" $(PKG)/cmd/litcli
 
 go-install-cli:
 	@$(call print, "Installing all CLI binaries.")

--- a/app.go
+++ b/app.go
@@ -1,0 +1,19 @@
+//go:build !litd_no_ui
+// +build !litd_no_ui
+
+package terminal
+
+import (
+	"embed"
+)
+
+var (
+	// appBuildFS is an in-memory file system that contains all the static
+	// HTML/CSS/JS files of the UI. It is compiled into the binary with the
+	// go 1.16 embed directive below. Because the path is relative to the
+	// root package, all assets will have a path prefix of /app/build/ which
+	// we'll strip by giving a sub directory to the HTTP server.
+	//
+	//go:embed app/build/*
+	appBuildFS embed.FS
+)

--- a/app_noui.go
+++ b/app_noui.go
@@ -1,0 +1,10 @@
+//go:build litd_no_ui
+// +build litd_no_ui
+
+package terminal
+
+import "embed"
+
+var (
+	appBuildFS embed.FS
+)

--- a/docs/release-notes/release-notes-0.13.4.md
+++ b/docs/release-notes/release-notes-0.13.4.md
@@ -6,6 +6,8 @@
 
 - [Fixed a bug where REST calls for the `WalletUnlocker` service weren't allowed
   on startup](https://github.com/lightninglabs/lightning-terminal/pull/806).
+- [Added build flag 'litd_no_ui' for building litd without the ui, accessible 
+with 'make go-build-noui' and 'make go-install-noui'](https://github.com/lightninglabs/lightning-terminal/pull/500).
 
 ### LND
 

--- a/terminal.go
+++ b/terminal.go
@@ -3,7 +3,6 @@ package terminal
 import (
 	"context"
 	"crypto/tls"
-	"embed"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -90,15 +89,6 @@ var (
 	// macDatabaseOpenTimeout is how long we wait for acquiring the lock on
 	// the macaroon database before we give up with an error.
 	macDatabaseOpenTimeout = time.Second * 5
-
-	// appBuildFS is an in-memory file system that contains all the static
-	// HTML/CSS/JS files of the UI. It is compiled into the binary with the
-	// go 1.16 embed directive below. Because the path is relative to the
-	// root package, all assets will have a path prefix of /app/build/ which
-	// we'll strip by giving a sub directory to the HTTP server.
-	//
-	//go:embed app/build/*
-	appBuildFS embed.FS
 
 	// appFilesDir is the sub directory of the above build directory which
 	// we pass to the HTTP server.


### PR DESCRIPTION
This commit adds support for building without UI. If the build tag "no_ui" is set the UI will be disabled and an empty `embed.FS` will be served. I'm successfully running it on my nix-bitcoin node with the following nix-bitcoin pkgs/modules https://github.com/sputn1ck/nix-bitcoin/commit/d69e557740b6f4d33a9f48816ee58275c0dbc6a5

NOTE: this doesn't remove the need for an `uipassword`