### PR TITLE
itest: export `ServerHarness` and `HarnessNode`

### DIFF
--- a/itest/litd_node.go
+++ b/itest/litd_node.go
@@ -339,9 +339,9 @@ var _ lnrpc.LightningClient = (*HarnessNode)(nil)
 var _ lnrpc.WalletUnlockerClient = (*HarnessNode)(nil)
 var _ invoicesrpc.InvoicesClient = (*HarnessNode)(nil)
 
-// newNode creates a new test lightning node instance from the passed config.
-func newNode(t *testing.T, cfg *LitNodeConfig,
-	harness *NetworkHarness) (*HarnessNode, error) {
+// NewNode creates a new test lightning node instance from the passed config.
+func NewNode(t *testing.T, cfg *LitNodeConfig,
+	harness *lntest.HarnessTest) (*HarnessNode, error) {
 
 	if cfg.BaseDir == "" {
 		var err error
@@ -393,7 +393,7 @@ func newNode(t *testing.T, cfg *LitNodeConfig,
 
 	var remoteNode *node.HarnessNode
 	if cfg.RemoteMode {
-		lndHarness := harness.LNDHarness
+		lndHarness := harness
 
 		remoteNode = lndHarness.NewNode("bob-custom", cfg.ExtraArgs)
 		tenBTC := btcutil.Amount(10 * btcutil.SatoshiPerBitcoin)
@@ -538,7 +538,7 @@ func renameFile(fromFileName, toFileName string) {
 //
 // This may not clean up properly if an error is returned, so the caller should
 // call shutdown() regardless of the return value.
-func (hn *HarnessNode) start(litdBinary string, litdError chan<- error,
+func (hn *HarnessNode) Start(litdBinary string, litdError chan<- error,
 	wait bool, litArgOpts ...LitArgOption) error {
 
 	hn.quit = make(chan struct{})
@@ -1165,8 +1165,8 @@ func (hn *HarnessNode) cleanup() error {
 	return os.RemoveAll(hn.Cfg.BaseDir)
 }
 
-// Stop attempts to stop the active litd process.
-func (hn *HarnessNode) stop() error {
+// Stop attempts to Stop the active litd process.
+func (hn *HarnessNode) Stop() error {
 	// Do nothing if the process is not running.
 	if hn.processExit == nil {
 		return nil
@@ -1246,7 +1246,7 @@ func (hn *HarnessNode) stop() error {
 // shutdown stops the active lnd process and cleans up any temporary directories
 // created along the way.
 func (hn *HarnessNode) shutdown() error {
-	if err := hn.stop(); err != nil {
+	if err := hn.Stop(); err != nil {
 		return err
 	}
 	if err := hn.cleanup(); err != nil {

--- a/itest/network_harness.go
+++ b/itest/network_harness.go
@@ -315,7 +315,7 @@ func (n *NetworkHarness) newNode(t *testing.T, name string, extraArgs,
 		RemoteMode:     remoteMode,
 	}
 
-	node, err := newNode(t, cfg, n)
+	node, err := NewNode(t, cfg, n.LNDHarness)
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +326,7 @@ func (n *NetworkHarness) newNode(t *testing.T, name string, extraArgs,
 	n.activeNodes[node.NodeID] = node
 	n.mtx.Unlock()
 
-	err = node.start(n.litdBinary, n.lndErrorChan, wait)
+	err = node.Start(n.litdBinary, n.lndErrorChan, wait)
 	if err != nil {
 		return nil, err
 	}
@@ -649,7 +649,7 @@ func (n *NetworkHarness) RestartNode(node *HarnessNode, callback func() error,
 func (n *NetworkHarness) RestartNodeNoUnlock(node *HarnessNode,
 	callback func() error, wait bool, litArgOpts ...LitArgOption) error {
 
-	if err := node.stop(); err != nil {
+	if err := node.Stop(); err != nil {
 		return err
 	}
 
@@ -659,18 +659,18 @@ func (n *NetworkHarness) RestartNodeNoUnlock(node *HarnessNode,
 		}
 	}
 
-	return node.start(n.litdBinary, n.lndErrorChan, wait, litArgOpts...)
+	return node.Start(n.litdBinary, n.lndErrorChan, wait, litArgOpts...)
 }
 
 // SuspendNode stops the given node and returns a callback that can be used to
 // start it again.
 func (n *NetworkHarness) SuspendNode(node *HarnessNode) (func() error, error) {
-	if err := node.stop(); err != nil {
+	if err := node.Stop(); err != nil {
 		return nil, err
 	}
 
 	restart := func() error {
-		return node.start(n.litdBinary, n.lndErrorChan, true)
+		return node.Start(n.litdBinary, n.lndErrorChan, true)
 	}
 
 	return restart, nil
@@ -701,7 +701,7 @@ func (n *NetworkHarness) KillNode(node *HarnessNode) error {
 // This can be used to temporarily bring a node down during a test, to be later
 // started up again.
 func (n *NetworkHarness) StopNode(node *HarnessNode) error {
-	return node.stop()
+	return node.Stop()
 }
 
 // OpenChannel attempts to open a channel between srcNode and destNode with the

--- a/itest/network_harness.go
+++ b/itest/network_harness.go
@@ -49,7 +49,7 @@ type NetworkHarness struct {
 	LNDHarness *lntest.HarnessTest
 
 	// server is an instance of the local Loop/Pool mock server.
-	server *serverHarness
+	server *ServerHarness
 
 	// BackendCfg houses the information necessary to use a node as LND
 	// chain backend, such as rpc configuration, P2P information etc.
@@ -130,8 +130,8 @@ func (n *NetworkHarness) SetUp(t *testing.T,
 	mockServerAddr := fmt.Sprintf(
 		node.ListenerFormat, node.NextAvailablePort(),
 	)
-	n.server = newServerHarness(mockServerAddr)
-	err := n.server.start()
+	n.server = NewServerHarness(mockServerAddr)
+	err := n.server.Start()
 	require.NoError(t, err)
 
 	// Start a mock autopilot server.
@@ -273,10 +273,10 @@ func (n *NetworkHarness) NewNode(t *testing.T, name string, extraArgs []string,
 	remoteMode bool, wait bool) (*HarnessNode, error) {
 
 	litArgs := []string{
-		fmt.Sprintf("--loop.server.host=%s", n.server.serverHost),
-		fmt.Sprintf("--loop.server.tlspath=%s", n.server.certFile),
-		fmt.Sprintf("--pool.auctionserver=%s", n.server.serverHost),
-		fmt.Sprintf("--pool.tlspathauctserver=%s", n.server.certFile),
+		fmt.Sprintf("--loop.server.host=%s", n.server.ServerHost),
+		fmt.Sprintf("--loop.server.tlspath=%s", n.server.CertFile),
+		fmt.Sprintf("--pool.auctionserver=%s", n.server.ServerHost),
+		fmt.Sprintf("--pool.tlspathauctserver=%s", n.server.CertFile),
 		"--autopilot.insecure",
 		fmt.Sprintf(
 			"--autopilot.address=localhost:%d",

--- a/itest/server_harness.go
+++ b/itest/server_harness.go
@@ -27,11 +27,11 @@ type loopPoolServer struct {
 	swapserverrpc.UnimplementedSwapServerServer
 }
 
-type serverHarness struct {
-	serverHost string
+type ServerHarness struct {
+	ServerHost string
 	mockServer *grpc.Server
 
-	certFile string
+	CertFile string
 	server   *loopPoolServer
 
 	errChan chan error
@@ -39,32 +39,35 @@ type serverHarness struct {
 	wg sync.WaitGroup
 }
 
-func newServerHarness(serverHost string) *serverHarness {
-	return &serverHarness{
-		serverHost: serverHost,
+// NewServerHarness creates a new ServerHarness instance.
+func NewServerHarness(serverHost string) *ServerHarness {
+	return &ServerHarness{
+		ServerHost: serverHost,
 		errChan:    make(chan error, 1),
 	}
 }
 
-func (s *serverHarness) stop() {
+// Stop stops the mock Loop/Pool server.
+func (s *ServerHarness) Stop() {
 	s.mockServer.Stop()
 	s.wg.Wait()
 }
 
-func (s *serverHarness) start() error {
+// Start starts the mock Loop/Pool server.
+func (s *ServerHarness) Start() error {
 	tempDirName, err := ioutil.TempDir("", "litditest")
 	if err != nil {
 		return err
 	}
 
-	s.certFile = filepath.Join(tempDirName, "proxy.cert")
+	s.CertFile = filepath.Join(tempDirName, "proxy.cert")
 	keyFile := filepath.Join(tempDirName, "proxy.key")
-	creds, err := genCertPair(s.certFile, keyFile)
+	creds, err := genCertPair(s.CertFile, keyFile)
 	if err != nil {
 		return err
 	}
 
-	httpListener, err := net.Listen("tcp", s.serverHost)
+	httpListener, err := net.Listen("tcp", s.ServerHost)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In this PR we export the itest structs `ServerHarness` and `HarnessNode`. This is useful to make it possible to use the structures independently in other test frameworks that need to run and interact with Lit instance(s), and reuse the structures from the `lightning-terminal` repo.

Let me know if there are other components of the itest framework that you think would be useful to export, and I'll update this PR with those as well :)!