### PR TITLE
config: add a "--version" config option 

### DIFF
--- a/config.go
+++ b/config.go
@@ -147,6 +147,8 @@ var (
 // all config items of its enveloping subservers, each prefixed with their
 // daemon's short name.
 type Config struct {
+	ShowVersion bool `long:"version" description:"Display version information and exit."`
+
 	HTTPSListen    string   `long:"httpslisten" description:"The main litd host:port to listen on for incoming HTTP/2 connections. On this port all gRPC services of all enabled daemons are exposed as well as REST (if --enablerest is specified), grpc-web and the web UI itself."`
 	HTTPListen     string   `long:"insecure-httplisten" description:"The host:port to listen on with TLS disabled. This is dangerous to enable as credentials will be submitted without encryption. Should only be used in combination with Tor hidden services or other external encryption."`
 	EnableREST     bool     `long:"enablerest" description:"Also allow REST requests to be made to the main HTTP(s) port(s) configured above."`
@@ -345,6 +347,10 @@ func loadAndValidateConfig(interceptor signal.Interceptor) (*Config, error) {
 	// Show the version and exit if the version flag was specified.
 	appName := filepath.Base(os.Args[0])
 	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
+	if preCfg.ShowVersion {
+		fmt.Println(appName, "version", Version())
+		os.Exit(0)
+	}
 	if preCfg.Lnd.ShowVersion {
 		fmt.Println(appName, "version", build.Version(),
 			"commit="+build.Commit)

--- a/docs/release-notes/release-notes-0.13.4.md
+++ b/docs/release-notes/release-notes-0.13.4.md
@@ -4,10 +4,15 @@
 
 ### Lightning Terminal
 
-- [Fixed a bug where REST calls for the `WalletUnlocker` service weren't allowed
+* [Fixed a bug where REST calls for the `WalletUnlocker` service weren't allowed
   on startup](https://github.com/lightninglabs/lightning-terminal/pull/806).
-- [Added build flag 'litd_no_ui' for building litd without the ui, accessible 
+
+* [Added build flag 'litd_no_ui' for building litd without the ui, accessible 
 with 'make go-build-noui' and 'make go-install-noui'](https://github.com/lightninglabs/lightning-terminal/pull/500).
+
+* Add a ['--version' 
+  flag](https://github.com/lightninglabs/lightning-terminal/pull/830) to litd 
+  which can be used to obtain version information of the daemon.
 
 ### LND
 
@@ -23,4 +28,5 @@ with 'make go-build-noui' and 'make go-install-noui'](https://github.com/lightni
 
 # Contributors (Alphabetical Order)
 
+* Elle Mouton
 * Oliver Gugger

--- a/version.go
+++ b/version.go
@@ -16,7 +16,7 @@ import (
 var Commit string
 
 // semanticAlphabet
-const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-."
 
 // These constants define the application version and follow the semantic
 // versioning 2.0.0 spec (http://semver.org/).


### PR DESCRIPTION
With this commit, a user can now run `litd --version` instead of needing
to run `litd --lnd.version` or `litcli --version` to obtain the LiTd
version.

Fixes https://github.com/lightninglabs/lightning-terminal/issues/828