### PR TITLE
litclient: add taprpc packages to `Registrations`

### DIFF
--- a/litclient/jsoncallbacks.go
+++ b/litclient/jsoncallbacks.go
@@ -10,6 +10,9 @@ import (
 	"github.com/lightninglabs/taproot-assets/taprpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/assetwalletrpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
+	"github.com/lightninglabs/taproot-assets/taprpc/priceoraclerpc"
+	"github.com/lightninglabs/taproot-assets/taprpc/rfqrpc"
+	"github.com/lightninglabs/taproot-assets/taprpc/tapchannelrpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/universerpc"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/autopilotrpc"
@@ -55,4 +58,7 @@ var Registrations = []StubPackageRegistration{
 	assetwalletrpc.RegisterAssetWalletJSONCallbacks,
 	universerpc.RegisterUniverseJSONCallbacks,
 	mintrpc.RegisterMintJSONCallbacks,
+	priceoraclerpc.RegisterPriceOracleJSONCallbacks,
+	rfqrpc.RegisterRfqJSONCallbacks,
+	tapchannelrpc.RegisterTaprootAssetChannelsJSONCallbacks,
 }


### PR DESCRIPTION
Add the `priceoraclerpc`, `rfqrpc`, and the `tapchannelrpc` JSON callbacks to the litclient's `Registrations` array. This allows the litclient to use the rpc functions contained in these JSON callbacks.

These registrations are required for apps using the LNC (wasm) to call RPC methods. Without these additional callbacks, the wasm will return a "RPC method not found" error when calling RPCs contained in these packages. 