### PR TITLE
Bump litd to version `v0.13.1-alpha`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ in remote mode (meaning that `lnd-mode=remote` is set). It shows the
 
 | LiT               | LND          |
 |-------------------|--------------|
+| **v0.13.1-alpha** | v0.17.0-beta |
 | **v0.13.0-alpha** | v0.17.0-beta |
 | **v0.12.5-alpha** | v0.17.0-beta |
 | **v0.12.4-alpha** | v0.17.0-beta |
@@ -156,6 +157,7 @@ The following table shows the supported combinations:
 
 | LiT               | LND          | Loop         | Faraday       | Pool         | Taproot Assets |
 |-------------------|--------------|--------------|---------------|--------------|----------------|
+| **v0.13.1-alpha** | v0.18.1-beta | v0.28.5-beta | v0.2.13-alpha | v0.6.5-beta  | v0.3.3-alpha   |
 | **v0.13.0-alpha** | v0.18.0-beta | v0.28.5-beta | v0.2.13-alpha | v0.6.5-beta  | v0.3.3-alpha   |
 | **v0.12.5-alpha** | v0.17.5-beta | v0.28.1-beta | v0.2.13-alpha | v0.6.4-beta  | v0.3.3-alpha   |
 | **v0.12.4-alpha** | v0.17.4-beta | v0.28.0-beta | v0.2.13-alpha | v0.6.4-beta  | v0.3.3-alpha   |

--- a/docs/release-notes/release-notes-0.13.1.md
+++ b/docs/release-notes/release-notes-0.13.1.md
@@ -3,20 +3,11 @@
 # Integrated Binary Updates
 
 ### LND
+  * [Update the integrated LND version to v0.18.1-beta](https://github.com/lightninglabs/lightning-terminal/pull/783) 
 ### Loop
 ### Pool
 ### Faraday
 ### Taproot Assets
-
-# Autopilot 
-
-# Accounts
-
-# Architectural Updates
-
-# Bug Fixes
-
-# `litcli` Updates
 
 # Misc
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/lightninglabs/lightning-terminal
 
 require (
-	github.com/btcsuite/btcd v0.24.2-beta.rc1.0.20240403021926-ae5533602c46
+	github.com/btcsuite/btcd v0.24.2
 	github.com/btcsuite/btcd/btcec/v2 v2.3.3
 	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
@@ -20,7 +20,7 @@ require (
 	github.com/lightninglabs/pool v0.6.5-beta.0.20240531084722-4000ec802aaa
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.2
 	github.com/lightninglabs/taproot-assets v0.3.4-0.20240531080458-69ff7704168c
-	github.com/lightningnetwork/lnd v0.18.0-beta.1
+	github.com/lightningnetwork/lnd v0.18.1-beta
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/kvdb v1.4.8
 	github.com/lightningnetwork/lnd/tlv v1.2.6
@@ -51,7 +51,7 @@ require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.8 // indirect
-	github.com/btcsuite/btcwallet v0.16.10-0.20240410030101-6fe19a472a62 // indirect
+	github.com/btcsuite/btcwallet v0.16.10-0.20240625163855-b42ed59f0528 // indirect
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.4 // indirect
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.1 // indirect
 	github.com/btcsuite/btcwallet/wallet/txsizes v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -649,8 +649,8 @@ github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=
-github.com/btcsuite/btcd v0.24.2-beta.rc1.0.20240403021926-ae5533602c46 h1:tjpNTdZNQqE14menwDGAxWfzN0DFHVTXFEyEL8yvA/4=
-github.com/btcsuite/btcd v0.24.2-beta.rc1.0.20240403021926-ae5533602c46/go.mod h1:5C8ChTkl5ejr3WHj8tkQSCmydiMEPB0ZhQhehpq7Dgg=
+github.com/btcsuite/btcd v0.24.2 h1:aLmxPguqxza+4ag8R1I2nnJjSu2iFn/kqtHTIImswcY=
+github.com/btcsuite/btcd v0.24.2/go.mod h1:5C8ChTkl5ejr3WHj8tkQSCmydiMEPB0ZhQhehpq7Dgg=
 github.com/btcsuite/btcd/btcec/v2 v2.1.0/go.mod h1:2VzYrv4Gm4apmbVVsSq5bqf1Ec8v56E48Vt0Y/umPgA=
 github.com/btcsuite/btcd/btcec/v2 v2.1.3/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
 github.com/btcsuite/btcd/btcec/v2 v2.3.3 h1:6+iXlDKE8RMtKsvK0gshlXIuPbyWM/h84Ensb7o3sC0=
@@ -668,8 +668,8 @@ github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0/go.mod h1:7SFka0XMvUgj3hfZtyd
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcwallet v0.16.10-0.20240410030101-6fe19a472a62 h1:MtcTVTcDbGdTJhfDc7LLikojyl0PYtSRNLwoRaLVbWI=
-github.com/btcsuite/btcwallet v0.16.10-0.20240410030101-6fe19a472a62/go.mod h1:2C3Q/MhYAKmk7F+Tey6LfKtKRTdQsrCf8AAAzzDPmH4=
+github.com/btcsuite/btcwallet v0.16.10-0.20240625163855-b42ed59f0528 h1:DZRmr47CdPnNglwEVACPnJnGrfb/GBGyoGs5oqvLFg4=
+github.com/btcsuite/btcwallet v0.16.10-0.20240625163855-b42ed59f0528/go.mod h1:SLFUSQbP8ON/wxholYMfVLvGPJyk7boczOW/ob+nww4=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.4 h1:poyHFf7+5+RdxNp5r2T6IBRD7RyraUsYARYbp/7t4D8=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.4/go.mod h1:GETGDQuyq+VFfH1S/+/7slLM/9aNa4l7P4ejX6dJfb0=
 github.com/btcsuite/btcwallet/wallet/txrules v1.2.1 h1:UZo7YRzdHbwhK7Rhv3PO9bXgTxiOH45edK5qdsdiatk=
@@ -1187,8 +1187,8 @@ github.com/lightninglabs/taproot-assets v0.3.4-0.20240531080458-69ff7704168c h1:
 github.com/lightninglabs/taproot-assets v0.3.4-0.20240531080458-69ff7704168c/go.mod h1:EkrRgaQmQ8+tNqyXWqkGBaGMbm4GweoDnYX8oEccwcE=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f h1:Pua7+5TcFEJXIIZ1I2YAUapmbcttmLj4TTi786bIi3s=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
-github.com/lightningnetwork/lnd v0.18.0-beta.1 h1:7DpRre4rtUmLim4JC5oPd3KEd1Q3QpWTH6jQgSOGNYM=
-github.com/lightningnetwork/lnd v0.18.0-beta.1/go.mod h1:1SA9iv9rZddNAcfP38SN9lNSVT1zf5aqmukLUoomjDU=
+github.com/lightningnetwork/lnd v0.18.1-beta h1:72H53Zga2BY+O/x05V2lhIz3KTJIibYWyqPNH+8b+2E=
+github.com/lightningnetwork/lnd v0.18.1-beta/go.mod h1:pVPVyJ9cRqDEmGzG6dCoVFMdAV76K+qf+kSCZCgt3zQ=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=

--- a/version.go
+++ b/version.go
@@ -23,7 +23,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	appMajor uint = 0
 	appMinor uint = 13
-	appPatch uint = 0
+	appPatch uint = 1
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.


### PR DESCRIPTION
This PR bumps the litd version to `v0.13.1-alpha`.

This PR also bumps lnd to version `v0.18.1-beta`.

@ellemouton, would you please specifically check if this is how we would like to handle the release notes during a release?