### PR TITLE
mod+itest: reproduce and fix reverse direction invoice payment, bump to rc4

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Visit https://localhost:8443 to access Terminal.
 
 Note that a password with a minimum of 8 characters is required to run Lightning Terminal. In a production environment, it's recommended that you store this password as an environment variable to avoid it being recorded in the command history.
 
-To use LiT with a remote `lnd` instance please [follow these instructions](./doc/config-lnd-remote.md). If you would like to replace your existing LND instance with the one integrated within LiT please see [configuring Terminal](./doc/config-lnd-integrated.md).
+To use LiT with a remote `lnd` instance please [follow these instructions](./docs/config-lnd-remote.md). If you would like to replace your existing LND instance with the one integrated within LiT please see [configuring Terminal](./doc/config-lnd-integrated.md).
 
 ## LND
 Note that LiT requires `lnd` to be built with **all of its subservers** and requires running at least v0.11.0. Download the latest [official release binary](https://github.com/lightningnetwork/lnd/releases/latest) or build `lnd` from source by following the [installation instructions](https://github.com/lightningnetwork/lnd/blob/master/docs/INSTALL.md). If you choose to build `lnd` from source, use the following command to enable all the relevant subservers:
@@ -43,7 +43,7 @@ Note that LiT requires `lnd` to be built with **all of its subservers** and requ
 
 ## Interaction
 If you plan to run LiT on a remote machine but access the web-interface from your computer you may not want to deal with self-signed certificate browser warnings. To avoid these warnings configure the HTTP server to use a certificate from [Let's Encrypt](https://letsencrypt.org/). View the
-[Let's Encrypt Configuration](./doc/letsencrypt.md) doc for instructions on how to configure this.
+[Let's Encrypt Configuration](./docs/letsencrypt.md) doc for instructions on how to configure this.
 
 ## Upgrading
 If you used command line arguments with previous versions then you don't need to change anything when upgrading. 
@@ -56,13 +56,13 @@ To upgrade from v0.1.1-alpha or earlier simply create a `lit.conf` file in your 
 Move all the configuration settings specific to LiT from `lnd.conf` to `lit.conf` and remove any previous LiT-specific customizations from the configuration settings in `lnd.conf`. Note that any section headers (`[ Example ]`) in `lit.conf` should be removed or changed to comments (`# Example`). 
 
 ## Usage
-Read the [walkthrough](doc/WALKTHROUGH.md) document to learn more about how to use LiT.
+Read the [walkthrough](docs/WALKTHROUGH.md) document to learn more about how to use LiT.
 
 ## Troubleshooting
-If you encounter any issues please see our [troubleshooting guide](./doc/troubleshooting.md).
+If you encounter any issues please see our [troubleshooting guide](./docs/troubleshooting.md).
 
 ## Build from source
-If you’d prefer to compile from source code please follow [these instructions](./doc/compile.md).
+If you’d prefer to compile from source code please follow [these instructions](./docs/compile.md).
 
 ## Compatibility
 
@@ -126,9 +126,9 @@ in remote mode (meaning that `lnd-mode=remote` is set). It shows the
 
 LiT offers two main operating modes, one in which [`lnd` is running inside the
 LiT process (called "lnd integrated mode", set by `lnd-mode=integrated` config
-option)](doc/config-lnd-integrated.md) and one in which [`lnd` is running in
+option)](docs/config-lnd-integrated.md) and one in which [`lnd` is running in
 a standalone process on the same or remote machine (called "lnd remote mode",
-set by `lnd-mode=remote` config option)](doc/config-lnd-remote.md).
+set by `lnd-mode=remote` config option)](docs/config-lnd-remote.md).
 
 In addition to those main modes, the individual bundled daemons (Faraday, Loop
 and Pool) can be toggled to be integrated or remote as well, or as disabled.

--- a/cmd/litcli/ln.go
+++ b/cmd/litcli/ln.go
@@ -727,7 +727,7 @@ func addInvoice(ctx *cli.Context) error {
 		ValueMsat:       int64(numMSats),
 		DescriptionHash: descHash,
 		FallbackAddr:    ctx.String("fallback_addr"),
-		Expiry:          int64(timeoutSeconds),
+		Expiry:          int64(ctx.Uint64("expiry")),
 		Private:         ctx.Bool("private"),
 		IsAmp:           ctx.Bool("amp"),
 		RouteHints: []*lnrpc.RouteHint{

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/lightninglabs/loop/swapserverrpc v1.0.8
 	github.com/lightninglabs/pool v0.6.5-beta.0.20240604070222-e121aadb3289
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.2
-	github.com/lightninglabs/taproot-assets v0.4.0-alpha.rc3
+	github.com/lightninglabs/taproot-assets v0.4.0-rc4
 	github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240712025014-90f997c908d0
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/fn v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/lightninglabs/pool v0.6.5-beta.0.20240604070222-e121aadb3289
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.2
 	github.com/lightninglabs/taproot-assets v0.4.0-alpha.rc3
-	github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240709210732-0cd11ad84792
+	github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240712025014-90f997c908d0
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/fn v1.1.0
 	github.com/lightningnetwork/lnd/kvdb v1.4.8

--- a/go.sum
+++ b/go.sum
@@ -1179,8 +1179,8 @@ github.com/lightninglabs/taproot-assets v0.4.0-alpha.rc3 h1:Ovt4wMhCIqdw+uNwJaSf
 github.com/lightninglabs/taproot-assets v0.4.0-alpha.rc3/go.mod h1:oAiEnRj2sCbPHAURot+tmKbyDhIoxnvkmag0JqlF1bs=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f h1:Pua7+5TcFEJXIIZ1I2YAUapmbcttmLj4TTi786bIi3s=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240709210732-0cd11ad84792 h1:bM4UmjVTvhqwDCMzLZIDMecfo/mei4OS/BFLUzHiDNc=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240709210732-0cd11ad84792/go.mod h1:L3IArArdRrWtuw+wNsUlibuGmf/08Odsm/zo3+bPXuM=
+github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240712025014-90f997c908d0 h1:V+PoltFSxN5oijkErYe+QbnVz5WJjBsAzaMNRrhmz3Q=
+github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240712025014-90f997c908d0/go.mod h1:L3IArArdRrWtuw+wNsUlibuGmf/08Odsm/zo3+bPXuM=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=

--- a/go.sum
+++ b/go.sum
@@ -1175,8 +1175,8 @@ github.com/lightninglabs/pool/auctioneerrpc v1.1.2 h1:Dbg+9Z9jXnhimR27EN37foc4aB
 github.com/lightninglabs/pool/auctioneerrpc v1.1.2/go.mod h1:1wKDzN2zEP8srOi0B9iySlEsPdoPhw6oo3Vbm1v4Mhw=
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display h1:pRdza2wleRN1L2fJXd6ZoQ9ZegVFTAb2bOQfruJPKcY=
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-github.com/lightninglabs/taproot-assets v0.4.0-alpha.rc3 h1:Ovt4wMhCIqdw+uNwJaSfM/fWpn06n51b4rlIadAnL2g=
-github.com/lightninglabs/taproot-assets v0.4.0-alpha.rc3/go.mod h1:oAiEnRj2sCbPHAURot+tmKbyDhIoxnvkmag0JqlF1bs=
+github.com/lightninglabs/taproot-assets v0.4.0-rc4 h1:tl8gClGZBmLlkMxfDRVAdIhx+LyhThZCEjYBpuM37pc=
+github.com/lightninglabs/taproot-assets v0.4.0-rc4/go.mod h1:oAiEnRj2sCbPHAURot+tmKbyDhIoxnvkmag0JqlF1bs=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f h1:Pua7+5TcFEJXIIZ1I2YAUapmbcttmLj4TTi786bIi3s=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
 github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240712025014-90f997c908d0 h1:V+PoltFSxN5oijkErYe+QbnVz5WJjBsAzaMNRrhmz3Q=

--- a/itest/assets_test.go
+++ b/itest/assets_test.go
@@ -154,6 +154,7 @@ func createTestAssetNetwork(t *harnessTest, net *NetworkHarness, charlieTap,
 			AssetId:            assetID,
 			PeerPubkey:         fabiaTap.node.PubKey[:],
 			FeeRateSatPerVbyte: 5,
+			PushSat:            1065,
 		},
 	)
 	require.NoError(t.t, err)

--- a/itest/assets_test.go
+++ b/itest/assets_test.go
@@ -663,7 +663,7 @@ func createAndPayNormalInvoiceWithBtc(t *testing.T, src, dst *HarnessNode,
 }
 
 func createAndPayNormalInvoice(t *testing.T, src, rfqPeer, dst *HarnessNode,
-	amountSat btcutil.Amount, assetID []byte) uint64 {
+	amountSat btcutil.Amount, assetID []byte, smallShards bool) uint64 {
 
 	ctxb := context.Background()
 	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
@@ -677,7 +677,9 @@ func createAndPayNormalInvoice(t *testing.T, src, rfqPeer, dst *HarnessNode,
 	})
 	require.NoError(t, err)
 
-	return payInvoiceWithAssets(t, src, rfqPeer, invoiceResp, assetID)
+	return payInvoiceWithAssets(
+		t, src, rfqPeer, invoiceResp, assetID, smallShards,
+	)
 }
 
 func payInvoiceWithSatoshi(t *testing.T, payer *HarnessNode,
@@ -704,7 +706,8 @@ func payInvoiceWithSatoshi(t *testing.T, payer *HarnessNode,
 }
 
 func payInvoiceWithAssets(t *testing.T, payer, rfqPeer *HarnessNode,
-	invoice *lnrpc.AddInvoiceResponse, assetID []byte) uint64 {
+	invoice *lnrpc.AddInvoiceResponse, assetID []byte,
+	smallShards bool) uint64 {
 
 	ctxb := context.Background()
 	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
@@ -783,9 +786,13 @@ func payInvoiceWithAssets(t *testing.T, payer, rfqPeer *HarnessNode,
 		PaymentRequest:        invoice.PaymentRequest,
 		TimeoutSeconds:        2,
 		FirstHopCustomRecords: encodeResp.CustomRecords,
-		MaxShardSizeMsat:      80_000_000,
 		FeeLimitMsat:          1_000_000,
 	}
+
+	if smallShards {
+		sendReq.MaxShardSizeMsat = 80_000_000
+	}
+
 	stream, err := payer.RouterClient.SendPaymentV2(ctxt, sendReq)
 	require.NoError(t, err)
 

--- a/itest/litd_custom_channels_test.go
+++ b/itest/litd_custom_channels_test.go
@@ -65,7 +65,7 @@ var (
 		"--taproot-assets.experimental.rfq.priceoracleaddress=" +
 			"use_mock_price_oracle_service_promise_to_" +
 			"not_use_on_mainnet",
-		"--taproot-assets.experimental.rfq.mockoraclecentpersat=" +
+		"--taproot-assets.experimental.rfq.mockoracleassetsperbtc=" +
 			"5820600",
 		"--taproot-assets.universerpccourier.skipinitdelay",
 		"--taproot-assets.universerpccourier.backoffresetwait=100ms",

--- a/itest/litd_custom_channels_test.go
+++ b/itest/litd_custom_channels_test.go
@@ -209,13 +209,13 @@ func testCustomChannelsLarge(_ context.Context, net *NetworkHarness,
 	invoiceResp := createAssetInvoice(
 		t.t, erin, fabia, fabiaInvoiceAssetAmount, assetID,
 	)
-	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID)
+	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID, false)
 	logBalance(t.t, nodes, assetID, "after invoice")
 
 	invoiceResp2 := createAssetInvoice(
 		t.t, dave, charlie, fabiaInvoiceAssetAmount/2, assetID,
 	)
-	payInvoiceWithAssets(t.t, fabia, erin, invoiceResp2, assetID)
+	payInvoiceWithAssets(t.t, fabia, erin, invoiceResp2, assetID, false)
 	logBalance(t.t, nodes, assetID, "after invoice 2")
 
 	// Now we send a large invoice from Charlie to Dave.
@@ -223,7 +223,7 @@ func testCustomChannelsLarge(_ context.Context, net *NetworkHarness,
 	invoiceResp3 := createAssetInvoice(
 		t.t, charlie, dave, largeInvoiceAmount, assetID,
 	)
-	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp3, assetID)
+	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp3, assetID, false)
 	logBalance(t.t, nodes, assetID, "after invoice 3")
 }
 
@@ -380,7 +380,7 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 	invoiceResp := createAssetInvoice(
 		t.t, dave, charlie, keySendAmount, assetID,
 	)
-	payInvoiceWithAssets(t.t, dave, charlie, invoiceResp, assetID)
+	payInvoiceWithAssets(t.t, dave, charlie, invoiceResp, assetID, true)
 
 	charlieAssetBalance += keySendAmount
 	daveAssetBalance -= keySendAmount
@@ -395,7 +395,7 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 	// invoice.
 	// ------------
 	paidAssetAmount := createAndPayNormalInvoice(
-		t.t, charlie, dave, dave, 20_000, assetID,
+		t.t, charlie, dave, dave, 20_000, assetID, true,
 	)
 	logBalance(t.t, nodes, assetID, "after invoice")
 
@@ -416,7 +416,7 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 	invoiceResp = createAssetInvoice(
 		t.t, charlie, dave, daveInvoiceAssetAmount, assetID,
 	)
-	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID)
+	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID, true)
 	logBalance(t.t, nodes, assetID, "after invoice")
 
 	charlieAssetBalance -= daveInvoiceAssetAmount
