### PR TITLE
version: change "alpha" to "experimental" for Taproot Asset Channel release

### DIFF
--- a/version.go
+++ b/version.go
@@ -27,7 +27,7 @@ const (
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	appPreRelease = "alpha"
+	appPreRelease = "experimental"
 )
 
 // Version returns the application version as a properly formed string per the


### PR DESCRIPTION
As discussed offline, we're going with the `-experimental` version suffix for the Taproot Asset Channel release to signify it's non-production-readiness. The version suffix will also show in release binary artifacts and docker images tags.