### PR TITLE
dev.Dockerfile: allow forcing a specific taproot-assets version

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -23,8 +23,9 @@ COPY --from=nodejsbuilder /go/src/github.com/lightninglabs/lightning-terminal /g
 # queries required to connect to linked containers succeed.
 ENV GODEBUG netdns=cgo
 
-# allow forcing a specific taproot-assets version through a build argument
-# see https://go.dev/ref/mod#version-queries for the types of queries that can be used to define a version
+# Allow forcing a specific taproot-assets version through a build argument.
+# Please see https://go.dev/ref/mod#version-queries for the types of
+# queries that can be used to define a version.
 ARG TAPROOT_ASSETS_VERSION
 
 # Install dependencies and install/build lightning-terminal.

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -23,10 +23,18 @@ COPY --from=nodejsbuilder /go/src/github.com/lightninglabs/lightning-terminal /g
 # queries required to connect to linked containers succeed.
 ENV GODEBUG netdns=cgo
 
+# allow forcing a specific taproot-assets version through a build argument
+# see https://go.dev/ref/mod#version-queries for the types of queries that can be used to define a version
+ARG TAPROOT_ASSETS_VERSION
+
 # Install dependencies and install/build lightning-terminal.
-RUN apk add --no-cache --update alpine-sdk \
-  make \
+RUN apk add --no-cache --update alpine-sdk make \
   && cd /go/src/github.com/lightninglabs/lightning-terminal \
+  # if custom taproot-assets version supplied, apply it
+  && if [ -n "$TAPROOT_ASSETS_VERSION" ]; then \
+    go get -v github.com/lightninglabs/taproot-assets@$TAPROOT_ASSETS_VERSION \
+    && go mod tidy; \
+  fi \
   && make go-install \
   && make go-install-cli
 


### PR DESCRIPTION
dev.Dockerfile: allow forcing a specific taproot-assets version through a build argument.

An example of usage can be found here: https://github.com/lightninglabs/tapdvalidation/blob/cb7c752e9b123dc99882a471afa04cc1066e5111/docker-compose.yaml#L66