@@ -426,7 +426,7 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 	// Test case 4: Pay a normal invoice from Erin by Charlie.
 	// ------------
 	paidAssetAmount = createAndPayNormalInvoice(
-		t.t, charlie, dave, erin, 20_000, assetID,
+		t.t, charlie, dave, erin, 20_000, assetID, true,
 	)
 	logBalance(t.t, nodes, assetID, "after invoice")
 
@@ -441,7 +441,7 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 	invoiceResp = createAssetInvoice(
 		t.t, erin, fabia, fabiaInvoiceAssetAmount1, assetID,
 	)
-	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID)
+	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID, true)
 	logBalance(t.t, nodes, assetID, "after invoice")
 
 	charlieAssetBalance -= fabiaInvoiceAssetAmount1
@@ -475,7 +475,7 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 	invoiceResp = createAssetInvoice(
 		t.t, erin, fabia, fabiaInvoiceAssetAmount3, assetID,
 	)
-	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID)
+	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID, true)
 	logBalance(t.t, nodes, assetID, "after invoice")
 
 	charlieAssetBalance -= fabiaInvoiceAssetAmount3
@@ -493,7 +493,7 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 	invoiceResp = createAssetInvoice(
 		t.t, dave, yara, yaraInvoiceAssetAmount1, assetID,
 	)
