### PR TITLE
ui+loop: update loop out deadline to use seconds

### DIFF
--- a/app/src/store/views/buildSwapView.ts
+++ b/app/src/store/views/buildSwapView.ts
@@ -493,7 +493,7 @@ class BuildSwapView {
             amount,
             quote,
             this.selectedChanIds,
-            deadline,
+            Math.round(deadline / 1000), // convert milli-secs to secs
             this.confTarget,
             this.loopOutAddress,
           );


### PR DESCRIPTION
Fixes #618

Updates the swap deadline parameter for Loop Outs to be seconds rather than milli-seconds. 