### PR TITLE
terminal: fix macaroon DB directory

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -675,7 +675,8 @@ func (g *LightningTerminal) startSubservers() error {
 
 	// Set up the macaroon service.
 	rks, db, err := lndclient.NewBoltMacaroonStore(
-		g.cfg.LitDir, lncfg.MacaroonDBName, macDatabaseOpenTimeout,
+		filepath.Join(g.cfg.LitDir, g.cfg.Network),
+		lncfg.MacaroonDBName, macDatabaseOpenTimeout,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
The macarooon db should be under the network directory.

Small oversight made [here](https://github.com/lightninglabs/lightning-terminal/pull/517/files#diff-76dcb3ff0bf98acc001558927365f8a3b7f0d2253580a49dc5973dfa398372c7R678-R687)