### PR TITLE
makefile: add unit test helpers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,31 +176,18 @@ jobs:
         run: make lint mod-check
 
   ########################
-  # unit race tests
-  ########################
-  unit-race:
-    name: unit-race
-    runs-on: ubuntu-latest
-    steps:
-      - name: git checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: setup go ${{ env.GO_VERSION }}
-        uses: ./.github/actions/setup-go
-        with:
-          go-version: '${{ env.GO_VERSION }}'
-
-      - name: run check
-        run: make unit-race
-
-  ########################
   # unit tests
   ########################
-  unit:
-    name: unit tests
+  unit-test:
+    name: run unit tests
     runs-on: ubuntu-latest
+    strategy:
+      # Allow other tests in the matrix to continue if one fails.
+      fail-fast: false
+      matrix:
+        unit_type:
+          - unit-race
+          - unit
     steps:
       - name: git checkout
         uses: actions/checkout@v3
@@ -212,8 +199,8 @@ jobs:
         with:
           go-version: '${{ env.GO_VERSION }}'
 
-      - name: run check
-        run: make unit
+      - name: run ${{ matrix.unit_type }}
+        run: make ${{ matrix.unit_type }}
 
   ########################
   # integration tests

--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,6 @@ XARGS := xargs -L 1
 
 LINT = $(LINT_BIN) run -v
 
-UNIT := $(GOLIST) | $(XARGS) env $(GOTEST)
-UNIT_RACE := $(UNIT) -race
-
 include make/release_flags.mk
 include make/testing_flags.mk
 
@@ -199,7 +196,7 @@ check: unit
 unit:
 	@$(call print, "Running unit tests.")
 	mkdir -p app/build && touch app/build/index.html
-	$(UNIT) -tags="$(LND_RELEASE_TAGS)"
+	$(UNIT)
 
 unit-cover: $(GOACC_BIN)
 	@$(call print, "Running unit coverage tests.")
@@ -208,7 +205,7 @@ unit-cover: $(GOACC_BIN)
 unit-race:
 	@$(call print, "Running unit race tests.")
 	mkdir -p app/build && touch app/build/index.html
-	env CGO_ENABLED=1 GORACE="history_size=7 halt_on_errors=1" $(UNIT_RACE) -tags="$(LND_RELEASE_TAGS)"
+	env CGO_ENABLED=1 GORACE="history_size=7 halt_on_errors=1" $(UNIT_RACE)
 
 clean-itest:
 	@$(call print, "Cleaning itest binaries.")

