### PR TITLE
mod+itest: bump tapd, assert asset decimal display

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/lightninglabs/pool v0.6.5-beta.0.20241015105339-044cb451b5df
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.2
 	github.com/lightninglabs/pool/poolrpc v1.0.0
-	github.com/lightninglabs/taproot-assets v0.5.0-rc1.0.20241206085244-8113fa8bb314
+	github.com/lightninglabs/taproot-assets v0.5.0-rc1.0.20241209075049-4a15eb2ab84e
 	github.com/lightningnetwork/lnd v0.18.4-beta.rc1
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/fn v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -1177,8 +1177,8 @@ github.com/lightninglabs/pool/poolrpc v1.0.0 h1:vvosrgNx9WXF4mcHGqLjZOW8wNM0q+BL
 github.com/lightninglabs/pool/poolrpc v1.0.0/go.mod h1:ZqpEpBFRMMBAerMmilEjh27tqauSXDwLaLR0O3jvmMA=
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display h1:w7FM5LH9Z6CpKxl13mS48idsu6F+cEZf0lkyiV+Dq9g=
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
-github.com/lightninglabs/taproot-assets v0.5.0-rc1.0.20241206085244-8113fa8bb314 h1:ykWP63wGxW0OKW4lITz8/lWv6CLMswRRX4DCr37wAkU=
-github.com/lightninglabs/taproot-assets v0.5.0-rc1.0.20241206085244-8113fa8bb314/go.mod h1:d9GdY5DVoSh6+dEQRS4UUcjpVvZlAHgP8U2DAp4YedA=
+github.com/lightninglabs/taproot-assets v0.5.0-rc1.0.20241209075049-4a15eb2ab84e h1:dFbyAZrkQ9xALiVUf0qikLV2TabucCgPwJZ/Dc6r62Y=
+github.com/lightninglabs/taproot-assets v0.5.0-rc1.0.20241209075049-4a15eb2ab84e/go.mod h1:d9GdY5DVoSh6+dEQRS4UUcjpVvZlAHgP8U2DAp4YedA=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb h1:yfM05S8DXKhuCBp5qSMZdtSwvJ+GFzl94KbXMNB1JDY=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
 github.com/lightningnetwork/lnd v0.18.4-beta.rc1 h1:z6hFKvtbfo8udPrIb81GbSoKlUWd06d4LRxTkD19IMQ=

--- a/itest/litd_custom_channels_test.go
+++ b/itest/litd_custom_channels_test.go
@@ -681,7 +681,7 @@ func testCustomChannels(_ context.Context, net *NetworkHarness,
 		t.t, universeTap, assetID, nil, fundingScriptTreeBytes,
 		fmt.Sprintf("%v:%v", fundRespCD.Txid, fundRespCD.OutputIndex),
 	)
-	assertAssetChan(t.t, charlie, dave, fundingAmount, assetID)
+	assertAssetChan(t.t, charlie, dave, fundingAmount, cents)
 
 	// And let's just close the channel again.
 	chanPointCD = &lnrpc.ChannelPoint{
@@ -1116,7 +1116,7 @@ func testCustomChannelsGroupedAsset(_ context.Context, net *NetworkHarness,
 		t.t, universeTap, nil, groupID, fundingScriptTreeBytes,
 		fmt.Sprintf("%v:%v", fundRespCD.Txid, fundRespCD.OutputIndex),
 	)
-	assertAssetChan(t.t, charlie, dave, fundingAmount, assetID)
+	assertAssetChan(t.t, charlie, dave, fundingAmount, cents)
 
 	// And let's just close the channel again.
 	chanPointCD = &lnrpc.ChannelPoint{
@@ -1292,7 +1292,7 @@ func testCustomChannelsForceClose(_ context.Context, net *NetworkHarness,
 	)
 
 	// Make sure the channel shows the correct asset information.
-	assertAssetChan(t.t, charlie, dave, fundingAmount, assetID)
+	assertAssetChan(t.t, charlie, dave, fundingAmount, cents)
 
 	// Before we start sending out payments, let's make sure each node can
 	// see the other one in the graph and has all required features.
@@ -1635,7 +1635,7 @@ func testCustomChannelsBreach(_ context.Context, net *NetworkHarness,
 	)
 
 	// Make sure the channel shows the correct asset information.
-	assertAssetChan(t.t, charlie, dave, fundingAmount, assetID)
+	assertAssetChan(t.t, charlie, dave, fundingAmount, cents)
 
 	// Before we start sending out payments, let's make sure each node can
 	// see the other one in the graph and has all required features.
@@ -2289,7 +2289,7 @@ func testCustomChannelsBalanceConsistency(_ context.Context,
 	// Make sure the pending channel shows up in the list and has the
 	// custom records set as JSON.
 	assertPendingChannels(
-		t.t, charlieTap.node, assetID, 1, charlieBalance, 0,
+		t.t, charlieTap.node, cents, 1, charlieBalance, 0,
 	)
 
 	// Let's confirm the channel.
@@ -2325,7 +2325,7 @@ func testCustomChannelsBalanceConsistency(_ context.Context,
 
 	// Make sure the channel shows the correct asset information.
 	assertAssetChan(
-		t.t, charlieTap.node, daveTap.node, charlieBalance, assetID,
+		t.t, charlieTap.node, daveTap.node, charlieBalance, cents,
 	)
 
 	logBalance(t.t, nodes, assetID, "initial")
@@ -2513,7 +2513,7 @@ func testCustomChannelsSingleAssetMultiInput(_ context.Context,
 
 	// Make sure the channel shows the correct asset information.
 	assertAssetChan(
-		t.t, charlieTap.node, daveTap.node, 2*halfCentsAmount, assetID,
+		t.t, charlieTap.node, daveTap.node, 2*halfCentsAmount, cents,
 	)
 }
 


### PR DESCRIPTION
~Depends on https://github.com/lightninglabs/taproot-assets/pull/1245.~

Asserts the decimal display value for all pending and opened channels.