### PR TITLE
chore: add vscode config to support itest debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,22 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Debug itest",
+      "type": "go",
+      "request": "launch",
+      "mode": "exec",
+      "preLaunchTask": "reset before itest",
+      "program": "itest/itest.test",
+      "args": [
+        "-test.v",
+        "-test.run=TestLightningTerminal/test_custom_channels",
+        "-logoutput",
+        "-logdir=${workspaceFolder}/itest/.logs",
+        "-litdexec=${workspaceFolder}/itest/litd-itest",
+        "-btcdexec=${workspaceFolder}/itest/btcd-itest",
+      ]
+    },
+    {
       "name": "Debug Tests",
       "type": "node",
       "request": "launch",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,62 @@
+{
+  "version": "2.0.0",
+        "tasks": [
+                {
+                        "type": "shell",
+                        "label": "build itest all",
+                        "command": "make build-itest; make build-itest-litd",
+                        "presentation": {
+                                "echo": true,
+                                "reveal": "always",
+                                "focus": false,
+                                "panel": "shared",
+                                "clear": false
+                        },
+                        "problemMatcher": []
+                },
+                {
+                        "type": "shell",
+                        "label": "build itest litd",
+                        "command": "make build-itest-litd",
+                        "presentation": {
+                                "echo": true,
+                                "reveal": "always",
+                                "focus": false,
+                                "panel": "shared",
+                                "clear": false
+                        },
+                        "problemMatcher": []
+                },
+                {
+                        "type": "shell",
+                        "label": "clear itest logs",
+                        "options": {
+                                "cwd": "${workspaceFolder}/itest"
+                        },
+                        "command": "rm -rf ./*.log .logs*",
+                        "presentation": {
+                                "echo": true,
+                                "reveal": "always",
+                                "focus": false,
+                                "panel": "shared",
+                                "clear": false
+                        },
+                        "problemMatcher": []
+                },
+                {
+                        "label": "reset before itest",
+                        "dependsOn": [
+                                "build itest litd",
+                                "clear itest logs"
+                        ],
+                        "presentation": {
+                                "echo": true,
+                                "reveal": "always",
+                                "focus": false,
+                                "panel": "shared",
+                                "clear": false
+                        },
+                        "problemMatcher": []
+                }
+        ]
+}

--- a/Makefile
+++ b/Makefile
@@ -199,11 +199,12 @@ build-itest: app-build
 	CGO_ENABLED=0 $(GOBUILD) -tags="$(ITEST_TAGS)" -o itest/btcd-itest -ldflags "$(ITEST_LDFLAGS)" $(BTCD_PKG)
 	CGO_ENABLED=0 $(GOBUILD) -tags="$(ITEST_TAGS)" -o itest/lnd-itest -ldflags "$(ITEST_LDFLAGS)" $(LND_PKG)/cmd/lnd
 
-itest-only:
+build-itest-litd:
 	@$(call print, "Building itest binary.")
 	CGO_ENABLED=0 $(GOBUILD) -tags="$(ITEST_TAGS)" -o itest/litd-itest -ldflags "$(ITEST_LDFLAGS)" $(PKG)/cmd/litd
 	CGO_ENABLED=0 $(GOTEST) -v ./itest -tags="$(DEV_TAGS) $(ITEST_TAGS)" -c -o itest/itest.test
 
+itest-only: build-itest-litd
 	@$(call print, "Running integration tests.")
 	rm -rf itest/*.log itest/.logs*; date
 	scripts/itest_part.sh $(ITEST_FLAGS)


### PR DESCRIPTION
This PR adds a debug target for VSCode users to make itest debugging easier.

Breakpoints in the itest work as expected, and with some changes you can also step into the subprojects (tapd, lnd) being run as part of litd:

- Update `go.mod` to use a local copy of the subproject repo; e.x.:

`replace github.com/lightninglabs/taproot-assets => ../tap/tap`

- Set a breakpoint in an itest, right after all nodes are started.
- Open a new window in the workspace of the subproject.
- Use the 'Attach to process' debug target in that window to attach to a litd node started from the itest.

At that point, breakpoints in both windows should work as normal.

I think this would need some cleanup to be mergeable; I'm not sure if the itest case name could be fetched dynamiccaly from the task name. The subtasks could also be cleaned up a bit.