### PR TITLE
Add itest for MinRelayFee check in tapd

### DIFF
--- a/cmd/litcli/ln.go
+++ b/cmd/litcli/ln.go
@@ -64,7 +64,6 @@ var fundChannelCommand = cli.Command{
 			Usage: "(optional) a manual fee expressed in " +
 				"sat/vByte that should be used when crafting " +
 				"the transaction",
-			Value: 1,
 		},
 		cli.Uint64Flag{
 			Name: "push_amt",

--- a/docs/release-notes/release-notes-0.13.7.md
+++ b/docs/release-notes/release-notes-0.13.7.md
@@ -1,0 +1,41 @@
+# Release Notes
+
+- [Lightning Terminal](#lightning-terminal)
+  - [Bug Fixes](#bug-fixes)
+  - [Functional Changes/Additions](#functional-changesadditions)
+  - [Technical and Architectural Updates](#technical-and-architectural-updates)
+- [Integrated Binary Updates](#integrated-binary-updates)
+  - [LND](#lnd)
+  - [Loop](#loop)
+  - [Pool](#pool)
+  - [Faraday](#faraday)
+  - [Taproot Assets](#taproot-assets)
+- [Contributors](#contributors-alphabetical-order)
+
+## Lightning Terminal
+
+### Bug Fixes
+
+### Functional Changes/Additions
+
+* [Add itest](https://github.com/lightninglabs/lightning-terminal/pull/892) for
+  the MinRelayFee check added in Taproot Assets. The test ensures that
+  transactions with fees below the minimum relay fee are rejected.
+
+### Technical and Architectural Updates
+
+## Integrated Binary Updates
+
+### LND
+
+### Loop
+
+### Pool
+
+### Faraday
+
+### Taproot Assets
+
+
+
+# Contributors (Alphabetical Order)

--- a/go.mod
+++ b/go.mod
@@ -16,14 +16,14 @@ require (
 	github.com/lightninglabs/lightning-node-connect v0.3.2-alpha.0.20240822142323-ee4e7ff52f83
 	github.com/lightninglabs/lightning-terminal/autopilotserverrpc v0.0.1
 	github.com/lightninglabs/lightning-terminal/litrpc v1.0.0
-	github.com/lightninglabs/lndclient v0.18.4-1
+	github.com/lightninglabs/lndclient v0.18.4-3
 	github.com/lightninglabs/loop v0.28.8-beta.0.20241022072406-1e8ae31ddc27
 	github.com/lightninglabs/loop/looprpc v1.0.0
 	github.com/lightninglabs/loop/swapserverrpc v1.0.10
 	github.com/lightninglabs/pool v0.6.5-beta.0.20241015105339-044cb451b5df
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.2
 	github.com/lightninglabs/pool/poolrpc v1.0.0
-	github.com/lightninglabs/taproot-assets v0.4.2-0.20241031160301-588e58bfae6c
+	github.com/lightninglabs/taproot-assets v0.4.2-0.20241101220611-e6b78bd51722
 	github.com/lightningnetwork/lnd v0.18.3-beta.rc3.0.20241025090009-615f3d633e61
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/fn v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -1157,8 +1157,8 @@ github.com/lightninglabs/lightning-node-connect v0.3.2-alpha.0.20240822142323-ee
 github.com/lightninglabs/lightning-node-connect v0.3.2-alpha.0.20240822142323-ee4e7ff52f83/go.mod h1:+SasPOt0evcJdfApb/ALTaTz4x3a2/kWy5KqFoTpiX8=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2 h1:Er1miPZD2XZwcfE4xoS5AILqP1mj7kqnhbBSxW9BDxY=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2/go.mod h1:antQGRDRJiuyQF6l+k6NECCSImgCpwaZapATth2Chv4=
-github.com/lightninglabs/lndclient v0.18.4-1 h1:k2UnxHGNH243NRe5/dL2sKgrxc8WMHbFQRdnCtfilwc=
-github.com/lightninglabs/lndclient v0.18.4-1/go.mod h1:/HLqmZGL9MtP8F1g+laq+L9VrsugBN5tsTct3C5wWCg=
+github.com/lightninglabs/lndclient v0.18.4-3 h1:Xk3ZuCQE4ZlF70jaToryL2MvRcryiE0zTfUjJbmzUBY=
+github.com/lightninglabs/lndclient v0.18.4-3/go.mod h1:/HLqmZGL9MtP8F1g+laq+L9VrsugBN5tsTct3C5wWCg=
 github.com/lightninglabs/loop v0.28.8-beta.0.20241022072406-1e8ae31ddc27 h1:eZBvG9XvDL0zsUIqFfD7SCk+Ex8rGWEL8j5UQ/aqjco=
 github.com/lightninglabs/loop v0.28.8-beta.0.20241022072406-1e8ae31ddc27/go.mod h1:4B1DqrcOc5Yv9KyclAeQJY9Ah9UMX7RpI4Uru7aEzl4=
 github.com/lightninglabs/loop/looprpc v1.0.0 h1:xry4QPCZShPww660xJm1BVcNFj8etgNeN2vMpfsv3c4=
@@ -1177,8 +1177,8 @@ github.com/lightninglabs/pool/poolrpc v1.0.0 h1:vvosrgNx9WXF4mcHGqLjZOW8wNM0q+BL
 github.com/lightninglabs/pool/poolrpc v1.0.0/go.mod h1:ZqpEpBFRMMBAerMmilEjh27tqauSXDwLaLR0O3jvmMA=
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display h1:w7FM5LH9Z6CpKxl13mS48idsu6F+cEZf0lkyiV+Dq9g=
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
-github.com/lightninglabs/taproot-assets v0.4.2-0.20241031160301-588e58bfae6c h1:HfU82bWD4Yk+Mf2Ax25uhcIwq0SxToTq8J8YJLReW/U=
-github.com/lightninglabs/taproot-assets v0.4.2-0.20241031160301-588e58bfae6c/go.mod h1:AYq9p1FOMdwAGjEjVaT79+cDyAwcc4fj8W0YJvCU0JE=
+github.com/lightninglabs/taproot-assets v0.4.2-0.20241101220611-e6b78bd51722 h1:67uNN65L8P6rcTkFAAuD+oYldQcDkSQLGK+o4Cfu/X8=
+github.com/lightninglabs/taproot-assets v0.4.2-0.20241101220611-e6b78bd51722/go.mod h1:DLcxQrwsLSXLTMNr1hBY5+pJSxNJYqobPqxhflYYFp8=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb h1:yfM05S8DXKhuCBp5qSMZdtSwvJ+GFzl94KbXMNB1JDY=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
 github.com/lightningnetwork/lnd v0.18.3-beta.rc3.0.20241025090009-615f3d633e61 h1:EcBM2tz+iyspYRFaDVjUe5a2bkuBWFxOWD2mzdCraUc=

--- a/itest/litd_test_list_on_test.go
+++ b/itest/litd_test_list_on_test.go
@@ -60,4 +60,8 @@ var allTestCases = []*testCase{
 		name: "test custom channels oracle pricing",
 		test: testCustomChannelsOraclePricing,
 	},
+	{
+		name: "test custom channels fee",
+		test: testCustomChannelsFee,
+	},
 }


### PR DESCRIPTION
This commit adds an integration test for the MinRelayFee check. The test ensures that transactions with fees below the minimum relay fee are rejected.

This PR depends on https://github.com/lightninglabs/taproot-assets/pull/1163 which in turn depends on  https://github.com/lightninglabs/lndclient/pull/200

It uses pseudoversions in `go.mod` for ~both~ `taproot-assets` ~and `lndclient`~ that should be updated before merging.