### PR TITLE
go.mod: bump lndclient to 0.16.0-12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/lightninglabs/faraday v0.2.11-alpha
 	github.com/lightninglabs/lightning-node-connect v0.1.12-alpha
 	github.com/lightninglabs/lightning-terminal/autopilotserverrpc v0.0.1
-	github.com/lightninglabs/lndclient v0.16.0-10
+	github.com/lightninglabs/lndclient v0.16.0-12
 	github.com/lightninglabs/loop v0.23.0-beta
 	github.com/lightninglabs/loop/swapserverrpc v1.0.4
 	github.com/lightninglabs/pool v0.6.2-beta.0.20230329135228-c3bffb52df3a

--- a/go.sum
+++ b/go.sum
@@ -1033,8 +1033,8 @@ github.com/lightninglabs/lightning-node-connect v0.1.12-alpha/go.mod h1:dgyhE+O4
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2 h1:Er1miPZD2XZwcfE4xoS5AILqP1mj7kqnhbBSxW9BDxY=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2/go.mod h1:antQGRDRJiuyQF6l+k6NECCSImgCpwaZapATth2Chv4=
 github.com/lightninglabs/lndclient v0.15.0-0/go.mod h1:ORS/YFe9hAXlzN/Uj+gvTmrnXEml6yD6dWwzCjpTJyQ=
-github.com/lightninglabs/lndclient v0.16.0-10 h1:cMBJNfssBQtpgYIu23QLP/qw0ijiT5SBZffnXz8zjJk=
-github.com/lightninglabs/lndclient v0.16.0-10/go.mod h1:mqY0znSNa+M40HZowwKfno29RyZnmxoqo++BlYP82EY=
+github.com/lightninglabs/lndclient v0.16.0-12 h1:+OzITtmACkaM9z7MvahGva5Pd3GjWadgMbXv+PUfP9E=
+github.com/lightninglabs/lndclient v0.16.0-12/go.mod h1:mqY0znSNa+M40HZowwKfno29RyZnmxoqo++BlYP82EY=
 github.com/lightninglabs/loop v0.23.0-beta h1:me3g9erjnvoJq5udl7XLOC0e3Pp7+6YGupTNRIbl64E=
 github.com/lightninglabs/loop v0.23.0-beta/go.mod h1:rh5c7KZMNV/GOJ79n3x5qrO9h6FZT7ZZ54b6/FPIhQI=
 github.com/lightninglabs/loop/swapserverrpc v1.0.4 h1:cEX+mt7xmQlEbmuQ52vOBT7l+a471v94ofdJbB6MmXs=


### PR DESCRIPTION
This PR bumps the `lndclient` version to one that ensures that a more meaningful error
is returned if `RegisterRPCMiddleware` fails. Currently, the wanted error will be logged but
the official error will be `context cancelled` which is not very helpful. 

This will be especially important once https://github.com/lightninglabs/lightning-terminal/pull/541 is merged since we want 
meaningful errors to be displayed. 