### PR TITLE
multi: allow LND and subserver whitelisted calls

### DIFF
--- a/itest/litd_mode_integrated_test.go
+++ b/itest/litd_mode_integrated_test.go
@@ -1278,13 +1278,21 @@ func bakeSuperMacaroon(cfg *LitNodeConfig, readOnly bool) (string, error) {
 		return "", err
 	}
 
-	permsMgr.RegisterSubServer(subservers.LOOP, loop.RequiredPermissions)
-	permsMgr.RegisterSubServer(subservers.POOL, pool.RequiredPermissions)
-	permsMgr.RegisterSubServer(subservers.TAP, tap.RequiredPermissions)
 	permsMgr.RegisterSubServer(
-		subservers.FARADAY, faraday.RequiredPermissions,
+		subservers.LOOP, loop.RequiredPermissions, nil,
 	)
-	permsMgr.RegisterSubServer(subservers.TAP, tap.RequiredPermissions)
+	permsMgr.RegisterSubServer(
+		subservers.POOL, pool.RequiredPermissions, nil,
+	)
+	permsMgr.RegisterSubServer(
+		subservers.TAP, tap.RequiredPermissions, nil,
+	)
+	permsMgr.RegisterSubServer(
+		subservers.FARADAY, faraday.RequiredPermissions, nil,
+	)
+	permsMgr.RegisterSubServer(
+		subservers.TAP, tap.RequiredPermissions, nil,
+	)
 
 	superMacPermissions := permsMgr.ActivePermissions(readOnly)
 	nullID := [4]byte{}
@@ -1300,13 +1308,13 @@ func bakeSuperMacaroon(cfg *LitNodeConfig, readOnly bool) (string, error) {
 	// it's valid.
 	superMacBytes, _ := hex.DecodeString(superMacHex)
 
-	tempFile, err := ioutil.TempFile("", "lit-super-macaroon")
+	tempFile, err := os.CreateTemp("", "lit-super-macaroon")
 	if err != nil {
 		_ = os.Remove(tempFile.Name())
 		return "", err
 	}
 
-	err = ioutil.WriteFile(tempFile.Name(), superMacBytes, 0644)
+	err = os.WriteFile(tempFile.Name(), superMacBytes, 0644)
 	if err != nil {
 		_ = os.Remove(tempFile.Name())
 		return "", err

--- a/itest/litd_mode_integrated_test.go
+++ b/itest/litd_mode_integrated_test.go
@@ -422,8 +422,7 @@ func integratedTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					endpoint.requestFn,
 					endpoint.successPattern,
 					endpointDisabled,
-					"unknown permissions required for "+
-						"method",
+					"unknown request",
 				)
 			})
 		}
@@ -459,8 +458,7 @@ func integratedTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					shouldFailWithoutMacaroon,
 					endpoint.successPattern,
 					endpointDisabled,
-					"unknown permissions required for "+
-						"method",
+					"unknown request",
 				)
 			})
 		}
@@ -485,8 +483,7 @@ func integratedTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					ttt, cfg.LitAddr(), cfg.UIPassword,
 					endpoint.grpcWebURI,
 					withoutUIPassword, endpointDisabled,
-					"unknown permissions required for "+
-						"method",
+					"unknown request",
 				)
 			})
 		}
@@ -525,8 +522,7 @@ func integratedTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					endpoint.requestFn,
 					endpoint.successPattern,
 					endpointDisabled,
-					"unknown permissions required for "+
-						"method",
+					"unknown request",
 				)
 			})
 		}
@@ -1062,26 +1058,19 @@ func runLNCAuthTest(t *testing.T, rawLNCConn grpc.ClientConnInterface,
 	// macaroon permissions properly set up).
 	resp, err := makeRequest(ctxt, rawLNCConn)
 
-	// Is this a disallowed call?
-	if !callAllowed {
-		if disabled {
-			require.ErrorContains(t, err, "unknown permissions "+
-				"required for method")
-		} else {
-			require.ErrorContains(t, err, expectErrContains)
-		}
-
-		return
-	}
-
+	switch {
 	// The call should be allowed, so we expect no error unless this is
 	// for a disabled sub-server.
-	if disabled {
-		require.ErrorContains(t, err, "unknown permissions "+
-			"required for method")
+	case disabled:
+		require.ErrorContains(t, err, "unknown request")
 
 		return
-	} else {
+
+	// Is this a disallowed call?
+	case !callAllowed:
+		require.ErrorContains(t, err, expectErrContains)
+
+	default:
 		require.NoError(t, err)
 	}
 

--- a/itest/litd_mode_remote_test.go
+++ b/itest/litd_mode_remote_test.go
@@ -66,8 +66,7 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					endpoint.requestFn,
 					endpoint.successPattern,
 					endpointEnabled,
-					"unknown permissions required for "+
-						"method",
+					"unknown request",
 				)
 			})
 		}
@@ -93,8 +92,7 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					shouldFailWithoutMacaroon,
 					endpoint.successPattern,
 					endpointEnabled,
