### PR TITLE
accounts + main: Allow new accounts with 0 balance

### DIFF
--- a/accounts/store.go
+++ b/accounts/store.go
@@ -107,10 +107,6 @@ func (s *BoltStore) NewAccount(balance lnwire.MilliSatoshi,
 	expirationDate time.Time, label string) (*OffChainBalanceAccount,
 	error) {
 
-	if balance == 0 {
-		return nil, fmt.Errorf("a new account cannot have balance of 0")
-	}
-
 	// If a label is set, it must be unique, as we use it to identify the
 	// account in some of the RPCs. It also can't be mistaken for a hex
 	// encoded account ID to avoid confusion and make it easier for the CLI

--- a/accounts/store_test.go
+++ b/accounts/store_test.go
@@ -16,13 +16,8 @@ func TestAccountStore(t *testing.T) {
 	store, err := NewBoltStore(t.TempDir(), DBFilename)
 	require.NoError(t, err)
 
-	// An initial balance of 0 is not allowed, but later we can reach a
-	// zero balance.
-	_, err = store.NewAccount(0, time.Time{}, "")
-	require.ErrorContains(t, err, "cannot have balance of 0")
-
 	// Create an account that does not expire.
-	acct1, err := store.NewAccount(123, time.Time{}, "foo")
+	acct1, err := store.NewAccount(0, time.Time{}, "foo")
 	require.NoError(t, err)
 	require.False(t, acct1.HasExpired())
 

--- a/cmd/litcli/accounts.go
+++ b/cmd/litcli/accounts.go
@@ -114,10 +114,6 @@ func createAccount(ctx *cli.Context) error {
 		args = args.Tail()
 	}
 
-	if initialBalance <= 0 {
-		return fmt.Errorf("initial balance cannot be smaller than 1")
-	}
-
 	req := &litrpc.CreateAccountRequest{
 		AccountBalance: initialBalance,
 		ExpirationDate: expirationDate,


### PR DESCRIPTION
This PR updates the `accounts` subsystem to allow creation of accounts with an initial balance set to 0.
As accounts can now receive balance through settled invoices during the lifecycle of the account, it makes sense that we'd allow creation of accounts with an initial balance of 0.