### PR TITLE
terminal: allow wallet unlocker services REST calls

### DIFF
--- a/docs/release-notes/release-notes-0.13.4.md
+++ b/docs/release-notes/release-notes-0.13.4.md
@@ -1,0 +1,24 @@
+# Release Notes
+
+# Integrated Binary Updates
+
+### Lightning Terminal
+
+- [Fixed a bug where REST calls for the `WalletUnlocker` service weren't allowed
+  on startup](https://github.com/lightninglabs/lightning-terminal/pull/806).
+
+### LND
+
+### Loop
+
+### Pool
+
+### Faraday
+
+### Taproot Assets
+
+# Autopilot
+
+# Contributors (Alphabetical Order)
+
+* Oliver Gugger


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/lightning-terminal/issues/805.

When lnd isn't marked as fully ready yet, we didn't allow any REST methods through. But to allow creating a wallet through REST, we also need to allow these methods.