### PR TITLE
rules+session_rpc: use existing privacy mapper for obfuscating rules of linked sessions

### DIFF
--- a/firewall/privacy_mapper_test.go
+++ b/firewall/privacy_mapper_test.go
@@ -555,6 +555,12 @@ func (m *mockPrivacyMapDB) RealToPseudo(real string) (string, error) {
 	return p, nil
 }
 
+func (m *mockPrivacyMapDB) FetchAllPairs() (*firewalldb.PrivacyMapPairs,
+	error) {
+
+	return firewalldb.NewPrivacyMapPairs(m.r2p), nil
+}
+
 var _ firewalldb.PrivacyMapDB = (*mockPrivacyMapDB)(nil)
 
 // TestRandBetween tests random number generation for numbers in an interval.

--- a/firewalldb/privacy_mapper.go
+++ b/firewalldb/privacy_mapper.go
@@ -194,6 +194,16 @@ func (p *privacyMapTx) NewPair(real, pseudo string) error {
 		return err
 	}
 
+	if len(realToPseudoBucket.Get([]byte(real))) != 0 {
+		return fmt.Errorf("an entry already exists for real "+
+			"value: %x", real)
+	}
+
+	if len(pseudoToRealBucket.Get([]byte(pseudo))) != 0 {
+		return fmt.Errorf("an entry already exists for pseudo "+
+			"value: %x", pseudo)
+	}
+
 	err = realToPseudoBucket.Put([]byte(real), []byte(pseudo))
 	if err != nil {
 		return err

--- a/firewalldb/privacy_mapper_test.go
+++ b/firewalldb/privacy_mapper_test.go
@@ -61,6 +61,28 @@ func TestPrivacyMapStorage(t *testing.T) {
 
 		return nil
 	})
+
+	pdb3 := db.PrivacyDB([4]byte{3, 3, 3, 3})
+
+	_ = pdb3.Update(func(tx PrivacyMapTx) error {
+		// Add a new pair.
+		err = tx.NewPair("real 1", "pseudo 1")
+		require.NoError(t, err)
+
+		// Try to add a new pair that has the same real value as the
+		// first pair. This should fail.
+		err = tx.NewPair("real 1", "pseudo 2")
+		require.ErrorContains(t, err, "an entry already exists for "+
+			"real value")
+
+		// Try to add a new pair that has the same pseudo value as the
+		// first pair. This should fail.
+		err = tx.NewPair("real 2", "pseudo 1")
+		require.ErrorContains(t, err, "an entry already exists for "+
+			"pseudo value")
+
+		return nil
+	})
 }
 
 // TestPrivacyMapTxs tests that the `Update` and `View` functions correctly