-	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID)
+	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID, true)
 	logBalance(t.t, nodes, assetID, "after asset-to-asset")
 
 	charlieAssetBalance -= yaraInvoiceAssetAmount1
@@ -821,7 +821,7 @@ func testCustomChannelsGroupedAsset(_ context.Context, net *NetworkHarness,
 	// invoice.
 	// ------------
 	paidAssetAmount := createAndPayNormalInvoice(
-		t.t, charlie, dave, dave, 20_000, assetID,
+		t.t, charlie, dave, dave, 20_000, assetID, true,
 	)
 	logBalance(t.t, nodes, assetID, "after invoice")
 
@@ -842,7 +842,7 @@ func testCustomChannelsGroupedAsset(_ context.Context, net *NetworkHarness,
 	invoiceResp := createAssetInvoice(
 		t.t, charlie, dave, daveInvoiceAssetAmount, assetID,
 	)
-	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID)
+	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID, true)
 	logBalance(t.t, nodes, assetID, "after invoice")
 
 	charlieAssetBalance -= daveInvoiceAssetAmount
@@ -852,7 +852,7 @@ func testCustomChannelsGroupedAsset(_ context.Context, net *NetworkHarness,
 	// Test case 4: Pay a normal invoice from Erin by Charlie.
 	// ------------
 	paidAssetAmount = createAndPayNormalInvoice(
-		t.t, charlie, dave, erin, 20_000, assetID,
+		t.t, charlie, dave, erin, 20_000, assetID, true,
 	)
 	logBalance(t.t, nodes, assetID, "after invoice")
 
@@ -867,7 +867,7 @@ func testCustomChannelsGroupedAsset(_ context.Context, net *NetworkHarness,
 	invoiceResp = createAssetInvoice(
 		t.t, erin, fabia, fabiaInvoiceAssetAmount1, assetID,
 	)
-	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID)
+	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID, true)
 	logBalance(t.t, nodes, assetID, "after invoice")
 
 	charlieAssetBalance -= fabiaInvoiceAssetAmount1
