### PR TITLE
firewalldb: fetch correct bucket for session level temp KV store

### DIFF
--- a/firewalldb/kvstores.go
+++ b/firewalldb/kvstores.go
@@ -9,8 +9,11 @@ import (
 
 /*
 The KVStores are stored in the following structure in the KV db. Note that
-the `perm` and `temp` buckets are identical in structure. The only difference is
-that the `temp` bucket is cleared on restart of the db.
+the `perm` and `temp` buckets are identical in structure. The only difference
+is that the `temp` bucket is cleared on restart of the db. The reason persisting
+the temporary store changes instead of just keeping an in-memory store is that
+we can then guarantee idempotency if changes are made to both the permanent and
+temporary stores.
 
 rules -> perm -> rule-name -> global   -> {k:v}
               -> sessions -> group ID  -> session-kv-store  -> {k:v}
@@ -81,11 +84,17 @@ type KVStoreTx interface {
 	Local() KVStore
 
 	// GlobalTemp is similar to the Global store except that its contents
-	// is cleared upon restart of the database.
+	// is cleared upon restart of the database. The reason persisting the
+	// temporary store changes instead of just keeping an in-memory store is
+	// that we can then guarantee idempotency if changes are made to both
+	// the permanent and temporary stores.
 	GlobalTemp() KVStore
 
 	// LocalTemp is similar to the Local store except that its contents is
-	// cleared upon restart of the database.
+	// cleared upon restart of the database. The reason persisting the
+	// temporary store changes instead of just keeping an in-memory store is
+	// that we can then guarantee idempotency if changes are made to both
+	// the permanent and temporary stores.
 	LocalTemp() KVStore
 }
 

--- a/firewalldb/kvstores.go
+++ b/firewalldb/kvstores.go
@@ -268,7 +268,7 @@ func (tx *kvStoreTx) GlobalTemp() KVStore {
 //
 // NOTE: this is part of the KVStoreTx interface.
 func (tx *kvStoreTx) LocalTemp() KVStore {
-	fn := getSessionRuleBucket(true, tx.ruleName, tx.groupID)
+	fn := getSessionRuleBucket(false, tx.ruleName, tx.groupID)
 	if tx.featureName != "" {
 		fn = getSessionFeatureRuleBucket(
 			false, tx.ruleName, tx.groupID, tx.featureName,


### PR DESCRIPTION
In this commit, we fix a bug which would result in the "perm" store being used for the LocalTemp KV DB _if and only if_ the KV store being requested was a session level one (as opposed to a session feature level one). It is ok for us to just change this here since as of this commit, the session level KV store is not used at all and so nothing will be in that store yet.