### PR TITLE
multi: fix broken link to renamed docs folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Visit https://localhost:8443 to access Terminal.
 
 Note that a password with a minimum of 8 characters is required to run Lightning Terminal. In a production environment, it's recommended that you store this password as an environment variable to avoid it being recorded in the command history.
 
-To use LiT with a remote `lnd` instance please [follow these instructions](./docs/config-lnd-remote.md). If you would like to replace your existing LND instance with the one integrated within LiT please see [configuring Terminal](./doc/config-lnd-integrated.md).
+To use LiT with a remote `lnd` instance please [follow these instructions](./docs/config-lnd-remote.md). If you would like to replace your existing LND instance with the one integrated within LiT please see [configuring Terminal](./docs/config-lnd-integrated.md).
 
 ## LND
 Note that LiT requires `lnd` to be built with **all of its subservers** and requires running at least v0.11.0. Download the latest [official release binary](https://github.com/lightningnetwork/lnd/releases/latest) or build `lnd` from source by following the [installation instructions](https://github.com/lightningnetwork/lnd/blob/master/docs/INSTALL.md). If you choose to build `lnd` from source, use the following command to enable all the relevant subservers:


### PR DESCRIPTION
https://github.com/lightninglabs/lightning-terminal/pull/792/commits/993e1852cedf1d01a29be1e528f682e6096d223c#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R35

eluded 792 review

Comprehensiveness confirmed by grepping
`\(\./doc/`