### PR TITLE
itest: add <354 sats payment coverage for custom channels

### DIFF
--- a/itest/assets_test.go
+++ b/itest/assets_test.go
@@ -682,7 +682,7 @@ func createAndPayNormalInvoiceWithBtc(t *testing.T, src, dst *HarnessNode,
 	})
 	require.NoError(t, err)
 
-	payInvoiceWithSatoshi(t, src, invoiceResp)
+	payInvoiceWithSatoshi(t, src, invoiceResp, lnrpc.Payment_SUCCEEDED)
 }
 
 func createAndPayNormalInvoice(t *testing.T, src, rfqPeer, dst *HarnessNode,
@@ -706,7 +706,8 @@ func createAndPayNormalInvoice(t *testing.T, src, rfqPeer, dst *HarnessNode,
 }
 
 func payInvoiceWithSatoshi(t *testing.T, payer *HarnessNode,
-	invoice *lnrpc.AddInvoiceResponse) {
+	invoice *lnrpc.AddInvoiceResponse,
+	expectedStatus lnrpc.Payment_PaymentStatus) {
 
 	ctxb := context.Background()
 	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
@@ -723,7 +724,7 @@ func payInvoiceWithSatoshi(t *testing.T, payer *HarnessNode,
 
 	result, err := getPaymentResult(stream)
 	require.NoError(t, err)
-	require.Equal(t, lnrpc.Payment_SUCCEEDED, result.Status)
+	require.Equal(t, expectedStatus, result.Status)
 }
 
 func payInvoiceWithAssets(t *testing.T, payer, rfqPeer *HarnessNode,

--- a/itest/litd_custom_channels_test.go
+++ b/itest/litd_custom_channels_test.go
@@ -481,7 +481,9 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 	invoiceResp = createAssetInvoice(
 		t.t, charlie, dave, daveInvoiceAssetAmount, assetID,
 	)
-	payInvoiceWithSatoshi(t.t, charlie, invoiceResp)
+	payInvoiceWithSatoshi(
+		t.t, charlie, invoiceResp, lnrpc.Payment_SUCCEEDED,
+	)
 	logBalance(t.t, nodes, assetID, "after asset invoice paid with sats")
 
 	// We don't need to update the asset balances of Charlie and Dave here
@@ -524,7 +526,7 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 	invoiceResp = createAssetInvoice(
 		t.t, erin, fabia, fabiaInvoiceAssetAmount2, assetID,
 	)
-	payInvoiceWithSatoshi(t.t, dave, invoiceResp)
+	payInvoiceWithSatoshi(t.t, dave, invoiceResp, lnrpc.Payment_SUCCEEDED)
 	logBalance(t.t, nodes, assetID, "after invoice")
 
 	erinAssetBalance -= fabiaInvoiceAssetAmount2
@@ -952,7 +954,7 @@ func testCustomChannelsGroupedAsset(_ context.Context, net *NetworkHarness,
 	invoiceResp = createAssetInvoice(
 		t.t, erin, fabia, fabiaInvoiceAssetAmount2, assetID,
 	)
-	payInvoiceWithSatoshi(t.t, dave, invoiceResp)
+	payInvoiceWithSatoshi(t.t, dave, invoiceResp, lnrpc.Payment_SUCCEEDED)
 	logBalance(t.t, nodes, assetID, "after invoice")
 
 	erinAssetBalance -= fabiaInvoiceAssetAmount2
@@ -1940,4 +1942,17 @@ func testCustomChannelsLiquidityEdgeCases(_ context.Context,
 
 	logBalance(t.t, nodes, assetID, "after big asset payment (asset "+
 		"invoice, multi-hop)")
+
+	// Edge case: Now Charlie creates a tiny asset invoice to be paid for by
+	// Yara with satoshi. This is a multi-hop payment going over 2 asset
+	// channels, where the total asset value is less than the default anchor
+	// amount of 354 sats.
+	invoiceResp = createAssetInvoice(
+		t.t, dave, charlie, 1, assetID,
+	)
+
+	payInvoiceWithSatoshi(t.t, yara, invoiceResp, lnrpc.Payment_FAILED)
+
+	logBalance(t.t, nodes, assetID, "after small payment (asset "+
+		"invoice, <354sats)")
 }


### PR DESCRIPTION
## Description

This PR adds coverage for the scenario where an asset invoice worth less than 354 sats is paid for with sats (from a node that is not the RFQ peer).

This case triggers a specific code check in lnd where the incoming/outgoing sats produce a negative fee
(see [related issue](https://github.com/lightninglabs/taproot-assets/issues/1150))

The current expected status of the payment is set to `lnrpc.PAYMENT_FAILED` as this has not yet been patched.
This itest will be updated in order to expect a `lnrpc.PAYMENT_SUCCEEDED` once this behavior is fixed in lnd
(see [related PR](https://github.com/lightningnetwork/lnd/pull/8804) for tracking)