### PR TITLE
lightning-terminal: ensure reproducible releases

### DIFF
--- a/docs/release-notes/release-notes-0.13.5.md
+++ b/docs/release-notes/release-notes-0.13.5.md
@@ -7,6 +7,10 @@
 - [Fixed a bug due to google-protobuf where a channel with SCID aliases on would cause terminal frontend
   to be unable to call the `ListChannels` RPC](https://github.com/lightninglabs/lightning-terminal/pull/850).
 
+- [Ensured reproducible
+  releases](https://github.com/lightninglabs/lightning-terminal/pull/852) by
+  setting a fixed timestamps for the files in the release script.
+
 ### LND
 
 ### Loop

--- a/release.sh
+++ b/release.sh
@@ -17,6 +17,61 @@ POOL_PKG="github.com/lightninglabs/pool"
 TAP_PKG="github.com/lightninglabs/taproot-assets"
 PACKAGE=lightning-terminal
 
+# Needed for setting file timestamps to get reproducible archives.
+BUILD_DATE="2020-01-01 00:00:00"
+BUILD_DATE_STAMP="202001010000.00"
+
+# reproducible_tar_gzip creates a reproducible tar.gz file of a directory. This
+# includes setting all file timestamps and ownership settings uniformly.
+function reproducible_tar_gzip() {
+  local dir=$1
+  local tar_cmd=tar
+
+  # MacOS has a version of BSD tar which doesn't support setting the --mtime
+  # flag. We need gnu-tar, or gtar for short to be installed for this script to
+  # work properly.
+  tar_version=$(tar --version)
+  if [[ ! "$tar_version" =~ "GNU tar" ]]; then
+    if ! command -v "gtar"; then
+      echo "GNU tar is required but cannot be found!"
+      echo "On MacOS please run 'brew install gnu-tar' to install gtar."
+      exit 1
+    fi
+
+    # We have gtar installed, use that instead.
+    tar_cmd=gtar
+  fi
+
+  # Pin down the timestamp time zone.
+  export TZ=UTC
+
+  find "${dir}" -print0 | LC_ALL=C sort -r -z | $tar_cmd \
+    "--mtime=${BUILD_DATE}" --no-recursion --null --mode=u+rw,go+r-w,a+X \
+    --owner=0 --group=0 --numeric-owner -c -T - | gzip -9n > "${dir}.tar.gz"
+
+  rm -r "${dir}"
+}
+
+# reproducible_zip creates a reproducible zip file of a directory. This
+# includes setting all file timestamps.
+function reproducible_zip() {
+  local dir=$1
+
+  # Pin down file name encoding and timestamp time zone.
+  export TZ=UTC
+
+  # Set the date of each file in the directory that's about to be packaged to
+  # the same timestamp and make sure the same permissions are used everywhere.
+  chmod -R 0755 "${dir}"
+  touch -t "${BUILD_DATE_STAMP}" "${dir}"
+  find "${dir}" -print0 | LC_ALL=C sort -r -z | xargs -0r touch \
+    -t "${BUILD_DATE_STAMP}"
+
+  find "${dir}" | LC_ALL=C sort -r | zip -o -X -r -@ "${dir}.zip"
+
+  rm -r "${dir}"
+}
+
 # green prints one line of green text (if the terminal supports it).
 function green() {
   echo -e "\e[0;32m${1}\e[0m"
@@ -37,20 +92,27 @@ function build_release() {
 
   green " - Packaging vendor"
   go mod vendor
-  tar -czf vendor.tar.gz vendor
+  reproducible_tar_gzip vendor
 
   maindir=$PACKAGE-$tag
   mkdir -p $maindir
+  mv vendor.tar.gz "${maindir}/"
 
-  cp vendor.tar.gz $maindir/
-  rm vendor.tar.gz
-  rm -r vendor
+  # Don't use tag in source directory, otherwise our file names get too long and
+  # tar starts to package them non-deterministically.
+  package_source="${PACKAGE}-source"
 
-  package_source="${maindir}/${PACKAGE}-source-${tag}.tar"
-  git archive -o "${package_source}" HEAD
-  gzip -f "${package_source}" >"${package_source}.gz"
+  # The git archive command doesn't support setting timestamps and file
+  # permissions. That's why we unpack the tar again, then use our reproducible
+  # method to create the final archive.
+  git archive -o "${maindir}/${package_source}.tar" HEAD
 
   cd "${maindir}"
+  mkdir -p ${package_source}
+  tar -xf "${package_source}.tar" -C ${package_source}
+  rm "${package_source}.tar"
+  reproducible_tar_gzip ${package_source}
+  mv "${package_source}.tar.gz" "${package_source}-$tag.tar.gz"
 
   for i in $sys; do
     os=$(echo $i | cut -f1 -d-)
@@ -79,16 +141,21 @@ function build_release() {
     env CGO_ENABLED=0 GOOS=$os GOARCH=$arch GOARM=$arm go build -v -trimpath -ldflags="${ldflags}" -tags="${buildtags}" ${TAP_PKG}/cmd/tapcli
     popd
 
-    if [[ $os == "windows" ]]; then
-      zip -r "${dir}.zip" "${dir}"
-    else
-      tar -cvzf "${dir}.tar.gz" "${dir}"
-    fi
+    # Add the hashes for the individual binaries as well for easy verification
+    # of a single installed binary.
+    shasum -a 256 "${dir}/"* >> "manifest-$tag.txt" 
 
-    rm -r "${dir}"
+    if [[ $os == "windows" ]]; then
+      reproducible_zip "${dir}"
+    else
+      reproducible_tar_gzip "${dir}"
+    fi
   done
 
-  shasum -a 256 * >manifest-$tag.txt
+  # Add the hash of the packages too, then sort by the second column (name).
+  shasum -a 256 lightning-terminal-* vendor* >> "manifest-$tag.txt"
+  LC_ALL=C sort -k2 -o "manifest-$tag.txt" "manifest-$tag.txt"
+  cat "manifest-$tag.txt"
 }
 
 # usage prints the usage of the whole script.


### PR DESCRIPTION
This update modifies the release.sh script to ensure that release files are reproducible, generating identical hashes when rebuilt. Previously, the script did not set fixed timestamps for the files, resulting in different hashes across rebuilds.

Additionally, the release.sh script has been updated to align more closely with the behavior of the lnd release script, ensuring consistency and coherence across repositories for users. Let me know if you think it's unnecessary for us to mimic those behaviour in `litd` :) 

