### PR TITLE
version: bump to v0.13.99-alpha.rc2

### DIFF
--- a/version.go
+++ b/version.go
@@ -23,7 +23,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	appMajor uint = 0
 	appMinor uint = 13
-	appPatch uint = 2
+	appPatch uint = 99
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.


### PR DESCRIPTION
As discussed offline, we'll want to use the `.99` version suffix for the Taproot Asset Channel functionality, since this is on a staging branch and we don't know what actual/final version this is going to land in.
To make sure we don't conflict with other release version numbers of `litd` on the `master` branch (such as the upcoming https://github.com/lightninglabs/lightning-terminal/pull/752 or a version that'll include [`lnd v0.18.2-beta`](https://github.com/lightningnetwork/lnd/pull/8901)) we use a non-conflicting minor version for now.