-					"unknown permissions required for "+
-						"method",
+					"unknown request",
 				)
 			})
 		}
@@ -117,8 +115,7 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					ttt, cfg.LitAddr(), cfg.UIPassword,
 					endpoint.grpcWebURI, withoutUIPassword,
 					endpointEnabled,
-					"unknown permissions required for "+
-						"method",
+					"unknown request",
 				)
 			})
 		}
@@ -146,8 +143,7 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					endpoint.requestFn,
 					endpoint.successPattern,
 					endpointEnabled,
-					"unknown permissions required for "+
-						"method",
+					"unknown request",
 				)
 			})
 		}

--- a/itest/litd_mode_remote_test.go
+++ b/itest/litd_mode_remote_test.go
@@ -63,6 +63,7 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 				runGRPCAuthTest(
 					ttt, cfg.LitAddr(), cfg.LitTLSCertPath,
 					endpoint.macaroonFn(cfg),
+					endpoint.noAuth,
 					endpoint.requestFn,
 					endpoint.successPattern,
 					endpointEnabled,
@@ -89,6 +90,7 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 				runUIPasswordCheck(
 					ttt, cfg.LitAddr(), cfg.LitTLSCertPath,
 					cfg.UIPassword, endpoint.requestFn,
+					endpoint.noAuth,
 					shouldFailWithoutMacaroon,
 					endpoint.successPattern,
 					endpointEnabled,
@@ -115,7 +117,7 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					ttt, cfg.LitAddr(), cfg.UIPassword,
 					endpoint.grpcWebURI, withoutUIPassword,
 					endpointEnabled,
-					"unknown request",
+					"unknown request", endpoint.noAuth,
 				)
 			})
 		}
@@ -139,7 +141,7 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 			tt.Run(endpoint.name+" lit port", func(ttt *testing.T) {
 				runGRPCAuthTest(
 					ttt, cfg.LitAddr(), cfg.LitTLSCertPath,
-					superMacFile,
+					superMacFile, endpoint.noAuth,
 					endpoint.requestFn,
 					endpoint.successPattern,
 					endpointEnabled,
@@ -164,7 +166,7 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					endpoint.restWebURI,
 					endpoint.successPattern,
 					endpoint.restPOST, withoutUIPassword,
-					endpointDisabled,
+					endpointDisabled, endpoint.noAuth,
 				)
 			})
 		}
@@ -195,7 +197,7 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					endpoint.successPattern,
 					endpoint.allowedThroughLNC,
 					"unknown service",
-					endpointDisabled,
+					endpointDisabled, endpoint.noAuth,
 				)
 			})
 		}
@@ -240,7 +242,7 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					ttt, rawLNCConn, endpoint.requestFn,
 					endpoint.successPattern,
 					allowed, "permission denied",
-					endpointDisabled,
+					endpointDisabled, endpoint.noAuth,
 				)
 			})
 		}

