### PR TITLE
litcli: relax fundchannel checks

### DIFF
--- a/cmd/litcli/ln.go
+++ b/cmd/litcli/ln.go
@@ -120,22 +120,23 @@ func fundChannel(c *cli.Context) error {
 	}
 
 	assetFound := false
+	totalAmount := uint64(0)
 	for _, rpcAsset := range assets.Assets {
 		if !bytes.Equal(rpcAsset.AssetGenesis.AssetId, assetIDBytes) {
 			continue
 		}
 
-		if rpcAsset.Amount < requestedAmount {
-			continue
+		totalAmount += rpcAsset.Amount
+		if totalAmount >= requestedAmount {
+			assetFound = true
+			break
 		}
-
-		assetFound = true
 	}
 
 	if !assetFound {
-		return fmt.Errorf("asset with ID %x not found or no UTXO with "+
-			"at least amount %d is available", assetIDBytes,
-			requestedAmount)
+		return fmt.Errorf("asset with ID %x not found or no combined "+
+			"UTXOs with at least amount %d is available",
+			assetIDBytes, requestedAmount)
 	}
 
 	resp, err := tchrpcClient.FundChannel(

--- a/docs/release-notes/release-notes-0.13.995.md
+++ b/docs/release-notes/release-notes-0.13.995.md
@@ -19,9 +19,12 @@
 ### Taproot Assets
 
 * A few bugs related to TAP channel liquidity were fixed, sending very small or
-very big asset amounts is now possible. See [tapd PR](https://github.com/lightninglabs/taproot-assets/pull/1120).
-* `ListBalances` now supports the `include_leased` flag, which will include leased
-asset balances in the response.
+very big asset amounts is now possible. 
+See [tapd PR](https://github.com/lightninglabs/taproot-assets/pull/1120).
+* `ListBalances` now supports the `include_leased` flag, which will include
+leased asset balances in the response.
+* [The sanity checks for `fundchannel` now allow for composite 
+UTXOs.](https://github.com/lightninglabs/lightning-terminal/pull/865)
 
 # Autopilot
 


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/1142

The RPC calls were updated to allow composite UTXOs (assets from multiple asset utxos) for funding capability, but the same functionality is not available in the CLI due to the existing sanity check.

This commits changes the sanity check to allow for composite UTXOs by validating whether the running sum of the assets in the UTXOs is greater than the amount to be funded.