### PR TITLE
Bump `litd` version to `v0.13.6-alpha`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ in remote mode (meaning that `lnd-mode=remote` is set). It shows the
 
 | LiT               | LND          |
 |-------------------|--------------|
+| **v0.13.6-alpha** | v0.17.1-beta |
 | **v0.13.5-alpha** | v0.17.1-beta |
 | **v0.13.4-alpha** | v0.17.1-beta |
 | **v0.13.3-alpha** | v0.17.1-beta |
@@ -161,6 +162,7 @@ The following table shows the supported combinations:
 
 | LiT               | LND          | Loop         | Faraday       | Pool         | Taproot Assets |
 |-------------------|--------------|--------------|---------------|--------------|----------------|
+| **v0.13.6-alpha** | v0.18.3-beta | v0.28.8-beta | v0.2.13-alpha | v0.6.5-beta  | v0.4.1-alpha   |
 | **v0.13.5-alpha** | v0.18.3-beta | v0.28.8-beta | v0.2.13-alpha | v0.6.5-beta  | v0.4.1-alpha   |
 | **v0.13.4-alpha** | v0.18.3-beta | v0.28.7-beta | v0.2.13-alpha | v0.6.5-beta  | v0.4.1-alpha   |
 | **v0.13.3-alpha** | v0.18.2-beta | v0.28.6-beta | v0.2.13-alpha | v0.6.5-beta  | v0.4.1-alpha   |

--- a/docs/release-notes/release-notes-0.13.6.md
+++ b/docs/release-notes/release-notes-0.13.6.md
@@ -1,0 +1,39 @@
+# Release Notes
+
+- [Lightning Terminal](#lightning-terminal)
+  - [Bug Fixes](#bug-fixes)
+  - [Functional Changes/Additions](#functional-changesadditions)
+  - [Technical and Architectural Updates](#technical-and-architectural-updates)
+- [Integrated Binary Updates](#integrated-binary-updates)
+  - [LND](#lnd)
+  - [Loop](#loop)
+  - [Pool](#pool)
+  - [Faraday](#faraday)
+  - [Taproot Assets](#taproot-assets)
+- [Contributors](#contributors-alphabetical-order)
+
+## Lightning Terminal
+
+### Bug Fixes
+
+* [Bump application version](https://github.com/lightninglabs/lightning-terminal/pull/889)
+  to `v0.13.6-alpha` with a hotfix release, as the previous `litd` release
+  didn't update the application version.
+
+### Functional Changes/Additions
+
+### Technical and Architectural Updates
+
+## Integrated Binary Updates
+
+### LND
+
+### Loop
+
+### Pool
+
+### Faraday
+
+### Taproot Assets
+
+# Contributors (Alphabetical Order)

--- a/version.go
+++ b/version.go
@@ -23,7 +23,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	appMajor uint = 0
 	appMinor uint = 13
-	appPatch uint = 4
+	appPatch uint = 6
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.


### PR DESCRIPTION
This PR bumps the litd version to `v0.13.6-alpha`.

This is a hotfix release, which bumps the application version in `litd` to `v0.13.6-alpha`, as I forgot to update the application version in the previous release. Apologies for that! Not modifying the application version for the previous release, resulted in `litd` outputting an incorrect `version`.

For reviewers: I've kept the headings and subheadings in the release notes, despite the body of those sections being empty, following the approach used in lnd. Let me know if you'd prefer a different format for litd. :)