### PR TITLE
multi: fix typos

### DIFF
--- a/app/src/__tests__/util/appStorage.spec.ts
+++ b/app/src/__tests__/util/appStorage.spec.ts
@@ -38,7 +38,7 @@ describe('appStorage util', () => {
     expect(data).toBeUndefined();
   });
 
-  it('should save an value to sessionStorage', () => {
+  it('should save a value to sessionStorage', () => {
     appStorage.setSession(key, 'test-value');
 
     const value = sessionStorage.getItem(key);

--- a/app/src/__tests__/util/log.spec.ts
+++ b/app/src/__tests__/util/log.spec.ts
@@ -60,7 +60,7 @@ describe('log Util', () => {
       expect(debugMock).toBeCalledWith('[warn] sample message');
     });
 
-    it('should output a error log message', () => {
+    it('should output an error log message', () => {
       log.error('sample message');
       expect(debugMock).toBeCalledWith('[error] sample message');
     });
@@ -84,7 +84,7 @@ describe('log Util', () => {
       expect(debugMock).toBeCalledWith('[warn] sample message');
     });
 
-    it('should output a error log message', () => {
+    it('should output an error log message', () => {
       log.error('sample message');
       expect(debugMock).toBeCalledWith('[error] sample message');
     });
@@ -108,7 +108,7 @@ describe('log Util', () => {
       expect(debugMock).toBeCalledWith('[warn] sample message');
     });
 
-    it('should output a error log message', () => {
+    it('should output an error log message', () => {
       log.error('sample message');
       expect(debugMock).toBeCalledWith('[error] sample message');
     });
@@ -132,7 +132,7 @@ describe('log Util', () => {
       expect(debugMock).not.toBeCalledWith('[warn] sample message');
     });
 
-    it('should output a error log message', () => {
+    it('should output an error log message', () => {
       log.error('sample message');
       expect(debugMock).toBeCalledWith('[error] sample message');
     });

--- a/app/src/store/views/appView.ts
+++ b/app/src/store/views/appView.ts
@@ -182,7 +182,7 @@ export default class AppView {
     this._store.log.info('Switch to Setting screen', name);
   }
 
-  /** adds a alert to the store */
+  /** adds an alert to the store */
   notify(message: string, title?: string, type: Alert['type'] = 'error') {
     const alert: Alert = { id: Date.now(), type, message, title };
     if (type === 'success') alert.ms = 3000;

--- a/autopilotserver/client.go
+++ b/autopilotserver/client.go
@@ -103,7 +103,7 @@ type featurePerms struct {
 	sync.Mutex
 }
 
-// NewClient returns a autopilot-server client.
+// NewClient returns an autopilot-server client.
 func NewClient(cfg *Config) (Autopilot, error) {
 	var err error
 	cfg.DialOpts, err = getAutopilotServerDialOpts(


### PR DESCRIPTION
This pull request corrects several typos in the following files:

- **appStorage.spec.ts**: Changed "an value" to "a value" to fix an article usage error.
- **log.spec.ts**: Corrected "a error log message" to "an error log message" for proper article usage.
- **appView.ts**: Fixed "adds a alert" to "adds an alert" to ensure correct article usage.
- **client.go**: Corrected "returns a autopilot-server client" to "returns an autopilot-server client" to fix article usage.

These changes improve the consistency and accuracy of the code.
