### PR TITLE
subserver+status: check map entries before adding new servers

### DIFF
--- a/docs/release-notes/release-notes-0.13.5.md
+++ b/docs/release-notes/release-notes-0.13.5.md
@@ -32,6 +32,9 @@
 ### Technical and Architectural Updates
 
 * [Convert litrpc package into a module](https://github.com/lightninglabs/lightning-terminal/pull/823).
+
+* Check internal maps before registering new sub-servers for both the 
+  [status and sub-server manager.](https://github.com/lightninglabs/lightning-terminal/pull/877)
  
 ### Autopilot
 

--- a/docs/release-notes/release-notes-0.13.5.md
+++ b/docs/release-notes/release-notes-0.13.5.md
@@ -1,21 +1,41 @@
 # Release Notes
 
-# Integrated Binary Updates
+- [Lightning Terminal](#lightning-terminal)
+  - [Bug Fixes](#bug-fixes)
+  - [Functional Changes/Additions](#functional-changesadditions)
+  - [Technical and Architectural Updates](#technical-and-architectural-updates)
+- [Integrated Binary Updates](#integrated-binary-updates)
+  - [LND](#lnd)
+  - [Loop](#loop)
+  - [Pool](#pool)
+  - [Faraday](#faraday)
+  - [Taproot Assets](#taproot-assets)
+- [Contributors](#contributors-alphabetical-order)
 
-### Lightning Terminal
+## Lightning Terminal
+
+### Bug Fixes
 
 * [Fixed a bug](https://github.com/lightninglabs/lightning-terminal/pull/850) 
   due to google-protobuf where a channel with SCID aliases on would cause 
   terminal frontend to be unable to call the `ListChannels` RPC].
 
-* Add a new [`litcli bakesupermacaroon`](https://github.com/lightninglabs/lightning-terminal/pull/858) 
+### Functional Changes/Additions
+
+* [Add a new `litcli bakesupermacaroon`](https://github.com/lightninglabs/lightning-terminal/pull/858) 
   helper command. This new command can be used either with a LiT macaroon which 
   has the appropriate permissions or with an LND macaroon which has the 
   permissions required to call the LND `BakeMacaroon` call. This later case is 
   especially useful in stateless-init mode where users will not have access to 
   a LiT macaroon to perform this call with. 
 
-- [Convert litrpc package into a module](https://github.com/lightninglabs/lightning-terminal/pull/823).
+### Technical and Architectural Updates
+
+* [Convert litrpc package into a module](https://github.com/lightninglabs/lightning-terminal/pull/823).
+ 
+### Autopilot
+
+## Integrated Binary Updates
 
 ### LND
 
@@ -26,8 +46,6 @@
 ### Faraday
 
 ### Taproot Assets
-
-# Autopilot
 
 # Contributors (Alphabetical Order)
 

--- a/status/manager.go
+++ b/status/manager.go
@@ -145,30 +145,38 @@ func (s *Manager) SubServerStatus(_ context.Context,
 
 // RegisterSubServer will create a new sub-server entry for the Manager to
 // keep track of.
-func (s *Manager) RegisterSubServer(name string, opts ...SubServerOption) {
+func (s *Manager) RegisterSubServer(name string,
+	opts ...SubServerOption) error {
+
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	s.registerSubServerUnsafe(name, true, opts...)
+	return s.registerSubServerUnsafe(name, true, opts...)
 }
 
 // RegisterAndEnableSubServer will create a new sub-server entry for the
 // Manager to keep track of and will set it as enabled.
 func (s *Manager) RegisterAndEnableSubServer(name string,
-	opts ...SubServerOption) {
+	opts ...SubServerOption) error {
 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	s.registerSubServerUnsafe(name, false, opts...)
+	return s.registerSubServerUnsafe(name, false, opts...)
 }
 
 func (s *Manager) registerSubServerUnsafe(name string, disabled bool,
-	opts ...SubServerOption) {
+	opts ...SubServerOption) error {
 
-	ss := newSubServer(disabled, opts...)
+	_, ok := s.subServers[name]
+	if ok {
+		return fmt.Errorf("a subserver with name %s has already "+
+			"been registered with the status manager", name)
+	}
 
-	s.subServers[name] = ss
+	s.subServers[name] = newSubServer(disabled, opts...)
+
+	return nil
 }
 
 // SetCustomStatus updates the custom status of the given sub-server to the

--- a/subservers/manager.go
+++ b/subservers/manager.go
@@ -53,7 +53,10 @@ func NewManager(permsMgr *perms.Manager,
 // AddServer adds a new subServer to the manager's set.
 func (s *Manager) AddServer(ss SubServer, enable bool) error {
 	// Register all sub-servers with the status server.
-	s.statusServer.RegisterSubServer(ss.Name())
+	err := s.statusServer.RegisterSubServer(ss.Name())
+	if err != nil {
+		return err
+	}
 
 	// If the sub-server has explicitly been disabled, then we don't add it
 	// to the set of servers tracked by the Manager.

--- a/terminal.go
+++ b/terminal.go
@@ -296,7 +296,10 @@ func (g *LightningTerminal) Run() error {
 
 	// Register our sub-servers. This must be done before the REST proxy is
 	// set up so that the correct REST handlers are registered.
-	g.initSubServers()
+	err = g.initSubServers()
+	if err != nil {
+		return fmt.Errorf("could not initialise sub-servers: %w", err)
+	}
 
 	// Construct the rpcProxy. It must be initialised before the main web
 	// server is started.
@@ -1677,33 +1680,49 @@ func (g *LightningTerminal) validateSuperMacaroon(ctx context.Context,
 
 // initSubServers registers the faraday and loop sub-servers with the
 // subServerMgr.
-func (g *LightningTerminal) initSubServers() {
-	g.subServerMgr.AddServer(
+func (g *LightningTerminal) initSubServers() error {
+	err := g.subServerMgr.AddServer(
 		subservers.NewFaradaySubServer(
 			g.cfg.Faraday, g.cfg.faradayRpcConfig,
 			g.cfg.Remote.Faraday, g.cfg.faradayRemote,
 		), g.cfg.FaradayMode != ModeDisable,
 	)
+	if err != nil {
+		return fmt.Errorf("could not register Faraday subserver: %w",
+			err)
+	}
 
-	g.subServerMgr.AddServer(
+	err = g.subServerMgr.AddServer(
 		subservers.NewLoopSubServer(
 			g.cfg.Loop, g.cfg.Remote.Loop, g.cfg.loopRemote,
 		), g.cfg.LoopMode != ModeDisable,
 	)
+	if err != nil {
+		return fmt.Errorf("could not register Loop subserver: %w", err)
+	}
 
-	g.subServerMgr.AddServer(
+	err = g.subServerMgr.AddServer(
 		subservers.NewPoolSubServer(
 			g.cfg.Pool, g.cfg.Remote.Pool, g.cfg.poolRemote,
 		), g.cfg.PoolMode != ModeDisable,
 	)
+	if err != nil {
+		return fmt.Errorf("could not register Pool subserver: %w", err)
+	}
 
-	g.subServerMgr.AddServer(
+	err = g.subServerMgr.AddServer(
 		subservers.NewTaprootAssetsSubServer(
 			g.cfg.Network, g.cfg.TaprootAssets,
 			g.cfg.Remote.TaprootAssets,
 			g.cfg.tapRemote, g.cfg.lndRemote,
 		), g.cfg.TaprootAssetsMode != ModeDisable,
 	)
+	if err != nil {
+		return fmt.Errorf("could not register Taproot Assets "+
+			"subserver: %w", err)
+	}
+
+	return nil
 }
 
 // BakeSuperMacaroon uses the lnd client to bake a macaroon that can include

--- a/terminal.go
+++ b/terminal.go
@@ -279,11 +279,22 @@ func (g *LightningTerminal) Run() error {
 	}
 
 	// Register LND, LiT and Accounts with the status manager.
-	g.statusMgr.RegisterAndEnableSubServer(
+	err = g.statusMgr.RegisterAndEnableSubServer(
 		subservers.LND, status.WithIsReadyOverride(lndOverride),
 	)
-	g.statusMgr.RegisterAndEnableSubServer(subservers.LIT)
-	g.statusMgr.RegisterSubServer(subservers.ACCOUNTS)
+	if err != nil {
+		return err
+	}
+
+	err = g.statusMgr.RegisterAndEnableSubServer(subservers.LIT)
+	if err != nil {
+		return err
+	}
+
+	err = g.statusMgr.RegisterSubServer(subservers.ACCOUNTS)
+	if err != nil {
+		return err
+	}
 
 	// Also enable the accounts subserver if it's not disabled.
 	if !g.cfg.Accounts.Disable {


### PR DESCRIPTION
1) For the subserver manager: use a map instead of an array for subservers. Check that there is no name collision before adding a new server. This is also nice if we want to get a specific subserver by its name (as is done in https://github.com/lightninglabs/lightning-terminal/pull/848). 

2) for the status manager, first check that we are not overriding an existing subserver before we register a new one