--- a/perms/manager.go
+++ b/perms/manager.go
@@ -116,7 +116,7 @@ func (pm *Manager) IsWhiteListedURL(url string) bool {
 // RegisterSubServer adds the permissions of a given sub-server to the set
 // managed by the Manager.
 func (pm *Manager) RegisterSubServer(name string,
-	permissions map[string][]bakery.Op) {
+	permissions map[string][]bakery.Op, whiteListURLs map[string]struct{}) {
 
 	pm.permsMu.Lock()
 	defer pm.permsMu.Unlock()
@@ -125,6 +125,15 @@ func (pm *Manager) RegisterSubServer(name string,
 
 	for uri, ops := range permissions {
 		pm.perms[uri] = ops
+	}
+
+	for url := range whiteListURLs {
+		pm.perms[url] = nil
+
+		if pm.fixedPerms[name] == nil {
+			pm.fixedPerms[name] = make(map[string][]bakery.Op)
+		}
+		pm.fixedPerms[name][url] = []bakery.Op{}
 	}
 }
 

--- a/perms/permissions.go
+++ b/perms/permissions.go
@@ -80,7 +80,7 @@ var (
 
 	// whiteListedLNDMethods is a map of all lnd RPC methods that don't
 	// require any macaroon authentication.
-	whiteListedLNDMethods = map[string][]bakery.Op{
+	whiteListedLNDMethods = map[string]struct{}{
 		"/lnrpc.WalletUnlocker/GenSeed":        {},
 		"/lnrpc.WalletUnlocker/InitWallet":     {},
 		"/lnrpc.WalletUnlocker/UnlockWallet":   {},
@@ -91,6 +91,10 @@ var (
 		"/lnrpc.State/SubscribeState": {},
 		"/lnrpc.State/GetState":       {},
 	}
+
+	// whiteListedLitMethods is a map of all LiT's RPC methods that don't
+	// require any macaroon authentication.
+	whiteListedLitMethods = map[string]struct{}{}
 
 	// lndSubServerNameToTag is a map from the name of an LND subserver to
 	// the name of the LND tag that corresponds to the subserver. This map

--- a/subservers/faraday.go
+++ b/subservers/faraday.go
@@ -118,3 +118,11 @@ func (f *faradaySubServer) MacPath() string {
 func (f *faradaySubServer) Permissions() map[string][]bakery.Op {
 	return perms.RequiredPermissions
 }
+
+// WhiteListedURLs returns a map of all the sub-server's URLs that can be
+// accessed without a macaroon.
+//
+// NOTE: this is part of the SubServer interface.
+func (f *faradaySubServer) WhiteListedURLs() map[string]struct{} {
+	return nil
+}

--- a/subservers/interface.go
+++ b/subservers/interface.go
@@ -58,4 +58,8 @@ type SubServer interface {
 	// Permissions returns a map of all RPC methods and their required
 	// macaroon permissions to access the sub-server.
 	Permissions() map[string][]bakery.Op
+
+	// WhiteListedURLs returns a map of all the sub-server's URLs that can
+	// be accessed without a macaroon.
+	WhiteListedURLs() map[string]struct{}
 }

--- a/subservers/loop.go
+++ b/subservers/loop.go
@@ -128,3 +128,11 @@ func (l *loopSubServer) MacPath() string {
 func (l *loopSubServer) Permissions() map[string][]bakery.Op {
 	return perms.RequiredPermissions
 }
+
+// WhiteListedURLs returns a map of all the sub-server's URLs that can be
+// accessed without a macaroon.
+//
+// NOTE: this is part of the SubServer interface.
+func (l *loopSubServer) WhiteListedURLs() map[string]struct{} {
+	return nil
+}

--- a/subservers/manager.go
+++ b/subservers/manager.go
@@ -54,7 +54,9 @@ func (s *Manager) AddServer(ss SubServer) {
 		quit:      make(chan struct{}),
 	})
 
-	s.permsMgr.RegisterSubServer(ss.Name(), ss.Permissions())
+	s.permsMgr.RegisterSubServer(
+		ss.Name(), ss.Permissions(), ss.WhiteListedURLs(),
+	)
 }
 
 // StartIntegratedServers starts all the manager's sub-servers that should be

--- a/subservers/pool.go
+++ b/subservers/pool.go
@@ -118,3 +118,11 @@ func (p *poolSubServer) MacPath() string {
 func (p *poolSubServer) Permissions() map[string][]bakery.Op {
 	return perms.RequiredPermissions
 }
+
+// WhiteListedURLs returns a map of all the sub-server's URLs that can be
+// accessed without a macaroon.
+//
+// NOTE: this is part of the SubServer interface.
+func (p *poolSubServer) WhiteListedURLs() map[string]struct{} {
+	return nil
+}

--- a/subservers/taproot-assets.go
+++ b/subservers/taproot-assets.go
@@ -174,3 +174,19 @@ func (t *taprootAssetsSubServer) MacPath() string {
 func (t *taprootAssetsSubServer) Permissions() map[string][]bakery.Op {
 	return perms.RequiredPermissions
 }
+
+// WhiteListedURLs returns a map of all the sub-server's URLs that can be
+// accessed without a macaroon.
+//
+// NOTE: this is part of the SubServer interface.
+func (t *taprootAssetsSubServer) WhiteListedURLs() map[string]struct{} {
+	// If the taproot-asset daemon is running in integrated mode, then we
+	// use cfg.RpcConf.AllowPublicStats to determine if the public stats
+	// endpoints should be included in the whitelist. If it is running in
+	// remote mode, however, then we don't know if the public stats are
+	// allowed, and so we just allow the request through since the remote
+	// daemon will handle blocking the call if it is not whitelisted there.
+	return perms.MacaroonWhitelist(
+		t.cfg.RpcConf.AllowPublicStats || t.remote,
+	)
+}

--- a/terminal.go
+++ b/terminal.go
@@ -116,6 +116,7 @@ var (
 	lndRESTRegistrations = []restRegistration{
 		lnrpc.RegisterLightningHandlerFromEndpoint,
 		lnrpc.RegisterWalletUnlockerHandlerFromEndpoint,
+		lnrpc.RegisterStateHandlerFromEndpoint,
 		autopilotrpc.RegisterAutopilotHandlerFromEndpoint,
 		chainrpc.RegisterChainNotifierHandlerFromEndpoint,
 		invoicesrpc.RegisterInvoicesHandlerFromEndpoint,

--- a/terminal.go
+++ b/terminal.go
@@ -964,6 +964,12 @@ func (g *LightningTerminal) RegisterRestSubserver(ctx context.Context,
 func (g *LightningTerminal) ValidateMacaroon(ctx context.Context,
 	requiredPermissions []bakery.Op, fullMethod string) error {
 
+	// If the URL being queried has been whitelisted, then no macaroon
+	// validation is required for the query.
+	if g.permsMgr.IsWhiteListedURL(fullMethod) {
+		return nil
+	}
+
 	macHex, err := macaroons.RawMacaroonFromContext(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR does a few things:

1. Ensures that Lit register's LND's State server to it's REST server 
2. Allow LND's & Lit's and all Lit's subserver's whitelisted endpoints to pass through without requiring a macaroon 