### PR TITLE
fix: add new v2 methods to custom permissions

### DIFF
--- a/app/src/util/constants.ts
+++ b/app/src/util/constants.ts
@@ -105,8 +105,10 @@ export const PermissionUriMap: { [key: string]: string[] } = {
     '/lnrpc.Lightning/SendCoins',
     '/lnrpc.Lightning/SendMany',
     '/lnrpc.Lightning/SendPayment',
+    '/lnrpc.Lightning/SendPaymentV2',
     '/lnrpc.Lightning/SendPaymentSync',
     '/lnrpc.Lightning/SendToRoute',
+    '/lnrpc.Lightning/SendToRouteV2',
     '/lnrpc.Lightning/SendToRouteSync',
   ],
   receive: [

--- a/app/src/util/constants.ts
+++ b/app/src/util/constants.ts
@@ -105,10 +105,10 @@ export const PermissionUriMap: { [key: string]: string[] } = {
     '/lnrpc.Lightning/SendCoins',
     '/lnrpc.Lightning/SendMany',
     '/lnrpc.Lightning/SendPayment',
-    '/lnrpc.Lightning/SendPaymentV2',
+    '/routerrpc.Router/SendPaymentV2',
     '/lnrpc.Lightning/SendPaymentSync',
     '/lnrpc.Lightning/SendToRoute',
-    '/lnrpc.Lightning/SendToRouteV2',
+    '/routerrpc.Router/SendToRouteV2',
     '/lnrpc.Lightning/SendToRouteSync',
   ],
   receive: [


### PR DESCRIPTION
I spoke with @jamaljsr and we noticed that some of the V2 methods are not currently included when setting custom permissions and the deprecated versions are. This would cause any applications using LNC with the V2 methods to get a permissions error even though the user granted permission for these values. Adding these will now support clients that are using the latest LND API versions.