### PR TITLE
Add nightly schedule to Docker CD workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,11 @@ on:
   push:
     tags:
       - 'v*'
-
+  schedule:
+    # Every day at midnight (UTC).
+    - cron: '0 0 * * *'
+  # Manual trigger through the UI for testing.
+  workflow_dispatch:
 
 defaults:
   run:
@@ -13,6 +17,11 @@ defaults:
 env:
   DOCKER_ORG: lightninglabs
   DOCKER_REPO: lightning-terminal
+  NIGHTLY_DOCKER_REPO: lightning-terminal-nightly
+  # TODO(guggero): Change the branch to 'master' once the experimental branch is
+  # merged into master.
+  NIGHTLY_BRANCH_NAME: 0-19-staging
+  NIGHTLY_TAG_NAME: experimental-daily-testing
 
 jobs:
   main:
@@ -36,6 +45,15 @@ jobs:
         run: |
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
           echo "IMAGE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      # The daily/nightly build (or manual trigger) will always use the
+      # experimental branch and push to a different docker repo.
+      - name: Set daily tag
+        if: ${{ github.event.schedule == '0 0 * * *' || github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "RELEASE_VERSION=${{env.NIGHTLY_BRANCH_NAME}}" >> $GITHUB_ENV
+          echo "DOCKER_REPO=${{env.NIGHTLY_DOCKER_REPO}}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${{env.NIGHTLY_TAG_NAME}}-$(date -u +%Y%m%d)" >> $GITHUB_ENV
 
       - name: Build and push default image
         id: docker_build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,8 +30,12 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_API_KEY }}
 
+      # Make it possible to use different values for the version (used for git
+      # checkout) and the image tag (used for the docker image tag).
       - name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Build and push default image
         id: docker_build
@@ -39,7 +43,7 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: "${{ env.DOCKER_ORG }}/${{ env.DOCKER_REPO }}:${{ env.RELEASE_VERSION }}"
+          tags: "${{ env.DOCKER_ORG }}/${{ env.DOCKER_REPO }}:${{ env.IMAGE_TAG }}"
           build-args: checkout=${{ env.RELEASE_VERSION }}
 
       - name: Build and push image with /lit path
@@ -48,7 +52,7 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: "${{ env.DOCKER_ORG }}/${{ env.DOCKER_REPO }}:${{ env.RELEASE_VERSION }}-path-prefix"
+          tags: "${{ env.DOCKER_ORG }}/${{ env.DOCKER_REPO }}:${{ env.IMAGE_TAG }}-path-prefix"
           build-args: |
             checkout=${{ env.RELEASE_VERSION }}
             public_url=/lit

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,8 +11,8 @@ defaults:
     shell: bash
 
 env:
-  DOCKER_REPO: lightninglabs
-  DOCKER_IMAGE: lightning-terminal
+  DOCKER_ORG: lightninglabs
+  DOCKER_REPO: lightning-terminal
 
 jobs:
   main:
@@ -39,7 +39,7 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: "${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}"
+          tags: "${{ env.DOCKER_ORG }}/${{ env.DOCKER_REPO }}:${{ env.RELEASE_VERSION }}"
           build-args: checkout=${{ env.RELEASE_VERSION }}
 
       - name: Build and push image with /lit path
@@ -48,7 +48,7 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: "${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}-path-prefix"
+          tags: "${{ env.DOCKER_ORG }}/${{ env.DOCKER_REPO }}:${{ env.RELEASE_VERSION }}-path-prefix"
           build-args: |
             checkout=${{ env.RELEASE_VERSION }}
             public_url=/lit


### PR DESCRIPTION
Added a daily schedule to the Docker workflow to automate builds and
pushes of the `daily-testing` image. This change introduces a new cron
job that runs every day at midnight (UTC) and triggers the workflow.

Additionally, updated the workflow to set different environment
variables for daily builds, including `RELEASE_VERSION` and `IMAGE_TAG`.
These changes enable the automatic creation of daily testing images with
unique tags.

Inspired by:
https://github.com/lightningnetwork/lnd/blob/57a5e4912bced63ce13be06896f64d7e476616b4/.github/workflows/docker.yml#L7-L44