@@ -901,7 +901,7 @@ func testCustomChannelsGroupedAsset(_ context.Context, net *NetworkHarness,
 	invoiceResp = createAssetInvoice(
 		t.t, erin, fabia, fabiaInvoiceAssetAmount3, assetID,
 	)
-	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID)
+	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID, true)
 	logBalance(t.t, nodes, assetID, "after invoice")
 
 	charlieAssetBalance -= fabiaInvoiceAssetAmount3
@@ -919,7 +919,7 @@ func testCustomChannelsGroupedAsset(_ context.Context, net *NetworkHarness,
 	invoiceResp = createAssetInvoice(
 		t.t, dave, yara, yaraInvoiceAssetAmount1, assetID,
 	)
-	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID)
+	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID, true)
 	logBalance(t.t, nodes, assetID, "after asset-to-asset")
 
 	charlieAssetBalance -= yaraInvoiceAssetAmount1

--- a/itest/litd_custom_channels_test.go
+++ b/itest/litd_custom_channels_test.go
@@ -429,6 +429,19 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 	daveAssetBalance += daveInvoiceAssetAmount
 
 	// ------------
+	// Test case 3.5: Pay an asset invoice from Dave by Charlie with normal
+	// payment flow.
+	// ------------
+	invoiceResp = createAssetInvoice(
+		t.t, charlie, dave, daveInvoiceAssetAmount, assetID,
+	)
+	payInvoiceWithSatoshi(t.t, charlie, invoiceResp)
+	logBalance(t.t, nodes, assetID, "after asset invoice paid with sats")
+
+	// We don't need to update the asset balances of Charlie and Dave here
+	// as the invoice was paid with sats.
+
+	// ------------
 	// Test case 4: Pay a normal invoice from Erin by Charlie.
 	// ------------
 	paidAssetAmount = createAndPayNormalInvoice(

--- a/itest/litd_custom_channels_test.go
+++ b/itest/litd_custom_channels_test.go
@@ -80,6 +80,153 @@ const (
 	startAmount   = fundingAmount * 2
 )
 
+// testCustomChannelsLarge tests that we can create a network with custom
+// channels and send large asset payments over them.
+func testCustomChannelsLarge(_ context.Context, net *NetworkHarness,
+	t *harnessTest) {
+
+	lndArgs := slices.Clone(lndArgsTemplate)
+	litdArgs := slices.Clone(litdArgsTemplate)
+
+	// Explicitly set the proof courier as Alice (how has no other role
+	// other than proof shuffling), otherwise a hashmail courier will be
+	// used. For the funding transaction, we're just posting it and don't
+	// expect a true receiver.
+	zane, err := net.NewNode(
+		t.t, "Zane", lndArgs, false, true, litdArgs...,
+	)
+	require.NoError(t.t, err)
+
+	litdArgs = append(litdArgs, fmt.Sprintf(
+		"--taproot-assets.proofcourieraddr=%s://%s",
+		proof.UniverseRpcCourierType, zane.Cfg.LitAddr(),
+	))
+
+	// The topology we are going for looks like the following:
+	//
+	// Charlie  --[assets]-->  Dave  --[sats]-->  Erin  --[assets]-->  Fabia
+	//                          |
+	//                          |
+	//                       [assets]
+	//                          |
+	//                          v
+	//                        Yara
+	//
+	// With [assets] being a custom channel and [sats] being a normal, BTC
+	// only channel.
+	// All 5 nodes need to be full litd nodes running in integrated mode
+	// with tapd included. We also need specific flags to be enabled, so we
+	// create 5 completely new nodes, ignoring the two default nodes that
+	// are created by the harness.
+	charlie, err := net.NewNode(
+		t.t, "Charlie", lndArgs, false, true, litdArgs...,
+	)
+	require.NoError(t.t, err)
+
+	dave, err := net.NewNode(t.t, "Dave", lndArgs, false, true, litdArgs...)
+	require.NoError(t.t, err)
+	erin, err := net.NewNode(t.t, "Erin", lndArgs, false, true, litdArgs...)
+	require.NoError(t.t, err)
+	fabia, err := net.NewNode(
+		t.t, "Fabia", lndArgs, false, true, litdArgs...,
+	)
+	require.NoError(t.t, err)
+	yara, err := net.NewNode(
+		t.t, "Yara", lndArgs, false, true, litdArgs...,
+	)
+	require.NoError(t.t, err)
+
+	nodes := []*HarnessNode{charlie, dave, erin, fabia, yara}
+	connectAllNodes(t.t, net, nodes)
+	fundAllNodes(t.t, net, nodes)
+
+	// Create the normal channel between Dave and Erin.
+	t.Logf("Opening normal channel between Dave and Erin...")
+	channelOp := openChannelAndAssert(
+		t, net, dave, erin, lntest.OpenChannelParams{
+			Amt:         10_000_000,
+			SatPerVByte: 5,
+		},
+	)
+	defer closeChannelAndAssert(t, net, dave, channelOp, false)
+
+	// This is the only public channel, we need everyone to be aware of it.
+	assertChannelKnown(t.t, charlie, channelOp)
+	assertChannelKnown(t.t, fabia, channelOp)
+
+	universeTap := newTapClient(t.t, zane)
+	charlieTap := newTapClient(t.t, charlie)
+	daveTap := newTapClient(t.t, dave)
+	erinTap := newTapClient(t.t, erin)
+	fabiaTap := newTapClient(t.t, fabia)
+	yaraTap := newTapClient(t.t, yara)
+
+	// Mint an asset on Charlie and sync all nodes to Charlie as the
+	// universe.
+	mintedAssets := itest.MintAssetsConfirmBatch(
+		t.t, t.lndHarness.Miner.Client, charlieTap,
+		[]*mintrpc.MintAssetRequest{
+			{
+				Asset: itestAsset,
+			},
+		},
+	)
+	cents := mintedAssets[0]
+	assetID := cents.AssetGenesis.AssetId
+
+	t.Logf("Minted %d lightning cents, syncing universes...", cents.Amount)
+	syncUniverses(t.t, charlieTap, dave, erin, fabia, yara)
+	t.Logf("Universes synced between all nodes, distributing assets...")
+
+	const (
+		daveFundingAmount = uint64(400_000)
+		erinFundingAmount = uint64(200_000)
+	)
+	charlieFundingAmount := cents.Amount - uint64(2*400_000)
+
+	createTestAssetNetwork(
+		t, net, charlieTap, daveTap, erinTap, fabiaTap, yaraTap,
+		universeTap, cents, 400_000, charlieFundingAmount,
+		daveFundingAmount, erinFundingAmount,
+	)
+
+	// Before we start sending out payments, let's make sure each node can
+	// see the other one in the graph and has all required features.
+	require.NoError(t.t, t.lndHarness.AssertNodeKnown(charlie, dave))
+	require.NoError(t.t, t.lndHarness.AssertNodeKnown(dave, charlie))
+	require.NoError(t.t, t.lndHarness.AssertNodeKnown(dave, yara))
+	require.NoError(t.t, t.lndHarness.AssertNodeKnown(yara, dave))
+	require.NoError(t.t, t.lndHarness.AssertNodeKnown(erin, fabia))
+	require.NoError(t.t, t.lndHarness.AssertNodeKnown(fabia, erin))
+	require.NoError(t.t, t.lndHarness.AssertNodeKnown(charlie, erin))
+
+	// Print initial channel balances.
+	logBalance(t.t, nodes, assetID, "initial")
+
+	// Try larger invoice payments, first from Charlie to Erin, then half
+	// of the amount back in the other direction.
+	const fabiaInvoiceAssetAmount = 20_000
+	invoiceResp := createAssetInvoice(
+		t.t, erin, fabia, fabiaInvoiceAssetAmount, assetID,
+	)
+	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID)
+	logBalance(t.t, nodes, assetID, "after invoice")
+
+	invoiceResp2 := createAssetInvoice(
+		t.t, dave, charlie, fabiaInvoiceAssetAmount/2, assetID,
+	)
+	payInvoiceWithAssets(t.t, fabia, erin, invoiceResp2, assetID)
+	logBalance(t.t, nodes, assetID, "after invoice 2")
+
+	// Now we send a large invoice from Charlie to Dave.
+	const largeInvoiceAmount = 100_000
+	invoiceResp3 := createAssetInvoice(
+		t.t, charlie, dave, largeInvoiceAmount, assetID,
+	)
+	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp3, assetID)
+	logBalance(t.t, nodes, assetID, "after invoice 3")
+}
+
 // testCustomChannels tests that we can create a network with custom channels
 // and send asset payments over them.
 func testCustomChannels(_ context.Context, net *NetworkHarness,

--- a/itest/litd_custom_channels_test.go
+++ b/itest/litd_custom_channels_test.go
@@ -203,7 +203,7 @@ func testCustomChannelsLarge(_ context.Context, net *NetworkHarness,
 	// Print initial channel balances.
 	logBalance(t.t, nodes, assetID, "initial")
 
-	// Try larger invoice payments, first from Charlie to Erin, then half
+	// Try larger invoice payments, first from Charlie to Fabia, then half
 	// of the amount back in the other direction.
 	const fabiaInvoiceAssetAmount = 20_000
 	invoiceResp := createAssetInvoice(
@@ -215,6 +215,12 @@ func testCustomChannelsLarge(_ context.Context, net *NetworkHarness,
 	invoiceResp2 := createAssetInvoice(
 		t.t, dave, charlie, fabiaInvoiceAssetAmount/2, assetID,
 	)
+
+	// Sleep for a second to make sure the balances fully propagated before
+	// we make the payment. Otherwise, we'll make an RFQ order with a max
+	// amount of zero.
+	time.Sleep(time.Second * 1)
+
 	payInvoiceWithAssets(t.t, fabia, erin, invoiceResp2, assetID, false)
 	logBalance(t.t, nodes, assetID, "after invoice 2")
 

--- a/itest/litd_custom_channels_test.go
+++ b/itest/litd_custom_channels_test.go
@@ -218,7 +218,7 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 	// ------------
 	// Test case 1: Send a direct keysend payment from Charlie to Dave.
 	// ------------
-	const keySendAmount = 100
+	const keySendAmount = 1000
 	sendAssetKeySendPayment(
 		t.t, charlie, dave, keySendAmount, assetID, fn.None[int64](),
 	)
@@ -227,13 +227,13 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 	charlieAssetBalance -= keySendAmount
 	daveAssetBalance += keySendAmount
 
-	// We should be able to send the 100 assets back immediately, because
+	// We should be able to send the 1000 assets back immediately, because
 	// there is enough on-chain balance on Dave's side to be able to create
-	// an HTLC.
-	sendAssetKeySendPayment(
-		t.t, dave, charlie, keySendAmount, assetID, fn.None[int64](),
+	// an HTLC. We use an invoice to execute another code path.
+	invoiceResp := createAssetInvoice(
+		t.t, dave, charlie, keySendAmount, assetID,
 	)
-	logBalance(t.t, nodes, assetID, "after keysend back")
+	payInvoiceWithAssets(t.t, dave, charlie, invoiceResp, assetID)
 
 	charlieAssetBalance += keySendAmount
 	daveAssetBalance -= keySendAmount
@@ -266,7 +266,7 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 	// invoice.
 	// ------------
 	const daveInvoiceAssetAmount = 2_000
-	invoiceResp := createAssetInvoice(
+	invoiceResp = createAssetInvoice(
 		t.t, charlie, dave, daveInvoiceAssetAmount, assetID,
 	)
 	payInvoiceWithAssets(t.t, charlie, dave, invoiceResp, assetID)

--- a/itest/litd_node.go
+++ b/itest/litd_node.go
@@ -219,6 +219,7 @@ func (cfg *LitNodeConfig) defaultLitdArgs() *litArgs {
 			"enablerest":             "",
 			"restcors":               "*",
 			"lndconnectinterval":     "200ms",
+			"lnd.debuglevel":         "trace,GRPC=error,PEER=info",
 		}
 	)
 	for _, arg := range cfg.LitArgs {

--- a/itest/litd_test_list_on_test.go
+++ b/itest/litd_test_list_on_test.go
@@ -25,6 +25,10 @@ var allTestCases = []*testCase{
 		test: testCustomChannels,
 	},
 	{
+		name: "test custom channels large",
+		test: testCustomChannelsLarge,
+	},
+	{
 		name: "test custom channels grouped asset",
 		test: testCustomChannelsGroupedAsset,
 	},

--- a/subservers/taproot-assets.go
+++ b/subservers/taproot-assets.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"strings"
 
+	"github.com/btcsuite/btcd/chaincfg"
 	restProxy "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightninglabs/lndclient"
 	tap "github.com/lightninglabs/taproot-assets"
+	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/perms"
 	"github.com/lightninglabs/taproot-assets/tapcfg"
 	"github.com/lightninglabs/taproot-assets/taprpc"
@@ -39,15 +41,23 @@ var _ SubServer = (*taprootAssetsSubServer)(nil)
 
 // NewTaprootAssetsSubServer returns a new tap implementation of the SubServer
 // interface.
-func NewTaprootAssetsSubServer(cfg *tapcfg.Config,
+func NewTaprootAssetsSubServer(network string, cfg *tapcfg.Config,
 	remoteCfg *RemoteDaemonConfig, remote, lndRemote bool) SubServer {
 
 	// Overwrite the tap daemon's user agent name, so it sends "litd"
 	// instead of "tapd".
 	tap.SetAgentName("litd")
 
+	// A quirk of the address package is that it requires the exact testnet
+	// name, not the generic one...
+	if network == "testnet" {
+		network = chaincfg.TestNet3Params.Name
+	}
+
+	chainCfg := address.ParamsForChain(network)
+
 	return &taprootAssetsSubServer{
-		Server:    tap.NewServer(nil),
+		Server:    tap.NewServer(&chainCfg, nil),
 		cfg:       cfg,
 		remoteCfg: remoteCfg,
 		remote:    remote,

--- a/terminal.go
+++ b/terminal.go
@@ -1741,7 +1741,8 @@ func (g *LightningTerminal) initSubServers() {
 
 	g.subServerMgr.AddServer(
 		subservers.NewTaprootAssetsSubServer(
-			g.cfg.TaprootAssets, g.cfg.Remote.TaprootAssets,
+			g.cfg.Network, g.cfg.TaprootAssets,
+			g.cfg.Remote.TaprootAssets,
 			g.cfg.tapRemote, g.cfg.lndRemote,
 		), g.cfg.TaprootAssetsMode != ModeDisable,
 	)

--- a/version.go
+++ b/version.go
@@ -27,7 +27,7 @@ const (
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	appPreRelease = "alpha.rc3"
+	appPreRelease = "alpha.rc4"
 )
 
 // Version returns the application version as a properly formed string per the


### PR DESCRIPTION
Reported offline by @jamaljsr.

Depends on https://github.com/lightningnetwork/lnd/pull/8908.
Depends on https://github.com/lightninglabs/taproot-assets/pull/1011.

Fixes a bug that when an invoice is paid, the full invoice amount is checked when validating the local channel balance and reserve. But for custom channels the actual HTLC amount might be just above dust and shouldn't validate the channel reserve.
We update our itest to reproduce the issue and then update to the lnd commit that fixes it.