### PR TITLE
Don't shutdown lit on accounts service critical error, and register to status server

### DIFF
--- a/accounts/checkers_test.go
+++ b/accounts/checkers_test.go
@@ -68,6 +68,12 @@ func (m *mockService) AssociateInvoice(id AccountID, hash lntypes.Hash) error {
 	return nil
 }
 
+func (m *mockService) AssociatePayment(id AccountID, paymentHash lntypes.Hash,
+	amt lnwire.MilliSatoshi) error {
+
+	return nil
+}
+
 func (m *mockService) TrackPayment(_ AccountID, hash lntypes.Hash,
 	amt lnwire.MilliSatoshi) error {
 

--- a/accounts/checkers_test.go
+++ b/accounts/checkers_test.go
@@ -85,6 +85,10 @@ func (m *mockService) RemovePayment(hash lntypes.Hash) error {
 	return nil
 }
 
+func (*mockService) IsRunning() bool {
+	return true
+}
+
 var _ Service = (*mockService)(nil)
 
 // TestAccountChecker makes sure all round trip checkers can be instantiated

--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -160,6 +160,12 @@ var (
 	ErrNotSupportedWithAccounts = errors.New("this RPC call is not " +
 		"supported with restricted account macaroons")
 
+	// ErrAccountServiceDisabled is the error that is returned when the
+	// account service has been disabled due to an error being thrown
+	// in the service that cannot be recovered from.
+	ErrAccountServiceDisabled = errors.New("the account service has been " +
+		"stopped")
+
 	// MacaroonPermissions are the permissions required for an account
 	// macaroon.
 	MacaroonPermissions = []bakery.Op{{
@@ -240,4 +246,7 @@ type Service interface {
 	// longer needs to be tracked. The payment is certain to never succeed,
 	// so we never need to debit the amount from the account.
 	RemovePayment(hash lntypes.Hash) error
+
+	// IsRunning returns true if the service can be used.
+	IsRunning() bool
 }

--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -247,6 +247,9 @@ type Service interface {
 	// so we never need to debit the amount from the account.
 	RemovePayment(hash lntypes.Hash) error
 
-	// IsRunning returns true if the service can be used.
-	IsRunning() bool
+	// AssociatePayment associates a payment (hash) with the given account,
+	// ensuring that the payment will be tracked for a user when LiT is
+	// restarted.
+	AssociatePayment(id AccountID, paymentHash lntypes.Hash,
+		fullAmt lnwire.MilliSatoshi) error
 }

--- a/accounts/rpcserver.go
+++ b/accounts/rpcserver.go
@@ -53,10 +53,6 @@ func (s *RPCServer) CreateAccount(ctx context.Context,
 	log.Infof("[createaccount] label=%v, balance=%d, expiration=%d",
 		req.Label, req.AccountBalance, req.ExpirationDate)
 
-	if !s.service.IsRunning() {
-		return nil, ErrAccountServiceDisabled
-	}
-
 	var (
 		balanceMsat    lnwire.MilliSatoshi
 		expirationDate time.Time
@@ -119,10 +115,6 @@ func (s *RPCServer) UpdateAccount(_ context.Context,
 	log.Infof("[updateaccount] id=%s, label=%v, balance=%d, expiration=%d",
 		req.Id, req.Label, req.AccountBalance, req.ExpirationDate)
 
-	if !s.service.IsRunning() {
-		return nil, ErrAccountServiceDisabled
-	}
-
 	accountID, err := s.findAccount(req.Id, req.Label)
 	if err != nil {
 		return nil, err
@@ -145,10 +137,6 @@ func (s *RPCServer) ListAccounts(context.Context,
 	*litrpc.ListAccountsRequest) (*litrpc.ListAccountsResponse, error) {
 
 	log.Info("[listaccounts]")
-
-	if !s.service.IsRunning() {
-		return nil, ErrAccountServiceDisabled
-	}
 
 	// Retrieve all accounts from the macaroon account store.
 	accts, err := s.service.Accounts()
@@ -175,10 +163,6 @@ func (s *RPCServer) AccountInfo(_ context.Context,
 
 	log.Infof("[accountinfo] id=%v, label=%v", req.Id, req.Label)
 
-	if !s.service.IsRunning() {
-		return nil, ErrAccountServiceDisabled
-	}
-
 	accountID, err := s.findAccount(req.Id, req.Label)
 	if err != nil {
 		return nil, err
@@ -198,10 +182,6 @@ func (s *RPCServer) RemoveAccount(_ context.Context,
 	error) {
 
 	log.Infof("[removeaccount] id=%v, label=%v", req.Id, req.Label)
-
-	if !s.service.IsRunning() {
-		return nil, ErrAccountServiceDisabled
-	}
 
 	accountID, err := s.findAccount(req.Id, req.Label)
 	if err != nil {

--- a/accounts/rpcserver.go
+++ b/accounts/rpcserver.go
@@ -53,6 +53,10 @@ func (s *RPCServer) CreateAccount(ctx context.Context,
 	log.Infof("[createaccount] label=%v, balance=%d, expiration=%d",
 		req.Label, req.AccountBalance, req.ExpirationDate)
 
+	if !s.service.IsRunning() {
+		return nil, ErrAccountServiceDisabled
+	}
+
 	var (
 		balanceMsat    lnwire.MilliSatoshi
 		expirationDate time.Time
@@ -115,6 +119,10 @@ func (s *RPCServer) UpdateAccount(_ context.Context,
 	log.Infof("[updateaccount] id=%s, label=%v, balance=%d, expiration=%d",
 		req.Id, req.Label, req.AccountBalance, req.ExpirationDate)
 
+	if !s.service.IsRunning() {
+		return nil, ErrAccountServiceDisabled
+	}
+
 	accountID, err := s.findAccount(req.Id, req.Label)
 	if err != nil {
 		return nil, err
@@ -137,6 +145,10 @@ func (s *RPCServer) ListAccounts(context.Context,
 	*litrpc.ListAccountsRequest) (*litrpc.ListAccountsResponse, error) {
 
 	log.Info("[listaccounts]")
+
+	if !s.service.IsRunning() {
+		return nil, ErrAccountServiceDisabled
+	}
 
 	// Retrieve all accounts from the macaroon account store.
 	accts, err := s.service.Accounts()
@@ -163,6 +175,10 @@ func (s *RPCServer) AccountInfo(_ context.Context,
 
 	log.Infof("[accountinfo] id=%v, label=%v", req.Id, req.Label)
 
+	if !s.service.IsRunning() {
+		return nil, ErrAccountServiceDisabled
+	}
+
 	accountID, err := s.findAccount(req.Id, req.Label)
 	if err != nil {
 		return nil, err
@@ -182,6 +198,10 @@ func (s *RPCServer) RemoveAccount(_ context.Context,
 	error) {
 
 	log.Infof("[removeaccount] id=%v, label=%v", req.Id, req.Label)
+
+	if !s.service.IsRunning() {
+		return nil, ErrAccountServiceDisabled
+	}
 
 	accountID, err := s.findAccount(req.Id, req.Label)
 	if err != nil {

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -16,6 +16,12 @@ import (
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
+// Config holds the configuration options for the accounts service.
+type Config struct {
+	// Disable will disable the accounts service if set.
+	Disable bool `long:"disable" description:"disable the accounts service"`
+}
+
 // trackedPayment is a struct that holds all information that identifies a
 // payment that we are tracking in the service.
 type trackedPayment struct {

--- a/accounts/service_test.go
+++ b/accounts/service_test.go
@@ -287,7 +287,7 @@ func TestAccountService(t *testing.T) {
 			err := s.store.UpdateAccount(acct)
 			require.NoError(t, err)
 
-			lnd.mainErrChan <- testErr
+			s.mainErrCallback(testErr)
 		},
 		validate: func(t *testing.T, lnd *mockLnd,
 			s *InterceptorService) {
@@ -672,9 +672,10 @@ func TestAccountService(t *testing.T) {
 			tt.Parallel()
 
 			lndMock := newMockLnd()
-			service, err := NewService(
-				t.TempDir(), lndMock.mainErrChan,
-			)
+			errFunc := func(err error) {
+				lndMock.mainErrChan <- err
+			}
+			service, err := NewService(t.TempDir(), errFunc)
 			require.NoError(t, err)
 
 			// Is a setup call required to initialize initial

--- a/accounts/service_test.go
+++ b/accounts/service_test.go
@@ -72,6 +72,18 @@ func (m *mockLnd) assertMainErr(t *testing.T, expectedErr error) {
 	}
 }
 
+// assertMainErrContains asserts that the main error contains the expected error
+// string.
+func (m *mockLnd) assertMainErrContains(t *testing.T, expectedStr string) {
+	select {
+	case err := <-m.mainErrChan:
+		require.ErrorContains(t, err, expectedStr)
+
+	case <-time.After(testTimeout):
+		t.Fatalf("Did not get expected main err before timeout")
+	}
+}
+
 func (m *mockLnd) assertNoInvoiceRequest(t *testing.T) {
 	select {
 	case req := <-m.invoiceReq:
@@ -201,7 +213,7 @@ func TestAccountService(t *testing.T) {
 			s *InterceptorService) {
 
 			lnd.assertInvoiceRequest(t, 0, 0)
-			lnd.assertMainErr(t, testErr)
+			lnd.assertMainErrContains(t, testErr.Error())
 		},
 	}, {
 		name: "startup do not track completed payments",

--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lightninglabs/faraday"
 	"github.com/lightninglabs/faraday/chain"
 	"github.com/lightninglabs/faraday/frdrpcserver"
+	"github.com/lightninglabs/lightning-terminal/accounts"
 	"github.com/lightninglabs/lightning-terminal/autopilotserver"
 	"github.com/lightninglabs/lightning-terminal/firewall"
 	mid "github.com/lightninglabs/lightning-terminal/rpcmiddleware"
@@ -205,6 +206,8 @@ type Config struct {
 
 	Firewall *firewall.Config `group:"Firewall options" namespace:"firewall"`
 
+	Accounts *accounts.Config `group:"Accounts options" namespace:"accounts"`
+
 	// faradayRpcConfig is a subset of faraday's full configuration that is
 	// passed into faraday's RPC server.
 	faradayRpcConfig *frdrpcserver.Config
@@ -320,6 +323,7 @@ func defaultConfig() *Config {
 			PingCadence: time.Hour,
 		},
 		Firewall: firewall.DefaultConfig(),
+		Accounts: &accounts.Config{},
 	}
 }
 

--- a/itest/litd_mode_remote_test.go
+++ b/itest/litd_mode_remote_test.go
@@ -67,7 +67,7 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					endpoint.requestFn,
 					endpoint.successPattern,
 					endpointEnabled,
-					"unknown request",
+					endpoint.disabledPattern,
 				)
 			})
 		}
@@ -94,7 +94,7 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					shouldFailWithoutMacaroon,
 					endpoint.successPattern,
 					endpointEnabled,
-					"unknown request",
+					endpoint.disabledPattern,
 				)
 			})
 		}
@@ -117,7 +117,8 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					ttt, cfg.LitAddr(), cfg.UIPassword,
 					endpoint.grpcWebURI, withoutUIPassword,
 					endpointEnabled,
-					"unknown request", endpoint.noAuth,
+					endpoint.disabledPattern,
+					endpoint.noAuth,
 				)
 			})
 		}
@@ -145,7 +146,7 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					endpoint.requestFn,
 					endpoint.successPattern,
 					endpointEnabled,
-					"unknown request",
+					endpoint.disabledPattern,
 				)
 			})
 		}
@@ -197,7 +198,9 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					endpoint.successPattern,
 					endpoint.allowedThroughLNC,
 					"unknown service",
-					endpointDisabled, endpoint.noAuth,
+					endpointDisabled,
+					endpoint.disabledPattern,
+					endpoint.noAuth,
 				)
 			})
 		}
@@ -248,6 +251,7 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 					endpoint.successPattern,
 					allowed, expectedErr,
 					endpointDisabled,
+					endpoint.disabledPattern,
 					endpoint.noAuth,
 				)
 			})
@@ -256,6 +260,12 @@ func remoteTestSuite(ctx context.Context, net *NetworkHarness, t *testing.T,
 
 	t.Run("gRPC super macaroon account system test", func(tt *testing.T) {
 		cfg := net.Bob.Cfg
+
+		// If the accounts service is disabled, we skip this test as it
+		// will fail due to the accounts service being disabled.
+		if subServersDisabled {
+			return
+		}
 
 		superMacFile, err := bakeSuperMacaroon(cfg, false)
 		require.NoError(tt, err)

--- a/rpc_proxy.go
+++ b/rpc_proxy.go
@@ -623,6 +623,9 @@ func (p *rpcProxy) checkSubSystemStarted(requestURI string) error {
 	switch {
 	case handled:
 
+	case isAccountsReq(requestURI):
+		system = subservers.ACCOUNTS
+
 	case p.permsMgr.IsSubServerURI(subservers.LIT, requestURI):
 		system = subservers.LIT
 
@@ -692,5 +695,15 @@ func isStatusReq(uri string) bool {
 func isProxyReq(uri string) bool {
 	return strings.HasPrefix(
 		uri, fmt.Sprintf("/%s", litrpc.Proxy_ServiceDesc.ServiceName),
+	)
+}
+
+// isAccountsReq returns true if the given request is intended for the
+// litrpc.Accounts service.
+func isAccountsReq(uri string) bool {
+	return strings.HasPrefix(
+		uri, fmt.Sprintf(
+			"/%s", litrpc.Accounts_ServiceDesc.ServiceName,
+		),
 	)
 }

--- a/subservers/subserver.go
+++ b/subservers/subserver.go
@@ -11,12 +11,13 @@ import (
 )
 
 const (
-	LND     string = "lnd"
-	LIT     string = "lit"
-	LOOP    string = "loop"
-	POOL    string = "pool"
-	TAP     string = "taproot-assets"
-	FARADAY string = "faraday"
+	LND      string = "lnd"
+	LIT      string = "lit"
+	LOOP     string = "loop"
+	POOL     string = "pool"
+	TAP      string = "taproot-assets"
+	FARADAY  string = "faraday"
+	ACCOUNTS string = "accounts"
 )
 
 // subServerWrapper is a wrapper around the SubServer interface and is used by


### PR DESCRIPTION
This PR is based on #541

In this PR we ensure that if the accounts service critically errors, we won't shutdown LiT, but instead log the error and reject any new requests to the accounts service.

We also add the accounts service to the status manager, and use the status from the status manager to determine if we should allow gRPC requests for the accounts service through or not.

Finally, we also add a config option to allow users to disable the accounts service, which ensures that the accounts service isn't started if the config option is set to `disable`.

TODO:
- [x] add tests 