### PR TITLE
custom channels: add more itest coverage, fix pending channel bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/lightninglabs/loop/swapserverrpc v1.0.8
 	github.com/lightninglabs/pool v0.6.5-beta.0.20240604070222-e121aadb3289
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.2
-	github.com/lightninglabs/taproot-assets v0.4.0-rc4.0.20240716183814-7647ba8f48d5
+	github.com/lightninglabs/taproot-assets v0.4.0-rc4.0.20240719071936-7035dedc860a
 	github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240712025014-90f997c908d0
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/fn v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1175,8 +1175,8 @@ github.com/lightninglabs/pool/auctioneerrpc v1.1.2 h1:Dbg+9Z9jXnhimR27EN37foc4aB
 github.com/lightninglabs/pool/auctioneerrpc v1.1.2/go.mod h1:1wKDzN2zEP8srOi0B9iySlEsPdoPhw6oo3Vbm1v4Mhw=
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display h1:pRdza2wleRN1L2fJXd6ZoQ9ZegVFTAb2bOQfruJPKcY=
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-github.com/lightninglabs/taproot-assets v0.4.0-rc4.0.20240716183814-7647ba8f48d5 h1:+d5HMOuBUWMsUVx6tAzy7+g8m4A76tec5/FOb1w5iVs=
-github.com/lightninglabs/taproot-assets v0.4.0-rc4.0.20240716183814-7647ba8f48d5/go.mod h1:oAiEnRj2sCbPHAURot+tmKbyDhIoxnvkmag0JqlF1bs=
+github.com/lightninglabs/taproot-assets v0.4.0-rc4.0.20240719071936-7035dedc860a h1:iWKqqgFcrOCJc4tviMguRNncdwtR/jATWkulQD2FBIQ=
+github.com/lightninglabs/taproot-assets v0.4.0-rc4.0.20240719071936-7035dedc860a/go.mod h1:oAiEnRj2sCbPHAURot+tmKbyDhIoxnvkmag0JqlF1bs=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f h1:Pua7+5TcFEJXIIZ1I2YAUapmbcttmLj4TTi786bIi3s=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
 github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240712025014-90f997c908d0 h1:V+PoltFSxN5oijkErYe+QbnVz5WJjBsAzaMNRrhmz3Q=

--- a/itest/litd_custom_channels_test.go
+++ b/itest/litd_custom_channels_test.go
@@ -562,19 +562,19 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 	t.Logf("Closing Charlie -> Dave channel")
 	closeAssetChannelAndAssert(
 		t, net, charlie, dave, charlieChanPoint, assetID, nil,
-		universeTap, true, true,
+		universeTap, assertDefaultCoOpCloseBalance(true, true),
 	)
 
 	t.Logf("Closing Dave -> Yara channel, close initiated by Yara")
 	closeAssetChannelAndAssert(
 		t, net, yara, dave, daveChanPoint, assetID, nil,
-		universeTap, false, true,
+		universeTap, assertDefaultCoOpCloseBalance(false, true),
 	)
 
 	t.Logf("Closing Erin -> Fabia channel")
 	closeAssetChannelAndAssert(
 		t, net, erin, fabia, erinChanPoint, assetID, nil,
-		universeTap, true, true,
+		universeTap, assertDefaultCoOpCloseBalance(true, true),
 	)
 
 	// We've been tracking the off-chain channel balances all this time, so
@@ -627,7 +627,7 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 	t.Logf("Closing Charlie -> Dave channel")
 	closeAssetChannelAndAssert(
 		t, net, charlie, dave, charlieChanPoint, assetID, nil,
-		universeTap, false, false,
+		universeTap, assertDefaultCoOpCloseBalance(false, false),
 	)
 
 	// Charlie should still have four asset pieces, two with the same size.
@@ -988,19 +988,19 @@ func testCustomChannelsGroupedAsset(_ context.Context, net *NetworkHarness,
 	t.Logf("Closing Charlie -> Dave channel")
 	closeAssetChannelAndAssert(
 		t, net, charlie, dave, charlieChanPoint, assetID, groupID,
-		universeTap, true, true,
+		universeTap, assertDefaultCoOpCloseBalance(true, true),
 	)
 
 	t.Logf("Closing Dave -> Yara channel, close initiated by Yara")
 	closeAssetChannelAndAssert(
 		t, net, yara, dave, daveChanPoint, assetID, groupID,
-		universeTap, false, true,
+		universeTap, assertDefaultCoOpCloseBalance(false, true),
 	)
 
 	t.Logf("Closing Erin -> Fabia channel")
 	closeAssetChannelAndAssert(
 		t, net, erin, fabia, erinChanPoint, assetID, groupID,
-		universeTap, true, true,
+		universeTap, assertDefaultCoOpCloseBalance(true, true),
 	)
 
 	// We've been tracking the off-chain channel balances all this time, so
@@ -1053,7 +1053,7 @@ func testCustomChannelsGroupedAsset(_ context.Context, net *NetworkHarness,
 	t.Logf("Closing Charlie -> Dave channel")
 	closeAssetChannelAndAssert(
 		t, net, charlie, dave, charlieChanPoint, assetID, groupID,
-		universeTap, false, false,
+		universeTap, assertDefaultCoOpCloseBalance(false, false),
 	)
 
 	// Charlie should still have four asset pieces, two with the same size.


### PR DESCRIPTION
Adds another test case where we co-op close an asset channel when the full balance is on the non-initiator/recipient's side of a channel and assert the final balances are distributed correctly.

This also fixes https://github.com/lightninglabs/taproot-assets/issues/1019, by addressing the last of the 3 reported issues (pending channel staying forever).
