### PR TITLE
.github: bump upload-artifact action to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -237,7 +237,7 @@ jobs:
         run: 7z a logs-itest.zip itest/**/*.log
 
       - name: Upload log files on failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: logs-itest


### PR DESCRIPTION
the `actions/upload-artifact@v3` is (or it seems might already be) [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). 

As per the [migration notes](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md), the only thing to be aware of is that we need to take care to namespace artifacts correctly so that jobs in the same CI run dont overwrite the artifacts of other jobs with the same name. Luckily in Lit, we only have 1 possible artifact at the moment so no worries re namespacing at the moment. When we start adding different DB backends, then this will come into play