### PR TITLE
Replace deprecated boolean in .vscode with string value

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,8 +61,8 @@
     }
   ],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  },
+    "source.fixAll.eslint": "explicit"
+},
   "eslint.workingDirectories": [
     "./app"
   ],


### PR DESCRIPTION
The boolean values for `source.fixAll.eslint` are deprecated. This
commit changes the boolean values to the correct string values.

See: https://code.visualstudio.com/updates/v1_83#_editor