### PR TITLE
itest: add breach itest for custom channels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,8 @@ require (
 	github.com/lightninglabs/loop/swapserverrpc v1.0.8
 	github.com/lightninglabs/pool v0.6.5-beta.0.20240604070222-e121aadb3289
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.2
-	github.com/lightninglabs/taproot-assets v0.3.3-0.20240621202612-eae23c4f77e8
-	github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240621222000-c6e4d621d2b0
+	github.com/lightninglabs/taproot-assets v0.3.3-0.20240625161215-838206d62c99
+	github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240625154246-4e968d9b520c
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/fn v1.1.0
 	github.com/lightningnetwork/lnd/kvdb v1.4.8
@@ -227,3 +227,5 @@ replace github.com/lightninglabs/lightning-terminal/autopilotserverrpc => ./auto
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
 
 go 1.22.3
+
+toolchain go1.22.4

--- a/go.sum
+++ b/go.sum
@@ -1172,12 +1172,12 @@ github.com/lightninglabs/pool/auctioneerrpc v1.1.2 h1:Dbg+9Z9jXnhimR27EN37foc4aB
 github.com/lightninglabs/pool/auctioneerrpc v1.1.2/go.mod h1:1wKDzN2zEP8srOi0B9iySlEsPdoPhw6oo3Vbm1v4Mhw=
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display h1:pRdza2wleRN1L2fJXd6ZoQ9ZegVFTAb2bOQfruJPKcY=
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-github.com/lightninglabs/taproot-assets v0.3.3-0.20240621202612-eae23c4f77e8 h1:bjdVqtwUirxbi8mkq86oo4Q9WqFnfadzwnxTXNhAtoQ=
-github.com/lightninglabs/taproot-assets v0.3.3-0.20240621202612-eae23c4f77e8/go.mod h1:FAmcLipYgjm2jpqI2fiSOax8Oah/pekkGLfhJc6dwD0=
+github.com/lightninglabs/taproot-assets v0.3.3-0.20240625161215-838206d62c99 h1:eMWI/Ob3Gv+7dHs7b9WA9Rpsvc32w4jPj+iKQ6+lD4s=
+github.com/lightninglabs/taproot-assets v0.3.3-0.20240625161215-838206d62c99/go.mod h1:KhiaNUkgI3zIYNzfUoEClJjInXt5vScmnLVIvuUzWXY=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f h1:Pua7+5TcFEJXIIZ1I2YAUapmbcttmLj4TTi786bIi3s=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240621222000-c6e4d621d2b0 h1:v72KQn3kiNmPICIYsZSRnBdnDZpOQ3CUNc20E7v3Z3M=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240621222000-c6e4d621d2b0/go.mod h1:L3IArArdRrWtuw+wNsUlibuGmf/08Odsm/zo3+bPXuM=
+github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240625154246-4e968d9b520c h1:10hVKzgsnpuzOOgkYAhThUtDiq3fBBJBeZWdir+0ptk=
+github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240625154246-4e968d9b520c/go.mod h1:L3IArArdRrWtuw+wNsUlibuGmf/08Odsm/zo3+bPXuM=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=

--- a/itest/litd_node.go
+++ b/itest/litd_node.go
@@ -89,6 +89,9 @@ type LitNodeConfig struct {
 
 	LitPort     int
 	LitRESTPort int
+
+	// backupDBDir is the path where a database backup is stored, if any.
+	backupDBDir string
 }
 
 func (cfg *LitNodeConfig) LitAddr() string {
@@ -2061,4 +2064,39 @@ func connectLitRPC(ctx context.Context, hostPort, tlsCertPath,
 	}
 
 	return grpc.DialContext(ctx, hostPort, opts...)
+}
+
+// copyAll copies all files and directories from srcDir to dstDir recursively.
+// Note that this function does not support links.
+func copyAll(dstDir, srcDir string) error {
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(srcDir, entry.Name())
+		dstPath := filepath.Join(dstDir, entry.Name())
+
+		info, err := os.Stat(srcPath)
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			err := os.Mkdir(dstPath, info.Mode())
+			if err != nil && !os.IsExist(err) {
+				return err
+			}
+
+			err = copyAll(dstPath, srcPath)
+			if err != nil {
+				return err
+			}
+		} else if err := CopyFile(dstPath, srcPath); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/itest/litd_test_list_on_test.go
+++ b/itest/litd_test_list_on_test.go
@@ -28,4 +28,8 @@ var allTestCases = []*testCase{
 		name: "test custom channels force close",
 		test: testCustomChannelsForceClose,
 	},
+	{
+		name: "test custom channels breach",
+		test: testCustomChannelsBreach,
+	},
 }


### PR DESCRIPTION
In this commit, we add a breach itest for the custom channels. The scenario is as follows:
   * Two nodes: Charlie and Dave. 
   * Charlie does asset keysends to Dave. 
   * Dave snapshots his database. 
   * Charlie sends another keysend. 
   * Dave breaches. 
   * Charlie sweeps both asset UTXOs into a new anchor output after the breach confirms.