### PR TITLE
config: disable internal GRPC logger by default

### DIFF
--- a/docs/release-notes/release-notes-0.13.7.md
+++ b/docs/release-notes/release-notes-0.13.7.md
@@ -1,0 +1,42 @@
+# Release Notes
+
+- [Lightning Terminal](#lightning-terminal)
+    - [Bug Fixes](#bug-fixes)
+    - [Functional Changes/Additions](#functional-changesadditions)
+    - [Technical and Architectural Updates](#technical-and-architectural-updates)
+- [Integrated Binary Updates](#integrated-binary-updates)
+    - [LND](#lnd)
+    - [Loop](#loop)
+    - [Pool](#pool)
+    - [Faraday](#faraday)
+    - [Taproot Assets](#taproot-assets)
+- [Contributors](#contributors-alphabetical-order)
+
+## Lightning Terminal
+
+### Bug Fixes
+
+* [Disable the `GRPC` internal low-level connection logger by
+  default](https://github.com/lightninglabs/lightning-terminal/pull/896).
+  It can still be enabled by adding `,GRPC=info` at the end of the
+  `lnd.debuglevel` or `remote.lit-debuglevel` configuration options.
+
+### Functional Changes/Additions
+
+### Technical and Architectural Updates
+
+## Integrated Binary Updates
+
+### LND
+
+### Loop
+
+### Pool
+
+### Faraday
+
+### Taproot Assets
+
+# Contributors (Alphabetical Order)
+
+- Oliver Gugger


### PR DESCRIPTION
The GRPC connection logger is very verbose and normally not very useful. So it leads to more confusion and unnecessary log bloat than it actually helps to debug things.
So we disable it by default, meaning that if GRPC=<level> doesn't appear in the log level config string, we add GRPC=off.
That means we can still manually turn it on by adding ,GRPC=info to the log config (e.g. --lnd.debuglevel=debug,GRPC=info).

See https://github.com/lightninglabs/lightning-terminal/issues/895 for an example where the log is less than useful.