### PR TITLE
[custom channels]: Use new `tapchannelrpc` RPC methods

### DIFF
--- a/accounts/checkers_test.go
+++ b/accounts/checkers_test.go
@@ -513,13 +513,14 @@ func testSendPayment(t *testing.T, uri string) {
 	}
 
 	lndMock := newMockLnd()
+	routerMock := newMockRouter()
 	errFunc := func(err error) {
 		lndMock.mainErrChan <- err
 	}
 	service, err := NewService(t.TempDir(), errFunc)
 	require.NoError(t, err)
 
-	err = service.Start(lndMock, lndMock, chainParams)
+	err = service.Start(lndMock, routerMock, chainParams)
 	require.NoError(t, err)
 
 	assertBalance := func(id AccountID, expectedBalance int64) {
@@ -615,7 +616,7 @@ func testSendPayment(t *testing.T, uri string) {
 	require.NoError(t, err)
 	assertBalance(acct.ID, 4000)
 
-	lndMock.assertPaymentRequests(t, map[lntypes.Hash]struct{}{
+	routerMock.assertPaymentRequests(t, map[lntypes.Hash]struct{}{
 		testHash: {},
 	})
 
@@ -646,7 +647,7 @@ func testSendPayment(t *testing.T, uri string) {
 	// was initiated.
 	assertBalance(acct.ID, 4000)
 
-	lndMock.assertNoPaymentRequest(t)
+	routerMock.assertNoPaymentRequest(t)
 
 	// The final test we will do is to have two send requests initiated
 	// before the response for the first one has been received.
@@ -708,13 +709,14 @@ func TestSendPaymentV2(t *testing.T) {
 	}
 
 	lndMock := newMockLnd()
+	routerMock := newMockRouter()
 	errFunc := func(err error) {
 		lndMock.mainErrChan <- err
 	}
 	service, err := NewService(t.TempDir(), errFunc)
 	require.NoError(t, err)
 
-	err = service.Start(lndMock, lndMock, chainParams)
+	err = service.Start(lndMock, routerMock, chainParams)
 	require.NoError(t, err)
 
 	assertBalance := func(id AccountID, expectedBalance int64) {
@@ -808,7 +810,7 @@ func TestSendPaymentV2(t *testing.T) {
 	require.NoError(t, err)
 	assertBalance(acct.ID, 4000)
 
-	lndMock.assertPaymentRequests(t, map[lntypes.Hash]struct{}{
+	routerMock.assertPaymentRequests(t, map[lntypes.Hash]struct{}{
 		testHash: {},
 	})
 
@@ -836,7 +838,7 @@ func TestSendPaymentV2(t *testing.T) {
 	// was initiated.
 	assertBalance(acct.ID, 4000)
 
-	lndMock.assertNoPaymentRequest(t)
+	routerMock.assertNoPaymentRequest(t)
 
 	// The final test we will do is to have two send requests initiated
 	// before the response for the first one has been received.
@@ -894,13 +896,14 @@ func TestSendToRouteV2(t *testing.T) {
 	}
 
 	lndMock := newMockLnd()
+	routerMock := newMockRouter()
 	errFunc := func(err error) {
 		lndMock.mainErrChan <- err
 	}
 	service, err := NewService(t.TempDir(), errFunc)
 	require.NoError(t, err)
 
-	err = service.Start(lndMock, lndMock, chainParams)
+	err = service.Start(lndMock, routerMock, chainParams)
 	require.NoError(t, err)
 
 	assertBalance := func(id AccountID, expectedBalance int64) {
@@ -998,7 +1001,7 @@ func TestSendToRouteV2(t *testing.T) {
 	require.NoError(t, err)
 	assertBalance(acct.ID, 4000)
 
-	lndMock.assertPaymentRequests(t, map[lntypes.Hash]struct{}{
+	routerMock.assertPaymentRequests(t, map[lntypes.Hash]struct{}{
 		testHash: {},
 	})
 
@@ -1028,7 +1031,7 @@ func TestSendToRouteV2(t *testing.T) {
 	// was initiated.
 	assertBalance(acct.ID, 4000)
 
-	lndMock.assertNoPaymentRequest(t)
+	routerMock.assertNoPaymentRequest(t)
 
 	// The final test we will do is to have two send requests initiated
 	// before the response for the first one has been received.

--- a/go.mod
+++ b/go.mod
@@ -15,13 +15,13 @@ require (
 	github.com/lightninglabs/faraday v0.2.13-alpha
 	github.com/lightninglabs/lightning-node-connect v0.3.1-alpha
 	github.com/lightninglabs/lightning-terminal/autopilotserverrpc v0.0.1
-	github.com/lightninglabs/lndclient v1.0.1-0.20240724144614-a676c76e9eaa
+	github.com/lightninglabs/lndclient v1.0.1-0.20240725080034-64a756aa4c36
 	github.com/lightninglabs/loop v0.28.6-beta.0.20240729115851-63e976ab27a4
 	github.com/lightninglabs/loop/swapserverrpc v1.0.8
 	github.com/lightninglabs/pool v0.6.5-beta.0.20240604070222-e121aadb3289
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.2
-	github.com/lightninglabs/taproot-assets v0.4.1
-	github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240723043204-f09d4042aee4
+	github.com/lightninglabs/taproot-assets v0.4.2-0.20240807122703-23c09ff3b017
+	github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240730143253-1b353b0bfd58
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/fn v1.1.0
 	github.com/lightningnetwork/lnd/kvdb v1.4.8

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/lightninglabs/faraday v0.2.13-alpha
 	github.com/lightninglabs/lightning-node-connect v0.3.1-alpha
 	github.com/lightninglabs/lightning-terminal/autopilotserverrpc v0.0.1
-	github.com/lightninglabs/lndclient v1.0.1-0.20240607082608-4ce52a1a3f27
-	github.com/lightninglabs/loop v0.28.5-beta.0.20240607082710-7368d048da05
+	github.com/lightninglabs/lndclient v1.0.1-0.20240724144614-a676c76e9eaa
+	github.com/lightninglabs/loop v0.28.6-beta.0.20240729115851-63e976ab27a4
 	github.com/lightninglabs/loop/swapserverrpc v1.0.8
 	github.com/lightninglabs/pool v0.6.5-beta.0.20240604070222-e121aadb3289
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -1159,8 +1159,8 @@ github.com/lightninglabs/lightning-node-connect v0.3.1-alpha h1:fean3EXsohrpRmrc
 github.com/lightninglabs/lightning-node-connect v0.3.1-alpha/go.mod h1:TC+tFEPlJxU4+TU5UW/TKAfyav/+AZHHaV0nD02LVjk=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2 h1:Er1miPZD2XZwcfE4xoS5AILqP1mj7kqnhbBSxW9BDxY=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2/go.mod h1:antQGRDRJiuyQF6l+k6NECCSImgCpwaZapATth2Chv4=
-github.com/lightninglabs/lndclient v1.0.1-0.20240724144614-a676c76e9eaa h1:Yf3V7e6jVfGEjamRY4mTiAq+flbnasx97+66zHVoXX0=
-github.com/lightninglabs/lndclient v1.0.1-0.20240724144614-a676c76e9eaa/go.mod h1:bxd2a15cIaW8KKcmOf9nNDI/GTxxj0upEYs1EIkttqw=
+github.com/lightninglabs/lndclient v1.0.1-0.20240725080034-64a756aa4c36 h1:gfJ3TOuqSnuXEo1Boj1H9P6tpxPSH9cvi+rB10L0svI=
+github.com/lightninglabs/lndclient v1.0.1-0.20240725080034-64a756aa4c36/go.mod h1:bxd2a15cIaW8KKcmOf9nNDI/GTxxj0upEYs1EIkttqw=
 github.com/lightninglabs/loop v0.28.6-beta.0.20240729115851-63e976ab27a4 h1:Sr7rXR6zK5EaMVNP+3fMK32X1nqMrHJF8nFBsT6UO9o=
 github.com/lightninglabs/loop v0.28.6-beta.0.20240729115851-63e976ab27a4/go.mod h1:DxPSqqESqDRuJB4FJpCeVpOA7qSx7PXi04FFmiIbDqQ=
 github.com/lightninglabs/loop/swapserverrpc v1.0.8 h1:bk7dDGuA3JQUsMDqZNyAy5Pcw5xS9jforz7YnyeSxKM=
@@ -1175,12 +1175,12 @@ github.com/lightninglabs/pool/auctioneerrpc v1.1.2 h1:Dbg+9Z9jXnhimR27EN37foc4aB
 github.com/lightninglabs/pool/auctioneerrpc v1.1.2/go.mod h1:1wKDzN2zEP8srOi0B9iySlEsPdoPhw6oo3Vbm1v4Mhw=
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display h1:pRdza2wleRN1L2fJXd6ZoQ9ZegVFTAb2bOQfruJPKcY=
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-github.com/lightninglabs/taproot-assets v0.4.1 h1:XtOIbw2sUl0GkjWKgZXxopU76BCjxXMW1Dqj8Ia9dGI=
-github.com/lightninglabs/taproot-assets v0.4.1/go.mod h1:9ne4bQJkvp9b6Ez0DZhmDzXM/vbBKAHw6v3zc2FqTFQ=
+github.com/lightninglabs/taproot-assets v0.4.2-0.20240807122703-23c09ff3b017 h1:CKR/T9gnNreVbdIkuxHymC+JTnPynnluD2Z/D761RlE=
+github.com/lightninglabs/taproot-assets v0.4.2-0.20240807122703-23c09ff3b017/go.mod h1:PMlRq9aKXaxs6PMeLnj3y3YnofrylNvEOTxvegTbhSc=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f h1:Pua7+5TcFEJXIIZ1I2YAUapmbcttmLj4TTi786bIi3s=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240723043204-f09d4042aee4 h1:LPnz0JxnzXJvCro714eBanzO7FKx5HF0ldU++zIu9yY=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240723043204-f09d4042aee4/go.mod h1:0gen58n0DVnqJJqCMN3AXNtqWRT0KltQanlvehnhCq0=
+github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240730143253-1b353b0bfd58 h1:qmJAHLGfpeYIl1qUKyQViOjNAVRqF4afKuORzeIAwjA=
+github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240730143253-1b353b0bfd58/go.mod h1:0gen58n0DVnqJJqCMN3AXNtqWRT0KltQanlvehnhCq0=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=

--- a/go.sum
+++ b/go.sum
@@ -1159,10 +1159,10 @@ github.com/lightninglabs/lightning-node-connect v0.3.1-alpha h1:fean3EXsohrpRmrc
 github.com/lightninglabs/lightning-node-connect v0.3.1-alpha/go.mod h1:TC+tFEPlJxU4+TU5UW/TKAfyav/+AZHHaV0nD02LVjk=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2 h1:Er1miPZD2XZwcfE4xoS5AILqP1mj7kqnhbBSxW9BDxY=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2/go.mod h1:antQGRDRJiuyQF6l+k6NECCSImgCpwaZapATth2Chv4=
-github.com/lightninglabs/lndclient v1.0.1-0.20240607082608-4ce52a1a3f27 h1:vm8a13EzH2Qe6j4eZx+tHPeEVoNhJ7coihFPX6K2kco=
-github.com/lightninglabs/lndclient v1.0.1-0.20240607082608-4ce52a1a3f27/go.mod h1:bxd2a15cIaW8KKcmOf9nNDI/GTxxj0upEYs1EIkttqw=
-github.com/lightninglabs/loop v0.28.5-beta.0.20240607082710-7368d048da05 h1:EU0k3EwoF+iXLA3VBor4qZNKJH7FKdQMCUqKVpDdtEc=
-github.com/lightninglabs/loop v0.28.5-beta.0.20240607082710-7368d048da05/go.mod h1:YhiTlh/yqWNgyAeYvISWV+3h2daKPXr7pfNPf5wJ7H0=
+github.com/lightninglabs/lndclient v1.0.1-0.20240724144614-a676c76e9eaa h1:Yf3V7e6jVfGEjamRY4mTiAq+flbnasx97+66zHVoXX0=
+github.com/lightninglabs/lndclient v1.0.1-0.20240724144614-a676c76e9eaa/go.mod h1:bxd2a15cIaW8KKcmOf9nNDI/GTxxj0upEYs1EIkttqw=
+github.com/lightninglabs/loop v0.28.6-beta.0.20240729115851-63e976ab27a4 h1:Sr7rXR6zK5EaMVNP+3fMK32X1nqMrHJF8nFBsT6UO9o=
+github.com/lightninglabs/loop v0.28.6-beta.0.20240729115851-63e976ab27a4/go.mod h1:DxPSqqESqDRuJB4FJpCeVpOA7qSx7PXi04FFmiIbDqQ=
 github.com/lightninglabs/loop/swapserverrpc v1.0.8 h1:bk7dDGuA3JQUsMDqZNyAy5Pcw5xS9jforz7YnyeSxKM=
 github.com/lightninglabs/loop/swapserverrpc v1.0.8/go.mod h1:Ml3gMwe/iTRLvu1QGGZzXcr0DYSa9sJGwKPktLaWtwE=
 github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd h1:D8aRocHpoCv43hL8egXEMYyPmyOiefFHZ66338KQB2s=

--- a/itest/litd_custom_channels_test.go
+++ b/itest/litd_custom_channels_test.go
@@ -425,7 +425,7 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 	// Dave, making it possible to send another asset HTLC below, sending
 	// all assets back to Charlie (so we have enough balance for further
 	// tests).
-	sendKeySendPayment(t.t, charlie, dave, 2000, nil)
+	sendKeySendPayment(t.t, charlie, dave, 2000)
 	logBalance(t.t, nodes, assetID, "after BTC only keysend")
 
 	// Let's keysend the rest of the balance back to Charlie.
@@ -874,7 +874,7 @@ func testCustomChannelsGroupedAsset(_ context.Context, net *NetworkHarness,
 	daveAssetBalance -= keySendAmount
 
 	// We should also be able to do a non-asset (BTC only) keysend payment.
-	sendKeySendPayment(t.t, charlie, dave, 2000, nil)
+	sendKeySendPayment(t.t, charlie, dave, 2000)
 	logBalance(t.t, nodes, assetID, "after BTC only keysend")
 
 	// ------------


### PR DESCRIPTION
Depends on https://github.com/lightninglabs/taproot-assets/pull/1048.
~Depends on https://github.com/lightningnetwork/lnd/pull/8947.~

Uses the new `tapchannelrpc` RPC methods `SendPayment` and `AddInvoice` that do the RFQ part inline, so we don't have to keep that logic in the `litcli` code.