### PR TITLE
Revert "make: update VERSION_TAG to a globally-consistent build-input identifier"

### DIFF
--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -1,5 +1,4 @@
-# Create a globally-consistent, build-input identifier.
-VERSION_TAG = $(shell git describe --abbrev=40 --broken --tags --always)
+VERSION_TAG = $(shell git describe --tags)
 VERSION_CHECK = @$(call print, "Building master with date version tag")
 
 BUILD_SYSTEM = darwin-amd64 \


### PR DESCRIPTION
This PR reverts commit `66d2bd1bdade3cacf1df263799bf4569a97af3ec`. Unfortunately, this commit leads to a `-dirty` suffix being added to built releases, on multiple environments. The reason for that is that as the `make release` build process rebuilds the app build folder, which temporarily removes the `.gitkeep` file in that folder. As the `VERSION_TAG` then gets based on a build that lacks the `.gitkeep` file, the build process adds the `-dirty` suffix to the version.

To reviewers:
I'm pushing this as a draft PR for now, as I'd like to get a approach ACK that we'd like to do revert the commit.

Alternatively to reverting, the only other approach I could figure that actually worked to consistently produce a release build without the `-dirty` suffix, is to simply remove the execution of `app-build` in the `make release` command. We'd then need to make it a prerequisite to execute the `make app-build` command prior to the `make release` command during the release process. As that's not very bullet proof and easy to forget, I wouldn't personally opt for doing so. As our actual releases does come with a `-dirty` suffix for the commit when running `litd --version`, I could also see the argument for actually doing releases in that way.
This alternative approach could potentially also make it easier to achieve actual consistent reproducible releases across different environments as well. 