### PR TITLE
itest: spend assets after sweeping from force close

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/lightninglabs/loop/swapserverrpc v1.0.8
 	github.com/lightninglabs/pool v0.6.5-beta.0.20240604070222-e121aadb3289
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.2
-	github.com/lightninglabs/taproot-assets v0.4.2-0.20240815180811-2110839696cb
+	github.com/lightninglabs/taproot-assets v0.4.2-0.20240824000229-881ecafbeae1
 	github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240730143253-1b353b0bfd58
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/fn v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1175,8 +1175,8 @@ github.com/lightninglabs/pool/auctioneerrpc v1.1.2 h1:Dbg+9Z9jXnhimR27EN37foc4aB
 github.com/lightninglabs/pool/auctioneerrpc v1.1.2/go.mod h1:1wKDzN2zEP8srOi0B9iySlEsPdoPhw6oo3Vbm1v4Mhw=
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display h1:pRdza2wleRN1L2fJXd6ZoQ9ZegVFTAb2bOQfruJPKcY=
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-github.com/lightninglabs/taproot-assets v0.4.2-0.20240815180811-2110839696cb h1:0MPIRVvk7ExBV35xEfAS2gDzQyGfufPYVhCAp2S6jwo=
-github.com/lightninglabs/taproot-assets v0.4.2-0.20240815180811-2110839696cb/go.mod h1:PMlRq9aKXaxs6PMeLnj3y3YnofrylNvEOTxvegTbhSc=
+github.com/lightninglabs/taproot-assets v0.4.2-0.20240824000229-881ecafbeae1 h1:2yncq2U2xvEUPjYEP5dGazJGj83Y+gr0di/aQVmXPs8=
+github.com/lightninglabs/taproot-assets v0.4.2-0.20240824000229-881ecafbeae1/go.mod h1:PMlRq9aKXaxs6PMeLnj3y3YnofrylNvEOTxvegTbhSc=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f h1:Pua7+5TcFEJXIIZ1I2YAUapmbcttmLj4TTi786bIi3s=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
 github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240730143253-1b353b0bfd58 h1:qmJAHLGfpeYIl1qUKyQViOjNAVRqF4afKuORzeIAwjA=


### PR DESCRIPTION
Depends on https://github.com/lightninglabs/taproot-assets/pull/1103.

Demonstrates the issue in https://github.com/lightninglabs/taproot-assets/issues/1099, and that the fix works.