### PR TITLE
config: add flag to disable main UI http web server

### DIFF
--- a/config.go
+++ b/config.go
@@ -147,6 +147,8 @@ type Config struct {
 	UIPasswordFile string   `long:"uipassword_file" description:"Same as uipassword but instead of passing in the value directly, read the password from the specified file."`
 	UIPasswordEnv  string   `long:"uipassword_env" description:"Same as uipassword but instead of passing in the value directly, read the password from the specified environment variable."`
 
+	DisableWebServer bool `long:"disable-web-server" description:"Disables the main UI http web server."`
+
 	LetsEncrypt       bool   `long:"letsencrypt" description:"Use Let's Encrypt to create a TLS certificate for the UI instead of using lnd's TLS certificate. Port 80 must be free to listen on and must be reachable from the internet for this to work."`
 	LetsEncryptHost   string `long:"letsencrypthost" description:"The host name to create a Let's Encrypt certificate for."`
 	LetsEncryptDir    string `long:"letsencryptdir" description:"The directory where the Let's Encrypt library will store its key and certificate."`

--- a/itest/litd_node.go
+++ b/itest/litd_node.go
@@ -113,6 +113,7 @@ func (cfg *LitNodeConfig) GenArgs() []string {
 			fmt.Sprintf("--uipassword=%s", cfg.UIPassword),
 			"--enablerest",
 			"--restcors=*",
+			"--disable-web-server",
 		}
 	)
 	litArgs = append(litArgs, cfg.LitArgs...)

--- a/terminal.go
+++ b/terminal.go
@@ -437,8 +437,10 @@ func (g *LightningTerminal) Run() error {
 		return fmt.Errorf("error starting lnd gRPC proxy server: %v",
 			err)
 	}
-	if err := g.startMainWebServer(); err != nil {
-		return fmt.Errorf("error starting UI HTTP server: %v", err)
+	if !g.cfg.DisableWebServer {
+		if err := g.startMainWebServer(); err != nil {
+			return fmt.Errorf("error starting UI HTTP server: %v", err)
+		}
 	}
 
 	// Now that we have started the main UI web server, show some useful


### PR DESCRIPTION
This PR adds startup flag `--disable-web-server` for `litd` that disables the main UI web server.

This is particularly useful for users that want to use LNC but don't want to expose a web server on their machine, and don't want to put a firewall in place as a workaround.