### PR TITLE
config: fix macaroon path construction

### DIFF
--- a/config.go
+++ b/config.go
@@ -440,12 +440,10 @@ func loadAndValidateConfig(interceptor signal.Interceptor) (*Config, error) {
 		}
 	}
 
-	if cfg.Network != DefaultNetwork {
-		if cfg.MacaroonPath == DefaultMacaroonPath {
-			cfg.MacaroonPath = filepath.Join(
-				litDir, cfg.Network, DefaultMacaroonFilename,
-			)
-		}
+	if cfg.MacaroonPath == DefaultMacaroonPath {
+		cfg.MacaroonPath = filepath.Join(
+			litDir, cfg.Network, DefaultMacaroonFilename,
+		)
 	}
 
 	// Initiate our listeners. For now, we only support listening on one


### PR DESCRIPTION
Fix the macaroon path construction so that even if the network is not mainnet, the path gets constructed correctly from a user specified "--lit.dir" flag.

Fixes #596