### PR TITLE
Add lastHop parameter for loop in quotes

### DIFF
--- a/app/src/api/loop.ts
+++ b/app/src/api/loop.ts
@@ -57,10 +57,12 @@ class LoopApi extends BaseApi<LoopEvents> {
   async getLoopInQuote(
     amount: Big,
     confTarget?: number,
+    lastHop?: string,
   ): Promise<LOOP.InQuoteResponse.AsObject> {
     const req = new LOOP.QuoteRequest();
     req.setAmt(amount.toString());
     if (confTarget) req.setConfTarget(confTarget);
+    if (lastHop) req.setLoopInLastHop(b64(lastHop));
     const res = await this._grpc.request(SwapClient.GetLoopInQuote, req, this._meta);
     return res.toObject();
   }

--- a/app/src/store/views/buildSwapView.ts
+++ b/app/src/store/views/buildSwapView.ts
@@ -426,6 +426,7 @@ class BuildSwapView {
         const inQuote = await this._store.api.loop.getLoopInQuote(
           amount,
           this.confTarget,
+          this.loopInLastHop,
         );
         quote = {
           swapFee: Big(inQuote.swapFeeSat),

--- a/docs/release-notes/release-notes-0.14.1.md
+++ b/docs/release-notes/release-notes-0.14.1.md
@@ -16,6 +16,10 @@
 
 ### Bug Fixes
 
+* [Add `lastHop` parameter for Loop In 
+  quotes](https://github.com/lightninglabs/lightning-terminal/pull/920).
+  Fixes fee estimation bug when using Loop In for a specific channel.
+
 ### Functional Changes/Additions
 
 ### Technical and Architectural Updates
@@ -36,7 +40,7 @@
 
 ### Pool
 
-### Faraday
+### Faradayaa
 
 * The integrated `faraday` instance was
   [updated](https://github.com/lightninglabs/lightning-terminal/pull/952) to
@@ -55,5 +59,6 @@
 * Elle Mouton
 * jiangmencity
 * Oliver Gugger
+* Rachel Fish
 * Tristav
 * zhoufanjin


### PR DESCRIPTION
Fixes #904

Was able to reproduce this bug on regtest by changing the fee rate on one of my test nodes.

![Screenshot from 2024-12-12 16-17-17](https://github.com/user-attachments/assets/a707a092-62d9-4e98-a4e9-35ca5393bc68)

Fix was pretty simple because the `swapView` and loop protobuf definitons already had all of the necessary variables and functions defined :tada: 

![Screenshot from 2024-12-12 17-07-12](https://github.com/user-attachments/assets/caa6fc2b-2086-46ab-9258-d4e138ccc521)