--- a/docs/release-notes/release-notes-0.14.1.md
+++ b/docs/release-notes/release-notes-0.14.1.md
@@ -1,0 +1,41 @@
+# Release Notes
+
+- [Lightning Terminal](#lightning-terminal)
+    - [Bug Fixes](#bug-fixes)
+    - [Functional Changes/Additions](#functional-changesadditions)
+    - [Technical and Architectural Updates](#technical-and-architectural-updates)
+- [Integrated Binary Updates](#integrated-binary-updates)
+    - [LND](#lnd)
+    - [Loop](#loop)
+    - [Pool](#pool)
+    - [Faraday](#faraday)
+    - [Taproot Assets](#taproot-assets)
+- [Contributors](#contributors-alphabetical-order)
+ 
+## Lightning Terminal
+
+### Bug Fixes
+
+### Functional Changes/Additions
+
+### Technical and Architectural Updates
+
+* [Add some Makefile 
+  helpers](https://github.com/lightninglabs/lightning-terminal/pull/928) that 
+  allow for more control over running unit tests. 
+ 
+## Integrated Binary Updates
+
+### LND
+
+### Loop
+
+### Pool
+
+### Faraday
+
+### Taproot Assets
+
+# Contributors (Alphabetical Order)
+
+* Elle Mouton

--- a/make/compile_flags.mk
+++ b/make/compile_flags.mk
@@ -1,0 +1,1 @@
+COMPILE_TAGS = autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc neutrinorpc peersrpc

--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -1,3 +1,5 @@
+include make/compile_flags.mk
+
 # Create a globally-consistent, build-input identifier.
 VERSION_TAG = $(shell git describe --abbrev=40 --broken --tags --always)
 VERSION_CHECK = @$(call print, "Building master with date version tag")
@@ -21,7 +23,7 @@ linux-armv7 \
 linux-arm64 \
 windows-amd64
 
-LND_RELEASE_TAGS = litd autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc neutrinorpc peersrpc
+LND_RELEASE_TAGS = litd $(COMPILE_TAGS)
 
 # By default we will build all systems. But with the 'sys' tag, a specific
 # system can be specified. This is useful to release for a subset of

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -2,6 +2,7 @@ include make/compile_flags.mk
 
 ITEST_FLAGS =
 TEST_FLAGS =
+DEV_TAGS = dev
 
 # Define the integration test.run filter if the icase argument was provided.
 ifneq ($(icase),)
@@ -13,5 +14,10 @@ ifneq ($(case),)
 TEST_FLAGS += -test.run=$(case)
 endif
 
-UNIT := $(GOLIST) | $(XARGS) env $(GOTEST) -tags="$(COMPILE_TAGS)" $(TEST_FLAGS)
+# Add any additional tags that are passed in to make.
+ifneq ($(tags),)
+DEV_TAGS += ${tags}
+endif
+
+UNIT := $(GOLIST) | $(XARGS) env $(GOTEST) -tags="$(DEV_TAGS) $(COMPILE_TAGS)" $(TEST_FLAGS)
 UNIT_RACE := $(UNIT) -race

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -1,11 +1,17 @@
 include make/compile_flags.mk
 
 ITEST_FLAGS =
+TEST_FLAGS =
 
 # Define the integration test.run filter if the icase argument was provided.
 ifneq ($(icase),)
 ITEST_FLAGS += -test.run="TestLightningTerminal/$(icase)"
 endif
 
-UNIT := $(GOLIST) | $(XARGS) env $(GOTEST) -tags="$(COMPILE_TAGS)"
+# If a specific unit test case is being targeted, construct test.run filter.
+ifneq ($(case),)
+TEST_FLAGS += -test.run=$(case)
+endif
+
+UNIT := $(GOLIST) | $(XARGS) env $(GOTEST) -tags="$(COMPILE_TAGS)" $(TEST_FLAGS)
 UNIT_RACE := $(UNIT) -race

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -1,6 +1,11 @@
+include make/compile_flags.mk
+
 ITEST_FLAGS =
 
 # Define the integration test.run filter if the icase argument was provided.
 ifneq ($(icase),)
 ITEST_FLAGS += -test.run="TestLightningTerminal/$(icase)"
 endif
+
+UNIT := $(GOLIST) | $(XARGS) env $(GOTEST) -tags="$(COMPILE_TAGS)"
+UNIT_RACE := $(UNIT) -race

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -12,6 +12,16 @@ endif
 # If a specific unit test case is being targeted, construct test.run filter.
 ifneq ($(case),)
 TEST_FLAGS += -test.run=$(case)
+UNIT_TARGETED = yes
+endif
+
+# If specific package is being unit tested, construct the full name of the
+# subpackage.
+ifneq ($(pkg),)
+UNITPKG := $(PKG)/$(pkg)
+COVER_PKG := $(PKG)/$(pkg)
+UNIT_TARGETED = yes
+GOLIST = echo '$(PKG)/$(pkg)'
 endif
 
 # Add any additional tags that are passed in to make.
@@ -19,5 +29,18 @@ ifneq ($(tags),)
 DEV_TAGS += ${tags}
 endif
 
+# UNIT_TARGETED is undefined iff a specific package and/or unit test case is
+# not being targeted.
+UNIT_TARGETED ?= no
+
+# If a specific package/test case was requested, run the unit test for the
+# targeted case. Otherwise, default to running all tests.
+ifeq ($(UNIT_TARGETED), yes)
+UNIT := $(GOTEST) -tags="$(DEV_TAGS) $(COMPILE_TAGS)" $(TEST_FLAGS) $(UNITPKG)
+endif
+
+ifeq ($(UNIT_TARGETED), no)
 UNIT := $(GOLIST) | $(XARGS) env $(GOTEST) -tags="$(DEV_TAGS) $(COMPILE_TAGS)" $(TEST_FLAGS)
+endif
+
 UNIT_RACE := $(UNIT) -race

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -1,4 +1,4 @@
-ITEST_FLAGS = 
+ITEST_FLAGS =
 
 # Define the integration test.run filter if the icase argument was provided.
 ifneq ($(icase),)


### PR DESCRIPTION
Some helpers (lots of influence from the `taproot-assets` repo) to give devs more control over running unit tests. 

With this, we can now do things like:

```
# Run all tests in the accounts package.
make unit pkg=accounts

# Run a specific test in accounts package
make unit pkg=accounts case=TestAccountService

# Pass in additional flags (more useful in later PRs). 
make unit tags=test_db_postgres
```