### PR TITLE
status: apply functional options on subServer init

### DIFF
--- a/status/manager.go
+++ b/status/manager.go
@@ -55,9 +55,15 @@ type subServer struct {
 
 // newSubServer constructs a new subServer.
 func newSubServer(disabled bool, opts ...SubServerOption) *subServer {
-	return &subServer{
+	s := &subServer{
 		disabled: disabled,
 	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
 }
 
 // Manager manages the status of any sub-server registered to it. It is also an


### PR DESCRIPTION
In #694 we added support for initialising the `subServer` struct with functional options. Unfortunately though, with the last refactors in the PR I forgot to also apply the functional options in `subServer` constructor function. Sorry for that, this was totally my bad! The current resulting behaviour is that the `litcli status` won't function as expected for `lnd`, while `lnd` Subserver is in the `WalletReady` state (until it enters the `Running` state).

This PR addresses the issue, and applies the functional options in the `subServer` constructor.