### PR TITLE
go.mod: bump looprpc and swapserverrpc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/lightninglabs/lightning-terminal/litrpc v1.0.0
 	github.com/lightninglabs/lndclient v0.18.4-9
 	github.com/lightninglabs/loop v0.29.0-beta
-	github.com/lightninglabs/loop/looprpc v1.0.2
-	github.com/lightninglabs/loop/swapserverrpc v1.0.11
+	github.com/lightninglabs/loop/looprpc v1.0.3
+	github.com/lightninglabs/loop/swapserverrpc v1.0.12
 	github.com/lightninglabs/pool v0.6.5-beta.0.20241015105339-044cb451b5df
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.2
 	github.com/lightninglabs/pool/poolrpc v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1161,10 +1161,10 @@ github.com/lightninglabs/lndclient v0.18.4-9 h1:8PRBmJLyegs1zbqBvpN/0d8qGLiNst3M
 github.com/lightninglabs/lndclient v0.18.4-9/go.mod h1:11hKoRxXk+1IoIndEIvbmo18dwAJnTqr/lylRpYDVSU=
 github.com/lightninglabs/loop v0.29.0-beta h1:YRxZ3h41LsFOLTyvisxbijmvCf5UOUx4T0YUemdi0wA=
 github.com/lightninglabs/loop v0.29.0-beta/go.mod h1:Lc1qXyO0LoOHQVkzwxVlHTavybGGz0I1t5YozWH1WNo=
-github.com/lightninglabs/loop/looprpc v1.0.2 h1:evL3GpceeFaYmkeqf4hzeXQXgjrHeF3fzcB5Eajh7SM=
-github.com/lightninglabs/loop/looprpc v1.0.2/go.mod h1:w6zur9qV9EBY7I7bpnUYp0QGjVqNl9cjnozpPal9/XY=
-github.com/lightninglabs/loop/swapserverrpc v1.0.11 h1:R/8c/bo4rpqm5/cfi944rj24oQUlZu+xXjzMhEDSkrc=
-github.com/lightninglabs/loop/swapserverrpc v1.0.11/go.mod h1:Ml3gMwe/iTRLvu1QGGZzXcr0DYSa9sJGwKPktLaWtwE=
+github.com/lightninglabs/loop/looprpc v1.0.3 h1:TLJe6/SPY8ee3FzHaYx9E2isjWmdKR2HnYcF5Hdth98=
+github.com/lightninglabs/loop/looprpc v1.0.3/go.mod h1:w6zur9qV9EBY7I7bpnUYp0QGjVqNl9cjnozpPal9/XY=
+github.com/lightninglabs/loop/swapserverrpc v1.0.12 h1:A6ym5sCupNOPNsEhYEgTqWYR9C7Cev1cRpVetm6TewA=
+github.com/lightninglabs/loop/swapserverrpc v1.0.12/go.mod h1:Ml3gMwe/iTRLvu1QGGZzXcr0DYSa9sJGwKPktLaWtwE=
 github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd h1:D8aRocHpoCv43hL8egXEMYyPmyOiefFHZ66338KQB2s=
 github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd/go.mod h1:x3OmY2wsA18+Kc3TSV2QpSUewOCiscw2mKpXgZv2kZk=
 github.com/lightninglabs/neutrino/cache v1.1.2 h1:C9DY/DAPaPxbFC+xNNEI/z1SJY9GS3shmlu5hIQ798g=


### PR DESCRIPTION
Fix the build if GOPROXY="direct":

```
lightning-terminal$ go mod tidy 
go: downloading github.com/lightninglabs/loop/looprpc v1.0.2
go: downloading github.com/lightninglabs/loop/swapserverrpc v1.0.11
verifying github.com/lightninglabs/loop/looprpc@v1.0.2/go.mod: checksum mismatch
        downloaded: h1:+hPlWT2LGxEUY9mMVB2FcbV3KJmd1cmEezmZQagVUtY=
        go.sum:     h1:w6zur9qV9EBY7I7bpnUYp0QGjVqNl9cjnozpPal9/XY=

SECURITY ERROR
This download does NOT match an earlier download recorded in go.sum.
The bits may have been replaced on the origin server, or an attacker may
have intercepted the download attempt.

For more information, see 'go help module-auth'.
```

This happened, because the tags were reassigned to another commit and proxy.golang.org cached an old version.

New tags point to the same state.