### PR TITLE
refactor: using slices.Contains to simplify the code

### DIFF
--- a/session/privacy_flags.go
+++ b/session/privacy_flags.go
@@ -162,13 +162,7 @@ func Parse(flags string) (PrivacyFlags, error) {
 
 // Contains checks if a privacy flag is contained in the set.
 func (f PrivacyFlags) Contains(other PrivacyFlag) bool {
-	for _, flag := range f {
-		if flag == other {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(f, other)
 }
 
 // Equal checks if two sets of privacy flags are equal.


### PR DESCRIPTION
This is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.