### PR TITLE
accounts: fix service check in UpdateAccounts call

### DIFF
--- a/accounts/service.go
+++ b/accounts/service.go
@@ -305,7 +305,7 @@ func (s *InterceptorService) UpdateAccount(accountID AccountID, accountBalance,
 
 	// As this function updates account balances, we require that the
 	// service is running before we execute it.
-	if s.isRunningUnsafe() {
+	if !s.isRunningUnsafe() {
 		// This case can only happen if the service is disabled while
 		// we we're processing a request.
 		return nil, ErrAccountServiceDisabled


### PR DESCRIPTION
## Description

This PR fixes a simple check in the `UpdateAccount` RPC handler which checks if the service is running.