### PR TITLE
accounts: address `pendingPayments` issues

### DIFF
--- a/accounts/checkers.go
+++ b/accounts/checkers.go
@@ -398,6 +398,30 @@ func NewAccountChecker(service Service,
 	}
 }
 
+// handleErrorResponse passes an error to a checker if the checker has
+// registered an error handler.
+func (a *AccountChecker) handleErrorResponse(ctx context.Context,
+	fullUri string, parsedErr error) (error, error) {
+
+	// If we don't have a handler for the URI, it means we don't support
+	// that RPC.
+	checker, ok := a.checkers[fullUri]
+	if !ok {
+		return nil, ErrNotSupportedWithAccounts
+	}
+
+	newErr, err := checker.HandleErrorResponse(ctx, parsedErr)
+	if err != nil {
+		return nil, err
+	}
+
+	if newErr != nil {
+		parsedErr = newErr
+	}
+
+	return parsedErr, nil
+}
+
 // checkIncomingRequest makes sure the type of incoming call is supported and
 // if it is, that it is allowed with the current account balance.
 func (a *AccountChecker) checkIncomingRequest(ctx context.Context,

--- a/accounts/checkers.go
+++ b/accounts/checkers.go
@@ -522,12 +522,7 @@ func checkSend(ctx context.Context, chainParams *chaincfg.Params,
 	service Service, amt, amtMsat int64, invoice string,
 	paymentHash []byte, feeLimit *lnrpc.FeeLimit) error {
 
-	acct, err := AccountFromContext(ctx)
-	if err != nil {
-		return err
-	}
-
-	reqID, err := RequestIDFromContext(ctx)
+	log, acct, reqID, err := requestScopedValuesFromCtx(ctx)
 	if err != nil {
 		return err
 	}
@@ -583,6 +578,9 @@ func checkSend(ctx context.Context, chainParams *chaincfg.Params,
 	if pHash == emptyHash {
 		return fmt.Errorf("a payment hash is required")
 	}
+
+	log.Tracef("Handling send request for payment with hash: %s and "+
+		"amount: %d", pHash, sendAmt)
 
 	// We also add the max fee to the amount to check. This might mean that
 	// not every single satoshi of an account can be used up. But it
@@ -642,17 +640,12 @@ func checkSendResponse(ctx context.Context, service Service,
 func checkSendToRoute(ctx context.Context, service Service, paymentHash []byte,
 	route *lnrpc.Route) error {
 
-	acct, err := AccountFromContext(ctx)
+	log, acct, reqID, err := requestScopedValuesFromCtx(ctx)
 	if err != nil {
 		return err
 	}
 
 	hash, err := lntypes.MakeHash(paymentHash)
-	if err != nil {
-		return err
-	}
-
-	reqID, err := RequestIDFromContext(ctx)
 	if err != nil {
 		return err
 	}
@@ -665,6 +658,9 @@ func checkSendToRoute(ctx context.Context, service Service, paymentHash []byte,
 	if lnwire.MilliSatoshi(route.TotalAmtMsat) > sendAmt {
 		sendAmt = lnwire.MilliSatoshi(route.TotalAmtMsat)
 	}
+
+	log.Tracef("Handling send request for payment with hash: %s and "+
+		"amount: %d", hash, sendAmt)
 
 	// We also add the max fee to the amount to check. This might mean that
 	// not every single satoshi of an account can be used up. But it

--- a/accounts/checkers_test.go
+++ b/accounts/checkers_test.go
@@ -42,13 +42,16 @@ type mockService struct {
 
 	trackedInvoices map[lntypes.Hash]AccountID
 	trackedPayments AccountPayments
+
+	*requestValuesStore
 }
 
 func newMockService() *mockService {
 	return &mockService{
-		acctBalanceMsat: 0,
-		trackedInvoices: make(map[lntypes.Hash]AccountID),
-		trackedPayments: make(AccountPayments),
+		acctBalanceMsat:    0,
+		trackedInvoices:    make(map[lntypes.Hash]AccountID),
+		trackedPayments:    make(AccountPayments),
+		requestValuesStore: newRequestValuesStore(),
 	}
 }
 

--- a/accounts/checkers_test.go
+++ b/accounts/checkers_test.go
@@ -112,6 +112,8 @@ func TestAccountChecker(t *testing.T) {
 func TestAccountCheckers(t *testing.T) {
 	t.Parallel()
 
+	const reqID = uint64(55)
+
 	testCases := []struct {
 		name    string
 		fullURI string
@@ -416,9 +418,8 @@ func TestAccountCheckers(t *testing.T) {
 				Invoices: make(AccountInvoices),
 				Payments: make(AccountPayments),
 			}
-			ctx := AddToContext(
-				context.Background(), KeyAccount, acct,
-			)
+			ctx := AddAccountToContext(context.Background(), acct)
+			ctx = AddRequestIDToContext(ctx, reqID)
 
 			// Is a setup call required to initialize initial
 			// conditions?

--- a/accounts/checkers_test.go
+++ b/accounts/checkers_test.go
@@ -80,6 +80,10 @@ func (m *mockService) AssociatePayment(id AccountID, paymentHash lntypes.Hash,
 	return nil
 }
 
+func (m *mockService) PaymentErrored(id AccountID, hash lntypes.Hash) error {
+	return nil
+}
+
 func (m *mockService) TrackPayment(_ AccountID, hash lntypes.Hash,
 	amt lnwire.MilliSatoshi) error {
 

--- a/accounts/checkers_test.go
+++ b/accounts/checkers_test.go
@@ -25,7 +25,10 @@ var (
 	}
 
 	testID   = AccountID{77, 88, 99}
-	testHash = lntypes.Hash{1, 2, 3, 4, 5}
+	testHash = lntypes.Hash{
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+	}
 
 	testAmount = &lnrpc.Amount{
 		Sat:  456,
@@ -207,7 +210,8 @@ func TestAccountCheckers(t *testing.T) {
 		name:    "send payment, not enough balance",
 		fullURI: "/lnrpc.Lightning/SendPaymentSync",
 		originalRequest: &lnrpc.SendRequest{
-			AmtMsat: 5000,
+			AmtMsat:     5000,
+			PaymentHash: testHash[:],
 		},
 		requestErr: "error validating account balance: invalid balance",
 	}, {
@@ -223,6 +227,7 @@ func TestAccountCheckers(t *testing.T) {
 					Percent: 1,
 				},
 			},
+			PaymentHash: testHash[:],
 		},
 		requestErr: "error validating account balance: invalid balance",
 	}, {
@@ -238,6 +243,7 @@ func TestAccountCheckers(t *testing.T) {
 					FixedMsat: 123,
 				},
 			},
+			PaymentHash: testHash[:],
 		},
 		originalResponse: &lnrpc.SendResponse{
 			PaymentHash: testHash[:],

--- a/accounts/context.go
+++ b/accounts/context.go
@@ -18,6 +18,10 @@ var (
 	// KeyAccount is the key under which we store the account in the request
 	// context.
 	KeyAccount = ContextKey{"account"}
+
+	// KeyRequestID is the key under which we store the middleware request
+	// ID.
+	KeyRequestID = ContextKey{"request_id"}
 )
 
 // FromContext tries to extract a value from the given context.
@@ -25,11 +29,12 @@ func FromContext(ctx context.Context, key ContextKey) interface{} {
 	return ctx.Value(key)
 }
 
-// AddToContext adds the given value to the context for easy retrieval later on.
-func AddToContext(ctx context.Context, key ContextKey,
+// AddAccountToContext adds the given value to the context for easy retrieval
+// later on.
+func AddAccountToContext(ctx context.Context,
 	value *OffChainBalanceAccount) context.Context {
 
-	return context.WithValue(ctx, key, value)
+	return context.WithValue(ctx, KeyAccount, value)
 }
 
 // AccountFromContext attempts to extract an account from the given context.
@@ -45,4 +50,25 @@ func AccountFromContext(ctx context.Context) (*OffChainBalanceAccount, error) {
 	}
 
 	return acct, nil
+}
+
+// AddRequestIDToContext adds the given request ID to the context for easy
+// retrieval later on.
+func AddRequestIDToContext(ctx context.Context, value uint64) context.Context {
+	return context.WithValue(ctx, KeyRequestID, value)
+}
+
+// RequestIDFromContext attempts to extract a request ID from the given context.
+func RequestIDFromContext(ctx context.Context) (uint64, error) {
+	val := FromContext(ctx, KeyRequestID)
+	if val == nil {
+		return 0, fmt.Errorf("no request ID found in context")
+	}
+
+	reqID, ok := val.(uint64)
+	if !ok {
+		return 0, fmt.Errorf("invalid request ID value in context")
+	}
+
+	return reqID, nil
 }

--- a/accounts/context.go
+++ b/accounts/context.go
@@ -3,6 +3,9 @@ package accounts
 import (
 	"context"
 	"fmt"
+
+	"github.com/btcsuite/btclog"
+	"github.com/lightningnetwork/lnd/build"
 )
 
 // ContextKey is the type that we use to identify account specific values in the
@@ -71,4 +74,26 @@ func RequestIDFromContext(ctx context.Context) (uint64, error) {
 	}
 
 	return reqID, nil
+}
+
+// requestScopedValuesFromCtx is a helper function that can be used to extract
+// an account and requestID from the given context. It also creates a new
+// prefixed logger that can be used by account request and response handlers.
+// Each log line will be prefixed by the account ID and the request ID.
+func requestScopedValuesFromCtx(ctx context.Context) (btclog.Logger,
+	*OffChainBalanceAccount, uint64, error) {
+
+	acc, err := AccountFromContext(ctx)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	reqID, err := RequestIDFromContext(ctx)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	prefix := fmt.Sprintf("[account: %s, request: %d]", acc.ID, reqID)
+
+	return build.NewPrefixLog(prefix, log), acc, reqID, nil
 }

--- a/accounts/interceptor.go
+++ b/accounts/interceptor.go
@@ -101,9 +101,10 @@ func (s *InterceptorService) Intercept(ctx context.Context,
 		)
 	}
 
-	// We now add the account to the incoming context to give each checker
-	// access to it if required.
-	ctxAccount := AddToContext(ctx, KeyAccount, acct)
+	// We now add the account and request ID to the incoming context to give
+	// each checker access to them if required.
+	ctx = AddAccountToContext(ctx, acct)
+	ctx = AddRequestIDToContext(ctx, req.RequestId)
 
 	switch r := req.InterceptType.(type) {
 	// In the authentication phase we just check that the account hasn't
@@ -120,7 +121,7 @@ func (s *InterceptorService) Intercept(ctx context.Context,
 		}
 
 		return mid.RPCErr(req, s.checkers.checkIncomingRequest(
-			ctxAccount, r.Request.MethodFullUri, msg,
+			ctx, r.Request.MethodFullUri, msg,
 		))
 
 	// Parse and possibly manipulate outgoing responses.
@@ -131,7 +132,7 @@ func (s *InterceptorService) Intercept(ctx context.Context,
 		}
 
 		replacement, err := s.checkers.replaceOutgoingResponse(
-			ctxAccount, r.Response.MethodFullUri, msg,
+			ctx, r.Response.MethodFullUri, msg,
 		)
 		if err != nil {
 			return mid.RPCErr(req, err)

--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -258,6 +258,11 @@ type Service interface {
 	AssociatePayment(id AccountID, paymentHash lntypes.Hash,
 		fullAmt lnwire.MilliSatoshi) error
 
+	// PaymentErrored removes a pending payment from the accounts
+	// registered payment list. This should only ever be called if we are
+	// sure that the payment request errored out.
+	PaymentErrored(id AccountID, hash lntypes.Hash) error
+
 	RequestValuesStore
 }
 

--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -252,4 +252,33 @@ type Service interface {
 	// restarted.
 	AssociatePayment(id AccountID, paymentHash lntypes.Hash,
 		fullAmt lnwire.MilliSatoshi) error
+
+	RequestValuesStore
+}
+
+// RequestValues holds various values associated with a specific request that
+// we may want access to when handling the response. At the moment this only
+// stores payment related data.
+type RequestValues struct {
+	// PaymentHash is the hash of the payment that this request is
+	// associated with.
+	PaymentHash lntypes.Hash
+
+	// PaymentAmount is the value of the payment being made.
+	PaymentAmount lnwire.MilliSatoshi
+}
+
+// RequestValuesStore is a store that can be used to keep track of the mapping
+// between a request ID and various values associated with that request which
+// we may want access to when handling the request response.
+type RequestValuesStore interface {
+	// RegisterValues stores values for the given request ID.
+	RegisterValues(reqID uint64, values *RequestValues) error
+
+	// GetValues returns the corresponding request values for the given
+	// request ID if they exist.
+	GetValues(reqID uint64) (*RequestValues, bool)
+
+	// DeleteValues deletes any values stored for the given request ID.
+	DeleteValues(reqID uint64)
 }

--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -53,6 +53,11 @@ func ParseAccountID(idStr string) (*AccountID, error) {
 	return &id, nil
 }
 
+// String returns the string representation of the AccountID.
+func (a AccountID) String() string {
+	return hex.EncodeToString(a[:])
+}
+
 // PaymentEntry is the data we track per payment that is associated with an
 // account. This basically includes all information required to make sure
 // in-flight payments don't exceed the total available account balance.

--- a/accounts/log.go
+++ b/accounts/log.go
@@ -5,7 +5,7 @@ import (
 	"github.com/lightningnetwork/lnd/build"
 )
 
-const Subsystem = "ACCT"
+const Subsystem = "ACNT"
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -406,8 +406,13 @@ func (s *InterceptorService) CheckBalance(id AccountID,
 	}
 
 	var inFlightAmt int64
-	for _, pendingPayment := range s.pendingPayments {
-		inFlightAmt += int64(pendingPayment.fullAmount)
+	for _, payment := range account.Payments {
+		if inflightState(payment.Status) {
+			// If a payment is in-flight and associated with the
+			// account, the user should not be able to spend that
+			// amount while it's in-flight.
+			inFlightAmt += int64(payment.FullAmount)
+		}
 	}
 
 	availableAmount := account.CurrentBalance - inFlightAmt

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -764,9 +764,7 @@ func (s *InterceptorService) paymentUpdate(hash lntypes.Hash,
 	// Are we still in-flight? Then we don't have to do anything just yet.
 	// The unknown state should never happen in practice but if it ever did
 	// we couldn't handle it anyway, so let's also ignore it.
-	if status.State == lnrpc.Payment_IN_FLIGHT ||
-		status.State == lnrpc.Payment_UNKNOWN {
-
+	if inflightState(status.State) {
 		return false, nil
 	}
 
@@ -886,6 +884,13 @@ func (s *InterceptorService) removePayment(hash lntypes.Hash,
 // successState returns true if a payment was completed successfully.
 func successState(status lnrpc.Payment_PaymentStatus) bool {
 	return status == lnrpc.Payment_SUCCEEDED
+}
+
+// inflightState returns true if a payment should be seen as in-flight by the
+// accounts system.
+func inflightState(status lnrpc.Payment_PaymentStatus) bool {
+	return status != lnrpc.Payment_SUCCEEDED &&
+		status != lnrpc.Payment_FAILED
 }
 
 // requestValuesStore is an in-memory implementation of the

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -729,6 +729,20 @@ func (s *InterceptorService) TrackPayment(id AccountID, hash lntypes.Hash,
 					log.Debugf("Payment %v not initiated, "+
 						"stopping tracking", hash)
 
+					// We also remove the payment from the
+					// account, so that the payment won't be
+					// seen as in-flight balance when
+					// calculating the account's available
+					// balance.
+					err := s.RemovePayment(hash)
+					if err != nil {
+						// We don't disable the service
+						// here, as the worst that can
+						// happen is that the payment is
+						// seen as still in-flight.
+						s.mainErrCallback(err)
+					}
+
 					return
 				}
 

--- a/rpcmiddleware/interface.go
+++ b/rpcmiddleware/interface.go
@@ -35,7 +35,9 @@ var (
 
 	// PassThroughErrorHandler is an ErrorHandler that does not modify an
 	// error and instead just passes it through.
-	PassThroughErrorHandler ErrorHandler = func(error) (error, error) {
+	PassThroughErrorHandler ErrorHandler = func(context.Context, error) (
+		error, error) {
+
 		return nil, nil
 	}
 
@@ -81,7 +83,7 @@ type messageHandler func(context.Context, proto.Message) (proto.Message, error)
 // pass through the error unchanged (=return nil, nil), replace the error with
 // a different one (=return non-nil error, nil error) or abort by returning a
 // non-nil error.
-type ErrorHandler func(respErr error) (error, error)
+type ErrorHandler func(ctx context.Context, respErr error) (error, error)
 
 // RoundTripChecker is a type that represents a basic request/response round
 // trip checker.
@@ -115,7 +117,7 @@ type RoundTripChecker interface {
 	// The handler can pass through the error (=return nil, nil), replace
 	// the response error with a new one (=return non-nil error, nil) or
 	// abort by returning a non nil error (=return nil, non-nil error).
-	HandleErrorResponse(error) (error, error)
+	HandleErrorResponse(context.Context, error) (error, error)
 }
 
 // DefaultChecker is the default implementation of a round trip checker.
@@ -171,8 +173,10 @@ func (r *DefaultChecker) HandleResponse(ctx context.Context,
 // The handler can pass through the error (=return nil, nil), replace
 // the response error with a new one (=return non-nil error, nil) or
 // abort by returning a non nil error (=return nil, non-nil error).
-func (r *DefaultChecker) HandleErrorResponse(respErr error) (error, error) {
-	return r.errorHandler(respErr)
+func (r *DefaultChecker) HandleErrorResponse(ctx context.Context,
+	respErr error) (error, error) {
+
+	return r.errorHandler(ctx, respErr)
 }
 
 // NewPassThrough returns a round trip checker that allows the incoming request


### PR DESCRIPTION
This PR addresses two issues with the `pendingPayments` map handling in the accounts system.

1. Prior to this PR, we would deduct any pending payments as in-flight payments from an account's total balance when calculating the available balance, even if the pending payments were not initiated by the specific account itself. This PR adds an ID check to only deduct pending payments that are actually associated with the account.
2. If a payment with status `UNKNOWN` turns out to be uninitiated, we should remove it from the `pendingPayments` map. This ensures that the payment is not considered when calculating the in-flight balance for the account.