### PR TITLE
Launch.json test-mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,29 +8,42 @@
       "name": "Debug itest",
       "type": "go",
       "request": "launch",
-      "mode": "exec",
+      "mode": "test",
       "preLaunchTask": "reset before itest",
-      "program": "itest/itest.test",
+      "program": "${workspaceFolder}/itest",
+      "env": {
+        "CGO_ENABLED": "0",
+      },
       "args": [
         "-test.v",
         "-test.run=TestLightningTerminal/test_custom_channels",
         "-logoutput",
         "-logdir=${workspaceFolder}/itest/.logs",
         "-litdexec=${workspaceFolder}/itest/litd-itest",
-        "-btcdexec=${workspaceFolder}/itest/btcd-itest",
-      ]
+      ],
+      "buildFlags": [
+        "-ldflags=-X github.com/lightningnetwork/lnd/build.RawTags=chainrpc,walletrpc,signrpc,invoicesrpc,autopilotrpc,watchtowerrpc,twclientrpc -X github.com/lightningnetwork/lnd/build.Commit=lightning-terminal-v0.4.0-alpha -X github.com/lightninglabs/loop.Commit=localbuild -X github.com/lightninglabs/pool.Commit=localbuild -X github.com/lightninglabs/lightning-terminal.Commit=localbuild",
+        "-tags=dev integration itest lowscrypt litd autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc neutrinorpc peersrpc",
+      ],
     },
     {
       "name": "Debug Tests",
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "${workspaceRoot}/app/node_modules/.bin/react-scripts",
-      "args": ["test", "--runInBand", "--no-cache", "--watchAll=false"],
+      "args": [
+        "test",
+        "--runInBand",
+        "--no-cache",
+        "--watchAll=false"
+      ],
       "cwd": "${workspaceRoot}/app/",
       "protocol": "inspector",
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "env": { "CI": "true" },
+      "env": {
+        "CI": "true"
+      },
       "disableOptimisticBPs": true
     }
   ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,23 +1,10 @@
 {
-  "version": "2.0.0",
+        "version": "2.0.0",
         "tasks": [
                 {
                         "type": "shell",
-                        "label": "build itest all",
-                        "command": "make build-itest; make build-itest-litd",
-                        "presentation": {
-                                "echo": true,
-                                "reveal": "always",
-                                "focus": false,
-                                "panel": "shared",
-                                "clear": false
-                        },
-                        "problemMatcher": []
-                },
-                {
-                        "type": "shell",
-                        "label": "build itest litd",
-                        "command": "make build-itest-litd",
+                        "label": "build itest",
+                        "command": "make build-itest",
                         "presentation": {
                                 "echo": true,
                                 "reveal": "always",
@@ -46,7 +33,7 @@
                 {
                         "label": "reset before itest",
                         "dependsOn": [
-                                "build itest litd",
+                                "build itest",
                                 "clear itest logs"
                         ],
                         "presentation": {

--- a/Makefile
+++ b/Makefile
@@ -199,12 +199,11 @@ build-itest: app-build
 	CGO_ENABLED=0 $(GOBUILD) -tags="$(ITEST_TAGS)" -o itest/btcd-itest -ldflags "$(ITEST_LDFLAGS)" $(BTCD_PKG)
 	CGO_ENABLED=0 $(GOBUILD) -tags="$(ITEST_TAGS)" -o itest/lnd-itest -ldflags "$(ITEST_LDFLAGS)" $(LND_PKG)/cmd/lnd
 
-build-itest-litd:
+itest-only:
 	@$(call print, "Building itest binary.")
 	CGO_ENABLED=0 $(GOBUILD) -tags="$(ITEST_TAGS)" -o itest/litd-itest -ldflags "$(ITEST_LDFLAGS)" $(PKG)/cmd/litd
 	CGO_ENABLED=0 $(GOTEST) -v ./itest -tags="$(DEV_TAGS) $(ITEST_TAGS)" -c -o itest/itest.test
 
-itest-only: build-itest-litd
 	@$(call print, "Running integration tests.")
 	rm -rf itest/*.log itest/.logs*; date
 	scripts/itest_part.sh $(ITEST_FLAGS)


### PR DESCRIPTION
This commit changes the mode of itest configuration in `launch.json` to
test-mode. It also removes the unused flag `btcdexec`. The binary is
expected by lnd though, so it still needs to be built.