### PR TITLE
doc: add note for remote lnd credentials

### DIFF
--- a/doc/config-lnd-remote.md
+++ b/doc/config-lnd-remote.md
@@ -40,6 +40,10 @@ remote.lnd.macaroonpath=/some/folder/with/lnd/data/admin.macaroon
 remote.lnd.tlscertpath=/some/folder/with/lnd/data/tls.cert
 ```
 
+> NOTE: It is highly recommended to not place the LND connection credentials
+inside the terminal home directory (`~/.lit/`) as `litd` may overwrite some of
+these files.
+
 Run LiT:
 
 ```shell


### PR DESCRIPTION
## Description

Adds a small note in the doc for connecting `litd` to remote `lnd`. It is not clear that the LND `admin.macaroon` and `tls.cert` should not be placed inside the `.lit/` directory, as they may be overwritten.