### PR TITLE
make: add darwin-arm64 to release build architectures

### DIFF
--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -2,6 +2,7 @@ VERSION_TAG = $(shell git describe --tags)
 VERSION_CHECK = @$(call print, "Building master with date version tag")
 
 BUILD_SYSTEM = darwin-amd64 \
+darwin-arm64 \
 linux-386 \
 linux-amd64 \
 linux-armv6 \


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/lightning-terminal/issues/491.
