### PR TITLE
itest: add test for consistent balance reporting

### DIFF
--- a/docs/release-notes/release-notes-0.13.4.md
+++ b/docs/release-notes/release-notes-0.13.4.md
@@ -4,9 +4,9 @@
 
 ### Lightning Terminal
 
-- [Fixed a bug where REST calls for the `WalletUnlocker` service weren't allowed
+* [Fixed a bug where REST calls for the `WalletUnlocker` service weren't allowed
   on startup](https://github.com/lightninglabs/lightning-terminal/pull/806).
-- [Added build flag 'litd_no_ui' for building litd without the ui, accessible 
+* [Added build flag 'litd_no_ui' for building litd without the ui, accessible 
 with 'make go-build-noui' and 'make go-install-noui'](https://github.com/lightninglabs/lightning-terminal/pull/500).
 
 ### LND
@@ -19,8 +19,14 @@ with 'make go-build-noui' and 'make go-install-noui'](https://github.com/lightni
 
 ### Taproot Assets
 
+* [Inconsistent balance 
+  reporting](https://github.com/lightninglabs/lightning-terminal/pull/871) has
+  been fixed: on-channel balances are now exclusively reported through channel
+  balances and will not show up in asset balances reported by tapd.
+
 # Autopilot
 
 # Contributors (Alphabetical Order)
 
+* Gijs van Dam
 * Oliver Gugger

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/lightninglabs/loop/swapserverrpc v1.0.8
 	github.com/lightninglabs/pool v0.6.5-beta.0.20240604070222-e121aadb3289
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.2
-	github.com/lightninglabs/taproot-assets v0.4.2-0.20240923062224-3b92c82bb332
+	github.com/lightninglabs/taproot-assets v0.4.2-0.20241018073747-bacd6589ee90
 	github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240919091721-70580403898e
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/fn v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1175,8 +1175,8 @@ github.com/lightninglabs/pool/auctioneerrpc v1.1.2 h1:Dbg+9Z9jXnhimR27EN37foc4aB
 github.com/lightninglabs/pool/auctioneerrpc v1.1.2/go.mod h1:1wKDzN2zEP8srOi0B9iySlEsPdoPhw6oo3Vbm1v4Mhw=
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display h1:pRdza2wleRN1L2fJXd6ZoQ9ZegVFTAb2bOQfruJPKcY=
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-github.com/lightninglabs/taproot-assets v0.4.2-0.20240923062224-3b92c82bb332 h1:AVh0Ks5erEqC3RDY6gsycbf9dcYXv308j/kxi47WPyM=
-github.com/lightninglabs/taproot-assets v0.4.2-0.20240923062224-3b92c82bb332/go.mod h1:B6wbs1rSTBTJwTilsKt7p/WravtKqRvJI0ICDwvcdNQ=
+github.com/lightninglabs/taproot-assets v0.4.2-0.20241018073747-bacd6589ee90 h1:67sqOcoog67BcKzRuNMPhkPfG50vBLYQ617tUahoPWE=
+github.com/lightninglabs/taproot-assets v0.4.2-0.20241018073747-bacd6589ee90/go.mod h1:B6wbs1rSTBTJwTilsKt7p/WravtKqRvJI0ICDwvcdNQ=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f h1:Pua7+5TcFEJXIIZ1I2YAUapmbcttmLj4TTi786bIi3s=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
 github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240919091721-70580403898e h1:Weu9TWNEIpC4XLbcUoSFK3Pv2aUSwn7NlYZKdsm8wUU=

--- a/itest/assets_test.go
+++ b/itest/assets_test.go
@@ -1312,17 +1312,23 @@ func assertAssetBalance(t *testing.T, client *tapClient, assetID []byte,
 			return err
 		}
 
+		assetIDFound := false
 		for _, balance := range assetIDBalances.AssetBalances {
 			if !bytes.Equal(balance.AssetGenesis.AssetId, assetID) {
 				continue
 			}
 
+			assetIDFound = true
 			if expectedBalance != balance.Balance {
 				return fmt.Errorf("expected balance %d, got %d",
 					expectedBalance, balance.Balance)
 			}
 		}
 
+		if expectedBalance > 0 && !assetIDFound {
+			return fmt.Errorf("expected balance %d, got 0",
+				expectedBalance)
+		}
 		return nil
 	}, shortTimeout)
 	if err != nil {

--- a/itest/litd_test_list_on_test.go
+++ b/itest/litd_test_list_on_test.go
@@ -44,4 +44,8 @@ var allTestCases = []*testCase{
 		name: "test custom channels liquidity",
 		test: testCustomChannelsLiquidityEdgeCases,
 	},
+	{
+		name: "test custom channels balance consistency",
+		test: testCustomChannelsBalanceConsistency,
+	},
 }


### PR DESCRIPTION
We want proper asset balance reporting between lnd and tapd, without asset balances turing up in both the asset balance from tapd and the custom channel balance from lnd.

Currently this behavior is not aligned with that requirement. tapd has currently now way of not reporting asset balances that are actually part of the funding transaction of a custom channel. This is fixed with [taproot-assets PR 1151](https://github.com/lightninglabs/taproot-assets/pull/1151) 

The current PR under review here is dependent on the taproot-assets commit:
https://github.com/lightninglabs/taproot-assets/commit/31d333cce24bf1c20a43b6b3343fd4914713e8c3

Bumping the tap version was included in this commit 5bbf3d7424bcfaffaea3c01c6b47eb4f6fa791f1 and that commit should probably be edited once 1151 is merged.