### PR TITLE
.github: clear build cache between image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,6 +63,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: "${{ env.DOCKER_ORG }}/${{ env.DOCKER_REPO }}:${{ env.IMAGE_TAG }}"
           build-args: checkout=${{ env.RELEASE_VERSION }}
+      
+      - name: Clear the build cache
+        run: docker builder prune -a -f
 
       - name: Build and push image with /lit path
         id: docker_build2


### PR DESCRIPTION
To fix the issue that currently prevents the second image (with the /lit path prefix) to be built and pushed (both for releases and nightly builds), we clear the build cache between builds.

Example failure: https://github.com/lightninglabs/lightning-terminal/actions/runs/10462945206

```
System.IO.IOException: No space left on device : '/home/runner/runners/2.319.1/_diag/Worker_20240820-001701-utc.log'
```

