### PR TITLE
linter: re-enable the linter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,9 +156,6 @@ jobs:
   # lint code
   ########################
   lint:
-    # Temporarily disabling the linter while this issue persists:
-    #       https://github.com/golangci/golangci-lint/discussions/1920
-    if: false
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/accounts/service_test.go
+++ b/accounts/service_test.go
@@ -65,16 +65,6 @@ func (m *mockLnd) assertNoMainErr(t *testing.T) {
 	}
 }
 
-func (m *mockLnd) assertMainErr(t *testing.T, expectedErr error) {
-	select {
-	case err := <-m.mainErrChan:
-		require.Equal(t, expectedErr, err)
-
-	case <-time.After(testTimeout):
-		t.Fatalf("Did not get expected main err before timeout")
-	}
-}
-
 // assertMainErrContains asserts that the main error contains the expected error
 // string.
 func (m *mockLnd) assertMainErrContains(t *testing.T, expectedStr string) {
@@ -408,7 +398,6 @@ func TestAccountService(t *testing.T) {
 			lnd.assertMainErrContains(
 				t, "not mapped to any account",
 			)
-
 		},
 	}, {
 		name: "err in payment update chan",

--- a/cmd/litcli/accounts.go
+++ b/cmd/litcli/accounts.go
@@ -40,19 +40,17 @@ var createAccountCommand = cli.Command{
 	ShortName: "c",
 	Usage:     "Create a new off-chain account with a balance.",
 	ArgsUsage: "balance [expiration_date] [--label=LABEL] [--save_to=FILE]",
-	Description: "Adds an entry to the account database. " +
-		"This entry represents an amount of satoshis (account " +
-		"balance) that can be spent using off-chain transactions " +
-		"(e.g. paying invoices).\n\n" +
+	Description: `Adds an entry to the account database.
+This entry represents an amount of satoshis (account balance) that can be spent
+using off-chain transactions (e.g. paying invoices).
 
-		"   Macaroons can be created to be locked to an account. " +
-		"This makes sure that the bearer of the macaroon can only " +
-		"spend at most that amount of satoshis through the daemon " +
-		"that has issued the macaroon.\n\n" +
+Macaroons can be created to be locked to an account. This makes sure that the
+bearer of the macaroon can only spend at most that amount of satoshis through
+the daemon that has issued the macaroon.
 
-		"   Accounts only assert a maximum amount spendable. Having " +
-		"a certain account balance does not guarantee that the node " +
-		"has the channel liquidity to actually spend that amount.",
+Accounts only assert a maximum amount spendable. Having a certain account
+balance does not guarantee that the node has the channel liquidity to actually
+spend that amount.`,
 	Flags: []cli.Flag{
 		cli.Uint64Flag{
 			Name:  "balance",
@@ -315,10 +313,10 @@ func accountInfo(ctx *cli.Context) error {
 }
 
 var removeAccountCommand = cli.Command{
-	Name:      "remove",
-	ShortName: "r",
-	Usage:     "Remove an off-chain account from the database.",
-	ArgsUsage: "[id | label]",
+	Name:        "remove",
+	ShortName:   "r",
+	Usage:       "Remove an off-chain account from the database.",
+	ArgsUsage:   "[id | label]",
 	Description: "Removes an account entry from the account database.",
 	Flags: []cli.Flag{
 		cli.StringFlag{

--- a/cmd/litcli/actions.go
+++ b/cmd/litcli/actions.go
@@ -10,10 +10,10 @@ import (
 )
 
 var listActionsCommand = cli.Command{
-	Name:   "actions",
-	Usage:  "List actions performed on the Litd server",
+	Name:     "actions",
+	Usage:    "List actions performed on the Litd server",
 	Category: "Firewall",
-	Action: listActions,
+	Action:   listActions,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "feature",

--- a/cmd/litcli/autopilot.go
+++ b/cmd/litcli/autopilot.go
@@ -28,11 +28,11 @@ var autopilotCommands = cli.Command{
 }
 
 var listAutopilotFeaturesCmd = cli.Command{
-	Name:      "features",
-	ShortName: "f",
-	Usage:     "List available Autopilot features.",
+	Name:        "features",
+	ShortName:   "f",
+	Usage:       "List available Autopilot features.",
 	Description: "List available Autopilot features.",
-	Action: listFeatures,
+	Action:      listFeatures,
 }
 
 var addAutopilotSessionCmd = cli.Command{
@@ -85,11 +85,11 @@ var addAutopilotSessionCmd = cli.Command{
 }
 
 var revokeAutopilotSessionCmd = cli.Command{
-	Name:      "revoke",
-	ShortName: "r",
-	Usage:     "Revoke an Autopilot session.",
+	Name:        "revoke",
+	ShortName:   "r",
+	Usage:       "Revoke an Autopilot session.",
 	Description: "Revoke an active Autopilot session.",
-	Action: revokeAutopilotSession,
+	Action:      revokeAutopilotSession,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "localpubkey",
@@ -101,11 +101,11 @@ var revokeAutopilotSessionCmd = cli.Command{
 }
 
 var listAutopilotSessionsCmd = cli.Command{
-	Name:      "list",
-	ShortName: "l",
-	Usage:     "List all Autopilot sessions.",
+	Name:        "list",
+	ShortName:   "l",
+	Usage:       "List all Autopilot sessions.",
 	Description: "List all Autopilot sessions.\n",
-	Action: listAutopilotSessions,
+	Action:      listAutopilotSessions,
 }
 
 func revokeAutopilotSession(ctx *cli.Context) error {

--- a/cmd/litcli/helpers.go
+++ b/cmd/litcli/helpers.go
@@ -17,7 +17,7 @@ var helperCommands = cli.Command{
 	Name:        "helper",
 	Usage:       "Helper commands",
 	Description: "Helper commands.",
-	Category:     "LiT",
+	Category:    "LiT",
 	Subcommands: []cli.Command{
 		generateSuperMacRootIDCmd,
 		isSuperMacaroonCmd,

--- a/cmd/litcli/sessions.go
+++ b/cmd/litcli/sessions.go
@@ -17,8 +17,8 @@ var (
 	defaultSessionExpiry = time.Hour * 24 * 90
 
 	labelFlag = cli.StringFlag{
-		Name: "label",
-		Usage: "The session label.",
+		Name:     "label",
+		Usage:    "The session label.",
 		Required: true,
 	}
 	expiryFlag = cli.Uint64Flag{

--- a/cmd/litcli/status.go
+++ b/cmd/litcli/status.go
@@ -14,7 +14,7 @@ var statusCommands = []cli.Command{
 		Usage:       "View info about litd status",
 		Description: "View info about litd status.\n",
 		Category:    "LiT",
-		Action:   getStatus,
+		Action:      getStatus,
 	},
 }
 


### PR DESCRIPTION
The linter was disabled before due to a bug. Since the bug was likely
caused by an issue with a go module in a dependency project which was
updated in the meantime, we attempt to re-enable the linter in the CI
now.