--- a/rules/chan_policy_bounds.go
+++ b/rules/chan_policy_bounds.go
@@ -329,6 +329,8 @@ func (f *ChanPolicyBounds) PseudoToReal(_ firewalldb.PrivacyMapDB) (Values,
 // that should be persisted. This is a no-op for the ChanPolicyBounds rule.
 //
 // NOTE: this is part of the Values interface.
-func (f *ChanPolicyBounds) RealToPseudo() (Values, map[string]string, error) {
+func (f *ChanPolicyBounds) RealToPseudo(_ firewalldb.PrivacyMapReader) (Values,
+	map[string]string, error) {
+
 	return f, nil, nil
 }

--- a/rules/history_limit.go
+++ b/rules/history_limit.go
@@ -266,6 +266,8 @@ func (h *HistoryLimit) PseudoToReal(_ firewalldb.PrivacyMapDB) (Values,
 // that should be persisted. This is a no-op for the HistoryLimit rule.
 //
 // NOTE: this is part of the Values interface.
-func (h *HistoryLimit) RealToPseudo() (Values, map[string]string, error) {
+func (h *HistoryLimit) RealToPseudo(_ firewalldb.PrivacyMapReader) (Values,
+	map[string]string, error) {
+
 	return h, nil, nil
 }

--- a/rules/interfaces.go
+++ b/rules/interfaces.go
@@ -59,9 +59,11 @@ type Values interface {
 	ToProto() *litrpc.RuleValue
 
 	// RealToPseudo converts the rule Values to a new one that uses pseudo
-	// keys, channel IDs, channel points etc. It returns a map of real to
-	// pseudo strings that should be persisted.
-	RealToPseudo() (Values, map[string]string, error)
+	// keys, channel IDs, channel points etc. It returns a map of any new
+	// real to pseudo strings that should be persisted that it did not find
+	// in the given PrivacyMapReader.
+	RealToPseudo(db firewalldb.PrivacyMapReader) (Values, map[string]string,
+		error)
 
 	// PseudoToReal attempts to convert any appropriate pseudo fields in
 	// the rule Values to their corresponding real values. It uses the

--- a/rules/rate_limit.go
+++ b/rules/rate_limit.go
@@ -277,6 +277,8 @@ func (r *RateLimit) PseudoToReal(_ firewalldb.PrivacyMapDB) (Values,
 // that should be persisted. This is a no-op for the RateLimit rule.
 //
 // NOTE: this is part of the Values interface.
-func (r *RateLimit) RealToPseudo() (Values, map[string]string, error) {
+func (r *RateLimit) RealToPseudo(_ firewalldb.PrivacyMapReader) (Values,
+	map[string]string, error) {
+
 	return r, nil, nil
 }

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -838,11 +838,70 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 		return nil, fmt.Errorf("expiry must be in the future")
 	}
 
+	// If the privacy mapper is being used for this session, then we need
+	// to keep track of all our known privacy map pairs for this session
+	// along with any new pairs that we need to persist.
 	var (
 		privacy           = !req.NoPrivacyMapper
-		privacyMapPairs   = make(map[string]string)
 		knownPrivMapPairs = firewalldb.NewPrivacyMapPairs(nil)
+		newPrivMapPairs   = make(map[string]string)
 	)
+
+	// If a previous session ID has been set to link this new one to, we
+	// first check if we have the referenced session, and we make sure it
+	// has been revoked.
+	var (
+		linkedGroupID      *session.ID
+		linkedGroupSession *session.Session
+	)
+	if len(req.LinkedGroupId) != 0 {
+		var groupID session.ID
+		copy(groupID[:], req.LinkedGroupId)
+
+		// Check that the group actually does exist.
+		groupSess, err := s.cfg.db.GetSessionByID(groupID)
+		if err != nil {
+			return nil, err
+		}
+
+		// Ensure that the linked session is in fact the first session
+		// in its group.
+		if groupSess.ID != groupSess.GroupID {
+			return nil, fmt.Errorf("can not link to session "+
+				"%x since it is not the first in the session "+
+				"group %x", groupSess.ID, groupSess.GroupID)
+		}
+
+		// Now we need to check that all the sessions in the group are
+		// no longer active.
+		ok, err := s.cfg.db.CheckSessionGroupPredicate(
+			groupID, func(s *session.Session) bool {
+				return s.State == session.StateRevoked ||
+					s.State == session.StateExpired
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if !ok {
+			return nil, fmt.Errorf("a linked session in group "+
+				"%x is still active", groupID)
+		}
+
+		linkedGroupID = &groupID
+		linkedGroupSession = groupSess
+
+		privDB := s.cfg.privMap(groupID)
+		err = privDB.View(func(tx firewalldb.PrivacyMapTx) error {
+			knownPrivMapPairs, err = tx.FetchAllPairs()
+
+			return err
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	// First need to fetch all the perms that need to be baked into this
 	// mac based on the features.
@@ -892,8 +951,21 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 						return nil, err
 					}
 
+					// Store the new privacy map pairs in
+					// the newPrivMap pairs map so that
+					// they are later persisted to the real
+					// priv map db.
 					for k, v := range privMapPairs {
-						privacyMapPairs[k] = v
+						newPrivMapPairs[k] = v
+					}
+
+					// Also add the new pairs to the known
+					// set of pairs.
+					err = knownPrivMapPairs.Add(
+						privMapPairs,
+					)
+					if err != nil {
+						return nil, err
 					}
 				}
 
@@ -1017,52 +1089,6 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 		caveats = append(caveats, firewall.MetaPrivacyCaveat)
 	}
 
-	// If a previous session ID has been set to link this new one to, we
-	// first check if we have the referenced session, and we make sure it
-	// has been revoked.
-	var (
-		linkedGroupID      *session.ID
-		linkedGroupSession *session.Session
-	)
-	if len(req.LinkedGroupId) != 0 {
-		var groupID session.ID
-		copy(groupID[:], req.LinkedGroupId)
-
-		// Check that the group actually does exist.
-		groupSess, err := s.cfg.db.GetSessionByID(groupID)
-		if err != nil {
-			return nil, err
-		}
-
-		// Ensure that the linked session is in fact the first session
-		// in its group.
-		if groupSess.ID != groupSess.GroupID {
-			return nil, fmt.Errorf("can not link to session "+
-				"%x since it is not the first in the session "+
-				"group %x", groupSess.ID, groupSess.GroupID)
-		}
-
-		// Now we need to check that all the sessions in the group are
-		// no longer active.
-		ok, err := s.cfg.db.CheckSessionGroupPredicate(
-			groupID, func(s *session.Session) bool {
-				return s.State == session.StateRevoked ||
-					s.State == session.StateExpired
-			},
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		if !ok {
-			return nil, fmt.Errorf("a linked session in group "+
-				"%x is still active", groupID)
-		}
-
-		linkedGroupID = &groupID
-		linkedGroupSession = groupSess
-	}
-
 	s.sessRegMu.Lock()
 	defer s.sessRegMu.Unlock()
 
@@ -1101,7 +1127,7 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 	// Register all the privacy map pairs for this session ID.
 	privDB := s.cfg.privMap(sess.GroupID)
 	err = privDB.Update(func(tx firewalldb.PrivacyMapTx) error {
-		for r, p := range privacyMapPairs {
+		for r, p := range newPrivMapPairs {
 			err := tx.NewPair(r, p)
 			if err != nil {
 				return err

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -838,8 +838,11 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 		return nil, fmt.Errorf("expiry must be in the future")
 	}
 
-	privacy := !req.NoPrivacyMapper
-	privacyMapPairs := make(map[string]string)
+	var (
+		privacy           = !req.NoPrivacyMapper
+		privacyMapPairs   = make(map[string]string)
+		knownPrivMapPairs = firewalldb.NewPrivacyMapPairs(nil)
+	)
 
 	// First need to fetch all the perms that need to be baked into this
 	// mac based on the features.
@@ -882,7 +885,9 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 
 				if privacy {
 					var privMapPairs map[string]string
-					v, privMapPairs, err = v.RealToPseudo()
+					v, privMapPairs, err = v.RealToPseudo(
+						knownPrivMapPairs,
+					)
 					if err != nil {
 						return nil, err
 					}


### PR DESCRIPTION
In this PR, we ensure that if we are linking a session to a previous one, that we extract any existing real-to-pseudo pairs from the privacy map DB instead of generating new ones. 