### PR TITLE
Update litd to version `v0.10.4-alpha` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ versioning](#daemon-versions-packaged-with-lit).
 
 | LiT               | LND          |
 |-------------------|--------------|
+| **v0.10.4-alpha** | v0.16.0-beta |
 | **v0.10.2-alpha** | v0.16.0-beta |
 | **v0.10.1-alpha** | v0.16.0-beta |
 | **v0.10.0-alpha** | v0.16.0-beta |
@@ -140,6 +141,7 @@ The following table shows the supported combinations:
 
 | LiT               | LND          | Loop         | Faraday       | Pool         | Taproot Assets |
 |-------------------|--------------|--------------|---------------|--------------|----------------|
+| **v0.10.4-alpha** | v0.16.4-beta | v0.25.2-beta | v0.2.11-alpha | v0.6.4-beta  | v0.2.3-alpha   |
 | **v0.10.2-alpha** | v0.16.4-beta | v0.25.2-beta | v0.2.11-alpha | v0.6.4-beta  | v0.2.2-alpha   |
 | **v0.10.1-alpha** | v0.16.3-beta | v0.24.1-beta | v0.2.11-alpha | v0.6.4-beta  | v0.2.0-alpha   |
 | **v0.10.0-alpha** | v0.16.2-beta | v0.23.0-beta | v0.2.11-alpha | v0.6.2-beta  | v0.2.0-alpha   |

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/lightninglabs/pool v0.6.4-beta
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.0
 	github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display
-	github.com/lightninglabs/taproot-assets v0.2.2
+	github.com/lightninglabs/taproot-assets v0.2.3
 	github.com/lightningnetwork/lnd v0.16.4-beta
 	github.com/lightningnetwork/lnd/cert v1.2.1
 	github.com/lightningnetwork/lnd/kvdb v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -1054,8 +1054,8 @@ github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display h1:pRdza2wl
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display h1:RZJ8H4ueU/aQ9pFtx5wqsuD3B/DezrewJeVwDKKYY8E=
 github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display/go.mod h1:2oKOBU042GKFHrdbgGiKax4xVrFiZu51lhacUZQ9MnE=
-github.com/lightninglabs/taproot-assets v0.2.2 h1:DREtlSdtzgCMKeUWSlYpbXfqguNbA5Yn3c5wRy3IIgY=
-github.com/lightninglabs/taproot-assets v0.2.2/go.mod h1:ge1z/jmqgcMvP9LrYvLZPbQGgsWixLsKH2OagOVoTBo=
+github.com/lightninglabs/taproot-assets v0.2.3 h1:napiqnloxmu0iHfV0ai1P1P4CFf2IbunDQdF6+RD+io=
+github.com/lightninglabs/taproot-assets v0.2.3/go.mod h1:ok8A01D8FBc88JfLTuivUdmzBJ1mj7cCnpC3sWWihgQ=
 github.com/lightningnetwork/lightning-onion v1.0.2-0.20220211021909-bb84a1ccb0c5/go.mod h1:7dDx73ApjEZA0kcknI799m2O5kkpfg4/gr7N092ojNo=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20221202012345-ca23184850a1 h1:Wm0g70gkcAu2pGpNZwfWPSVOY21j8IyYsNewwK4OkT4=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20221202012345-ca23184850a1/go.mod h1:7dDx73ApjEZA0kcknI799m2O5kkpfg4/gr7N092ojNo=

--- a/version.go
+++ b/version.go
@@ -23,7 +23,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	appMajor uint = 0
 	appMinor uint = 10
-	appPatch uint = 2
+	appPatch uint = 4
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.


### PR DESCRIPTION
This PR updates litd to `v0.10.4-alpha`.
In this PR, we also bump taproot-assets to the latest release.

Happy to address any feedback :)!