### PR TITLE
Fix "no matching files found" compilation error when litd is used as a library

### DIFF
--- a/app/build/.gitkeep
+++ b/app/build/.gitkeep
@@ -1,0 +1,1 @@
+# Keep directory in git.

--- a/app/package.json
+++ b/app/package.json
@@ -8,6 +8,7 @@
     "start": "BROWSER=none react-scripts start",
     "develop": "REACT_APP_USE_SAMPLE_DATA=true yarn start",
     "build": "react-scripts build",
+    "postbuild": "echo -n '# Keep directory in git.' > build/.gitkeep",
     "test": "react-scripts test --env=jest-environment-jsdom",
     "test:ci": "cross-env CI=true yarn test --coverage",
     "eject": "react-scripts eject",


### PR DESCRIPTION
Fixes the `terminal.go:99:13: pattern app/build/*: no matching files found` error when litd is used as a library or module in another project.

Even though the content of the app/build directory should be ignored by
git, we need it to exist in order for the Golang embedded file system
compilation to succeed on an empty project. This is required to fix
compilation issues when lightning-terminal is used as a module
dependency in another project, where the frontend build process can't be
triggered.