### PR TITLE
itest: remove TODO after fix

### DIFF
--- a/itest/assets_test.go
+++ b/itest/assets_test.go
@@ -943,13 +943,7 @@ func closeAssetChannelAndAssert(t *harnessTest, net *NetworkHarness,
 	t.Logf("Channel closed with txid: %v", closeTxid)
 	t.Logf("Close transaction: %v", spew.Sdump(closeTx))
 
-	// TODO(guggero): Remove this if once the receiver of a channel imports
-	// the proofs correctly as well.
-	if localTapd.node.Name() != "Yara" {
-		waitForSendEvent(
-			t.t, sendEvents, tapfreighter.SendStateComplete,
-		)
-	}
+	waitForSendEvent(t.t, sendEvents, tapfreighter.SendStateComplete)
 
 	// With the channel closed, we'll now assert that the co-op close
 	// transaction was inserted into the local universe.


### PR DESCRIPTION
Since lightninglabs/taproot-assets#987 was merged, this TODO and if statement is no longer needed to make the test pass.