### PR TITLE
make: update VERSION_TAG to a globally-consistent build-input identifier

### DIFF
--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -1,4 +1,5 @@
-VERSION_TAG = $(shell git describe --tags)
+# Create a globally-consistent, build-input identifier.
+VERSION_TAG = $(shell git describe --abbrev=40 --broken --tags --always)
 VERSION_CHECK = @$(call print, "Building master with date version tag")
 
 BUILD_SYSTEM = darwin-amd64 \


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/lightning-terminal/issues/863 https://github.com/lightninglabs/lightning-terminal/issues/854

Additional flags produce:
* Globally consistent commitment hash length, regardless of gitconfig
* `--broken` to create fail-safe tag indicating a dirty or corrupted
  work tree
* `--always` to generate a tag, even if no tags are reachable from the
  current commit.
