### PR TITLE
multi: thread contexts through properly

### DIFF
--- a/accounts/checkers_test.go
+++ b/accounts/checkers_test.go
@@ -499,8 +499,8 @@ func TestSendPaymentCalls(t *testing.T) {
 
 func testSendPayment(t *testing.T, uri string) {
 	var (
-		parentCtx = context.Background()
-		zeroFee   = &lnrpc.FeeLimit{Limit: &lnrpc.FeeLimit_Fixed{
+		ctx     = context.Background()
+		zeroFee = &lnrpc.FeeLimit{Limit: &lnrpc.FeeLimit_Fixed{
 			Fixed: 0,
 		}}
 		requestID uint64
@@ -520,7 +520,7 @@ func testSendPayment(t *testing.T, uri string) {
 	service, err := NewService(t.TempDir(), errFunc)
 	require.NoError(t, err)
 
-	err = service.Start(lndMock, routerMock, chainParams)
+	err = service.Start(ctx, lndMock, routerMock, chainParams)
 	require.NoError(t, err)
 
 	assertBalance := func(id AccountID, expectedBalance int64) {
@@ -533,7 +533,7 @@ func testSendPayment(t *testing.T, uri string) {
 
 	// This should error because there is no account in the context.
 	err = service.checkers.checkIncomingRequest(
-		parentCtx, uri, &lnrpc.SendRequest{},
+		ctx, uri, &lnrpc.SendRequest{},
 	)
 	require.ErrorContains(t, err, "no account found in context")
 
@@ -543,7 +543,7 @@ func testSendPayment(t *testing.T, uri string) {
 	)
 	require.NoError(t, err)
 
-	ctxWithAcct := AddAccountToContext(parentCtx, acct)
+	ctxWithAcct := AddAccountToContext(ctx, acct)
 
 	// This should error because there is no request ID in the context.
 	err = service.checkers.checkIncomingRequest(
@@ -552,7 +552,7 @@ func testSendPayment(t *testing.T, uri string) {
 	require.ErrorContains(t, err, "no request ID found in context")
 
 	reqID1 := nextRequestID()
-	ctx := AddRequestIDToContext(ctxWithAcct, reqID1)
+	ctx = AddRequestIDToContext(ctxWithAcct, reqID1)
 
 	// This should error because no payment hash is provided.
 	err = service.checkers.checkIncomingRequest(
@@ -698,7 +698,7 @@ func testSendPayment(t *testing.T, uri string) {
 func TestSendPaymentV2(t *testing.T) {
 	var (
 		uri       = "/routerrpc.Router/SendPaymentV2"
-		parentCtx = context.Background()
+		ctx       = context.Background()
 		requestID uint64
 	)
 
@@ -716,7 +716,7 @@ func TestSendPaymentV2(t *testing.T) {
 	service, err := NewService(t.TempDir(), errFunc)
 	require.NoError(t, err)
 
-	err = service.Start(lndMock, routerMock, chainParams)
+	err = service.Start(ctx, lndMock, routerMock, chainParams)
 	require.NoError(t, err)
 
 	assertBalance := func(id AccountID, expectedBalance int64) {
@@ -729,7 +729,7 @@ func TestSendPaymentV2(t *testing.T) {
 
 	// This should error because there is no account in the context.
 	err = service.checkers.checkIncomingRequest(
-		parentCtx, uri, &routerrpc.SendPaymentRequest{},
+		ctx, uri, &routerrpc.SendPaymentRequest{},
 	)
 	require.ErrorContains(t, err, "no account found in context")
 
@@ -739,7 +739,7 @@ func TestSendPaymentV2(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	ctxWithAcct := AddAccountToContext(parentCtx, acct)
+	ctxWithAcct := AddAccountToContext(ctx, acct)
 
 	// This should error because there is no request ID in the context.
 	err = service.checkers.checkIncomingRequest(
@@ -748,7 +748,7 @@ func TestSendPaymentV2(t *testing.T) {
 	require.ErrorContains(t, err, "no request ID found in context")
 
 	reqID1 := nextRequestID()
-	ctx := AddRequestIDToContext(ctxWithAcct, reqID1)
+	ctx = AddRequestIDToContext(ctxWithAcct, reqID1)
 
 	// This should error because no payment hash is provided.
 	err = service.checkers.checkIncomingRequest(
@@ -885,7 +885,7 @@ func TestSendPaymentV2(t *testing.T) {
 func TestSendToRouteV2(t *testing.T) {
 	var (
 		uri       = "/routerrpc.Router/SendToRouteV2"
-		parentCtx = context.Background()
+		ctx       = context.Background()
 		requestID uint64
 	)
 
@@ -903,7 +903,7 @@ func TestSendToRouteV2(t *testing.T) {
 	service, err := NewService(t.TempDir(), errFunc)
 	require.NoError(t, err)
 
-	err = service.Start(lndMock, routerMock, chainParams)
+	err = service.Start(ctx, lndMock, routerMock, chainParams)
 	require.NoError(t, err)
 
 	assertBalance := func(id AccountID, expectedBalance int64) {
@@ -916,7 +916,7 @@ func TestSendToRouteV2(t *testing.T) {
 
 	// This should error because there is no account in the context.
 	err = service.checkers.checkIncomingRequest(
-		parentCtx, uri, &routerrpc.SendToRouteRequest{},
+		ctx, uri, &routerrpc.SendToRouteRequest{},
 	)
 	require.ErrorContains(t, err, "no account found in context")
 
@@ -926,7 +926,7 @@ func TestSendToRouteV2(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	ctxWithAcct := AddAccountToContext(parentCtx, acct)
+	ctxWithAcct := AddAccountToContext(ctx, acct)
 
 	// This should error because there is no request ID in the context.
 	err = service.checkers.checkIncomingRequest(
@@ -935,7 +935,7 @@ func TestSendToRouteV2(t *testing.T) {
 	require.ErrorContains(t, err, "no request ID found in context")
 
 	reqID1 := nextRequestID()
-	ctx := AddRequestIDToContext(ctxWithAcct, reqID1)
+	ctx = AddRequestIDToContext(ctxWithAcct, reqID1)
 
 	// This should error because no payment hash is provided.
 	err = service.checkers.checkIncomingRequest(

--- a/accounts/service_test.go
+++ b/accounts/service_test.go
@@ -838,7 +838,10 @@ func TestAccountService(t *testing.T) {
 			}
 
 			// Any errors during startup expected?
-			err = service.Start(lndMock, routerMock, chainParams)
+			err = service.Start(
+				context.Background(), lndMock, routerMock,
+				chainParams,
+			)
 			if tc.startupErr != "" {
 				require.ErrorContains(tt, err, tc.startupErr)
 

--- a/autopilotserver/client_test.go
+++ b/autopilotserver/client_test.go
@@ -32,7 +32,7 @@ func TestAutopilotClient(t *testing.T) {
 		PingCadence: time.Second,
 	})
 	require.NoError(t, err)
-	require.NoError(t, client.Start())
+	require.NoError(t, client.Start(ctx))
 	t.Cleanup(client.Stop)
 
 	privKey, err := btcec.NewPrivateKey()

--- a/autopilotserver/interface.go
+++ b/autopilotserver/interface.go
@@ -45,7 +45,7 @@ type Autopilot interface {
 	SessionRevoked(ctx context.Context, key *btcec.PublicKey)
 
 	// Start kicks off the goroutines of the client.
-	Start(opts ...func(cfg *Config)) error
+	Start(ctx context.Context, opts ...func(cfg *Config)) error
 
 	// Stop cleans up any resources held by the client.
 	Stop()

--- a/cmd/litcli/actions.go
+++ b/cmd/litcli/actions.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/hex"
 	"fmt"
 
@@ -98,49 +97,49 @@ var listActionsCommand = cli.Command{
 	},
 }
 
-func listActions(ctx *cli.Context) error {
-	ctxb := context.Background()
-	clientConn, cleanup, err := connectClient(ctx, false)
+func listActions(cli *cli.Context) error {
+	ctx := getContext()
+	clientConn, cleanup, err := connectClient(cli, false)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 	client := litrpc.NewFirewallClient(clientConn)
 
-	state, err := parseActionState(ctx.String("state"))
+	state, err := parseActionState(cli.String("state"))
 	if err != nil {
 		return err
 	}
 
 	var sessionID []byte
-	if ctx.String("session_id") != "" {
-		sessionID, err = hex.DecodeString(ctx.String("session_id"))
+	if cli.String("session_id") != "" {
+		sessionID, err = hex.DecodeString(cli.String("session_id"))
 		if err != nil {
 			return err
 		}
 	}
 
 	var groupID []byte
-	if ctx.String("group_id") != "" {
-		groupID, err = hex.DecodeString(ctx.String("group_id"))
+	if cli.String("group_id") != "" {
+		groupID, err = hex.DecodeString(cli.String("group_id"))
 		if err != nil {
 			return err
 		}
 	}
 
 	resp, err := client.ListActions(
-		ctxb, &litrpc.ListActionsRequest{
+		ctx, &litrpc.ListActionsRequest{
 			SessionId:      sessionID,
-			FeatureName:    ctx.String("feature"),
-			ActorName:      ctx.String("actor"),
-			MethodName:     ctx.String("method"),
+			FeatureName:    cli.String("feature"),
+			ActorName:      cli.String("actor"),
+			MethodName:     cli.String("method"),
 			State:          state,
-			IndexOffset:    ctx.Uint64("index_offset"),
-			MaxNumActions:  ctx.Uint64("max_num_actions"),
-			Reversed:       !ctx.Bool("oldest_first"),
-			CountTotal:     ctx.Bool("count_total"),
-			StartTimestamp: ctx.Uint64("start_timestamp"),
-			EndTimestamp:   ctx.Uint64("end_timestamp"),
+			IndexOffset:    cli.Uint64("index_offset"),
+			MaxNumActions:  cli.Uint64("max_num_actions"),
+			Reversed:       !cli.Bool("oldest_first"),
+			CountTotal:     cli.Bool("count_total"),
+			StartTimestamp: cli.Uint64("start_timestamp"),
+			EndTimestamp:   cli.Uint64("end_timestamp"),
 			GroupId:        groupID,
 		},
 	)

--- a/cmd/litcli/privacy_map.go
+++ b/cmd/litcli/privacy_map.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/hex"
 	"fmt"
 
@@ -63,9 +62,9 @@ var privacyMapConvertStrCommand = cli.Command{
 	},
 }
 
-func privacyMapConvertStr(ctx *cli.Context) error {
-	ctxb := context.Background()
-	clientConn, cleanup, err := connectClient(ctx, false)
+func privacyMapConvertStr(cli *cli.Context) error {
+	ctx := getContext()
+	clientConn, cleanup, err := connectClient(cli, false)
 	if err != nil {
 		return err
 	}
@@ -73,13 +72,13 @@ func privacyMapConvertStr(ctx *cli.Context) error {
 	client := litrpc.NewFirewallClient(clientConn)
 
 	var groupID []byte
-	if ctx.GlobalIsSet("group_id") {
-		groupID, err = hex.DecodeString(ctx.GlobalString("group_id"))
+	if cli.GlobalIsSet("group_id") {
+		groupID, err = hex.DecodeString(cli.GlobalString("group_id"))
 		if err != nil {
 			return err
 		}
-	} else if ctx.GlobalIsSet("session_id") {
-		groupID, err = hex.DecodeString(ctx.GlobalString("session_id"))
+	} else if cli.GlobalIsSet("session_id") {
+		groupID, err = hex.DecodeString(cli.GlobalString("session_id"))
 		if err != nil {
 			return err
 		}
@@ -88,9 +87,9 @@ func privacyMapConvertStr(ctx *cli.Context) error {
 	}
 
 	resp, err := client.PrivacyMapConversion(
-		ctxb, &litrpc.PrivacyMapConversionRequest{
-			RealToPseudo: ctx.GlobalBool("realtopseudo"),
-			Input:        ctx.String("input"),
+		ctx, &litrpc.PrivacyMapConversionRequest{
+			RealToPseudo: cli.GlobalBool("realtopseudo"),
+			Input:        cli.String("input"),
 			GroupId:      groupID,
 		},
 	)
@@ -117,9 +116,9 @@ var privacyMapConvertUint64Command = cli.Command{
 	},
 }
 
-func privacyMapConvertUint64(ctx *cli.Context) error {
-	ctxb := context.Background()
-	clientConn, cleanup, err := connectClient(ctx, false)
+func privacyMapConvertUint64(cli *cli.Context) error {
+	ctx := getContext()
+	clientConn, cleanup, err := connectClient(cli, false)
 	if err != nil {
 		return err
 	}
@@ -127,13 +126,13 @@ func privacyMapConvertUint64(ctx *cli.Context) error {
 	client := litrpc.NewFirewallClient(clientConn)
 
 	var groupID []byte
-	if ctx.GlobalIsSet("group_id") {
-		groupID, err = hex.DecodeString(ctx.GlobalString("group_id"))
+	if cli.GlobalIsSet("group_id") {
+		groupID, err = hex.DecodeString(cli.GlobalString("group_id"))
 		if err != nil {
 			return err
 		}
-	} else if ctx.GlobalIsSet("session_id") {
-		groupID, err = hex.DecodeString(ctx.GlobalString("session_id"))
+	} else if cli.GlobalIsSet("session_id") {
+		groupID, err = hex.DecodeString(cli.GlobalString("session_id"))
 		if err != nil {
 			return err
 		}
@@ -141,11 +140,11 @@ func privacyMapConvertUint64(ctx *cli.Context) error {
 		return fmt.Errorf("must set group_id")
 	}
 
-	input := firewalldb.Uint64ToStr(ctx.Uint64("input"))
+	input := firewalldb.Uint64ToStr(cli.Uint64("input"))
 
 	resp, err := client.PrivacyMapConversion(
-		ctxb, &litrpc.PrivacyMapConversionRequest{
-			RealToPseudo: ctx.GlobalBool("realtopseudo"),
+		ctx, &litrpc.PrivacyMapConversionRequest{
+			RealToPseudo: cli.GlobalBool("realtopseudo"),
 			Input:        input,
 			GroupId:      groupID,
 		},

--- a/cmd/litcli/status.go
+++ b/cmd/litcli/status.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"context"
-
 	"github.com/lightninglabs/lightning-terminal/litrpc"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/urfave/cli"
@@ -18,8 +16,8 @@ var statusCommands = []cli.Command{
 	},
 }
 
-func getStatus(ctx *cli.Context) error {
-	clientConn, cleanup, err := connectClient(ctx, true)
+func getStatus(cli *cli.Context) error {
+	clientConn, cleanup, err := connectClient(cli, true)
 	if err != nil {
 		return err
 	}
@@ -27,9 +25,9 @@ func getStatus(ctx *cli.Context) error {
 	litClient := litrpc.NewStatusClient(clientConn)
 
 	// Get LiT's status.
-	ctxb := context.Background()
+	ctx := getContext()
 	litResp, err := litClient.SubServerStatus(
-		ctxb, &litrpc.SubServerStatusReq{},
+		ctx, &litrpc.SubServerStatusReq{},
 	)
 	if err != nil {
 		return err
@@ -39,7 +37,7 @@ func getStatus(ctx *cli.Context) error {
 
 	// Get LND's state.
 	lndClient := lnrpc.NewStateClient(clientConn)
-	lndResp, err := lndClient.GetState(ctxb, &lnrpc.GetStateRequest{})
+	lndResp, err := lndClient.GetState(ctx, &lnrpc.GetStateRequest{})
 	if err != nil {
 		return err
 	}

--- a/cmd/litd/main.go
+++ b/cmd/litd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -11,7 +12,7 @@ import (
 
 // main starts the lightning-terminal application.
 func main() {
-	err := terminal.New().Run()
+	err := terminal.New().Run(context.Background())
 	var flagErr *flags.Error
 	isFlagErr := errors.As(err, &flagErr)
 	if err != nil && (!isFlagErr || flagErr.Type != flags.ErrHelp) {

--- a/rpcmiddleware/manager.go
+++ b/rpcmiddleware/manager.go
@@ -36,8 +36,8 @@ func NewManager(interceptTimeout time.Duration,
 }
 
 // Start starts the firewall by registering the interceptors with lnd.
-func (f *Manager) Start() error {
-	ctxc, cancel := context.WithCancel(context.Background())
+func (f *Manager) Start(ctx context.Context) error {
+	ctxc, cancel := context.WithCancel(ctx)
 	f.cancel = cancel
 
 	for _, i := range f.interceptors {

--- a/rules/chan_policy_bounds.go
+++ b/rules/chan_policy_bounds.go
@@ -39,8 +39,8 @@ func (b *ChanPolicyBoundsMgr) Stop() error {
 // values and config.
 //
 // NOTE: This is part of the Manager interface.
-func (b *ChanPolicyBoundsMgr) NewEnforcer(_ Config, values Values) (Enforcer,
-	error) {
+func (b *ChanPolicyBoundsMgr) NewEnforcer(_ context.Context, _ Config,
+	values Values) (Enforcer, error) {
 
 	bounds, ok := values.(*ChanPolicyBounds)
 	if !ok {

--- a/rules/channel_constraints.go
+++ b/rules/channel_constraints.go
@@ -38,8 +38,8 @@ func (m *ChanConstraintMgr) Stop() error {
 // values and config.
 //
 // NOTE: This is part of the Manager interface.
-func (m *ChanConstraintMgr) NewEnforcer(_ Config, values Values) (Enforcer,
-	error) {
+func (m *ChanConstraintMgr) NewEnforcer(_ context.Context, _ Config,
+	values Values) (Enforcer, error) {
 
 	bounds, ok := values.(*ChannelConstraint)
 	if !ok {

--- a/rules/channel_restrictions_test.go
+++ b/rules/channel_restrictions_test.go
@@ -53,7 +53,7 @@ func TestChannelRestrictCheckRequest(t *testing.T) {
 			},
 		},
 	}
-	enf, err := mgr.NewEnforcer(cfg, &ChannelRestrict{
+	enf, err := mgr.NewEnforcer(ctx, cfg, &ChannelRestrict{
 		DenyList: []uint64{
 			chanID1, chanID2,
 		},

--- a/rules/history_limit.go
+++ b/rules/history_limit.go
@@ -38,8 +38,8 @@ func (h *HistoryLimitMgr) Stop() error {
 // values and config.
 //
 // NOTE: This is part of the Manager interface.
-func (h *HistoryLimitMgr) NewEnforcer(_ Config, values Values) (Enforcer,
-	error) {
+func (h *HistoryLimitMgr) NewEnforcer(_ context.Context, _ Config,
+	values Values) (Enforcer, error) {
 
 	limit, ok := values.(*HistoryLimit)
 	if !ok {

--- a/rules/interfaces.go
+++ b/rules/interfaces.go
@@ -16,7 +16,8 @@ import (
 type Manager interface {
 	// NewEnforcer constructs a new rule enforcer using the passed values
 	// and config.
-	NewEnforcer(cfg Config, values Values) (Enforcer, error)
+	NewEnforcer(ctx context.Context, cfg Config, values Values) (Enforcer,
+		error)
 
 	// NewValueFromProto converts the given proto value into a Value object.
 	NewValueFromProto(p *litrpc.RuleValue) (Values, error)

--- a/rules/manager_set.go
+++ b/rules/manager_set.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -32,7 +33,7 @@ func NewRuleManagerSet() ManagerSet {
 
 // InitEnforcer gets the appropriate rule Manager for the given name and uses it
 // to create an appropriate rule Enforcer.
-func (m ManagerSet) InitEnforcer(cfg Config, name string,
+func (m ManagerSet) InitEnforcer(ctx context.Context, cfg Config, name string,
 	values Values) (Enforcer, error) {
 
 	mgr, ok := m[name]
@@ -41,7 +42,7 @@ func (m ManagerSet) InitEnforcer(cfg Config, name string,
 			name)
 	}
 
-	return mgr.NewEnforcer(cfg, values)
+	return mgr.NewEnforcer(ctx, cfg, values)
 }
 
 // GetAllRules returns a map of names of all the rules supported by rule

--- a/rules/onchain_budget.go
+++ b/rules/onchain_budget.go
@@ -63,8 +63,8 @@ func (o *OnChainBudgetMgr) Stop() error {
 // passed values and config.
 //
 // NOTE: This is part of the Manager interface.
-func (o *OnChainBudgetMgr) NewEnforcer(cfg Config, values Values) (Enforcer,
-	error) {
+func (o *OnChainBudgetMgr) NewEnforcer(_ context.Context, cfg Config,
+	values Values) (Enforcer, error) {
 
 	budget, ok := values.(*OnChainBudget)
 	if !ok {

--- a/rules/peer_restrictions_test.go
+++ b/rules/peer_restrictions_test.go
@@ -68,7 +68,7 @@ func TestPeerRestrictCheckRequest(t *testing.T) {
 		},
 	}
 
-	enf, err := mgr.NewEnforcer(cfg, &PeerRestrict{
+	enf, err := mgr.NewEnforcer(ctx, cfg, &PeerRestrict{
 		DenyList: []string{
 			peerID1, peerID2,
 		},

--- a/rules/rate_limit.go
+++ b/rules/rate_limit.go
@@ -38,8 +38,8 @@ func (r *RateLimitMgr) Stop() error {
 // and config.
 //
 // NOTE: This is part of the Manager interface.
-func (r *RateLimitMgr) NewEnforcer(cfg Config, values Values) (Enforcer,
-	error) {
+func (r *RateLimitMgr) NewEnforcer(_ context.Context, cfg Config,
+	values Values) (Enforcer, error) {
 
 	limits, ok := values.(*RateLimit)
 	if !ok {

--- a/terminal.go
+++ b/terminal.go
@@ -751,7 +751,7 @@ func (g *LightningTerminal) start(ctx context.Context) error {
 		g.basicClient, g.lndClient, createDefaultMacaroons,
 	)
 
-	err = g.startInternalSubServers(!g.cfg.statelessInitMode)
+	err = g.startInternalSubServers(ctx, !g.cfg.statelessInitMode)
 	if err != nil {
 		return fmt.Errorf("could not start litd sub-servers: %v", err)
 	}
@@ -959,7 +959,7 @@ func (g *LightningTerminal) setUpLNDClients(ctx context.Context,
 }
 
 // startInternalSubServers starts all Litd specific sub-servers.
-func (g *LightningTerminal) startInternalSubServers(
+func (g *LightningTerminal) startInternalSubServers(ctx context.Context,
 	createDefaultMacaroons bool) error {
 
 	log.Infof("Starting LiT macaroon service")
@@ -1012,7 +1012,7 @@ func (g *LightningTerminal) startInternalSubServers(
 	}
 
 	log.Infof("Starting LiT session server")
-	if err = g.sessionRpcServer.start(); err != nil {
+	if err = g.sessionRpcServer.start(ctx); err != nil {
 		return err
 	}
 	g.sessionRpcServerStarted = true

--- a/terminal.go
+++ b/terminal.go
@@ -236,6 +236,8 @@ func New() *LightningTerminal {
 // Run starts everything and then blocks until either the application is shut
 // down or a critical error happens.
 func (g *LightningTerminal) Run() error {
+	ctx := context.TODO()
+
 	// Hook interceptor for os signals.
 	shutdownInterceptor, err := signal.Intercept()
 	if err != nil {
@@ -345,7 +347,7 @@ func (g *LightningTerminal) Run() error {
 	// We'll also create a REST proxy that'll convert any REST calls to gRPC
 	// calls and forward them to the internal listener.
 	if g.cfg.EnableREST {
-		if err := g.createRESTProxy(); err != nil {
+		if err := g.createRESTProxy(ctx); err != nil {
 			return fmt.Errorf("error creating REST proxy: %v", err)
 		}
 	}
@@ -353,7 +355,7 @@ func (g *LightningTerminal) Run() error {
 	// Attempt to start Lit and all of its sub-servers. If an error is
 	// returned, it means that either one of Lit's internal sub-servers
 	// could not start or LND could not start or be connected to.
-	startErr := g.start()
+	startErr := g.start(ctx)
 	if startErr != nil {
 		g.statusMgr.SetErrored(
 			subservers.LIT, "could not start Lit: %v", startErr,
@@ -380,7 +382,7 @@ func (g *LightningTerminal) Run() error {
 // If any of the sub-servers managed by the subServerMgr error while starting
 // up, these are considered non-fatal and will not result in an error being
 // returned.
-func (g *LightningTerminal) start() error {
+func (g *LightningTerminal) start(ctx context.Context) error {
 	var err error
 
 	accountServiceErrCallback := func(err error) {
@@ -658,7 +660,7 @@ func (g *LightningTerminal) start() error {
 
 	// Now that we have started the main UI web server, show some useful
 	// information to the user so they can access the web UI easily.
-	if err := g.showStartupInfo(); err != nil {
+	if err := g.showStartupInfo(ctx); err != nil {
 		return fmt.Errorf("error displaying startup info: %v", err)
 	}
 
@@ -713,7 +715,7 @@ func (g *LightningTerminal) start() error {
 	}
 
 	// Set up all the LND clients required by LiT.
-	err = g.setUpLNDClients(lndQuit)
+	err = g.setUpLNDClients(ctx, lndQuit)
 	if err != nil {
 		g.statusMgr.SetErrored(
 			subservers.LND, "could not set up LND clients: %v", err,
@@ -773,7 +775,9 @@ func (g *LightningTerminal) basicLNDClient() (lnrpc.LightningClient, error) {
 }
 
 // setUpLNDClients sets up the various LND clients required by LiT.
-func (g *LightningTerminal) setUpLNDClients(lndQuit chan struct{}) error {
+func (g *LightningTerminal) setUpLNDClients(ctx context.Context,
+	lndQuit chan struct{}) error {
+
 	var (
 		err           error
 		insecure      bool
@@ -873,7 +877,7 @@ func (g *LightningTerminal) setUpLNDClients(lndQuit chan struct{}) error {
 	// subservers. This will just block until lnd signals readiness. But we
 	// still want to react to shutdown requests, so we need to listen for
 	// those.
-	ctxc, cancel := context.WithCancel(context.Background())
+	ctxc, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	// Make sure the context is canceled if the user requests shutdown.
@@ -940,7 +944,6 @@ func (g *LightningTerminal) setUpLNDClients(lndQuit chan struct{}) error {
 		// Create a super macaroon that can be used to control lnd,
 		// faraday, loop, and pool, all at the same time.
 		log.Infof("Baking internal super macaroon")
-		ctx := context.Background()
 		superMacaroon, err := BakeSuperMacaroon(
 			ctx, g.basicClient, session.NewSuperMacaroonRootKeyID(
 				[4]byte{},
@@ -1657,7 +1660,7 @@ func (g *LightningTerminal) startMainWebServer() error {
 // createRESTProxy creates a grpc-gateway based REST proxy that takes any call
 // identified as a REST call, converts it to a gRPC request and forwards it to
 // our local main server for further triage/forwarding.
-func (g *LightningTerminal) createRESTProxy() error {
+func (g *LightningTerminal) createRESTProxy(ctx context.Context) error {
 	// The default JSON marshaler of the REST proxy only sets OrigName to
 	// true, which instructs it to use the same field names as specified in
 	// the proto file and not switch to camel case. What we also want is
@@ -1700,7 +1703,7 @@ func (g *LightningTerminal) createRESTProxy() error {
 	// wildcard to prevent certificate issues when accessing the proxy
 	// externally.
 	restMux := restProxy.NewServeMux(customMarshalerOption)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	g.restCancel = cancel
 
 	// Enable WebSocket and CORS support as well. A request will pass
@@ -1926,7 +1929,7 @@ func allowCORS(handler http.Handler, origins []string) http.Handler {
 
 // showStartupInfo shows useful information to the user to easily access the
 // web UI that was just started.
-func (g *LightningTerminal) showStartupInfo() error {
+func (g *LightningTerminal) showStartupInfo(ctx context.Context) error {
 	info := struct {
 		mode    string
 		status  string
@@ -1958,7 +1961,6 @@ func (g *LightningTerminal) showStartupInfo() error {
 			return fmt.Errorf("error querying remote node: %v", err)
 		}
 
-		ctx := context.Background()
 		res, err := basicClient.GetInfo(ctx, &lnrpc.GetInfoRequest{})
 		if err != nil {
 			if !lndclient.IsUnlockError(err) {

--- a/terminal.go
+++ b/terminal.go
@@ -1104,7 +1104,7 @@ func (g *LightningTerminal) startInternalSubServers(ctx context.Context,
 		g.lndClient.Client, g.errQueue.ChanIn(), mw...,
 	)
 
-	if err = g.middleware.Start(); err != nil {
+	if err = g.middleware.Start(ctx); err != nil {
 		return err
 	}
 	g.middlewareStarted = true

--- a/terminal.go
+++ b/terminal.go
@@ -1005,7 +1005,8 @@ func (g *LightningTerminal) startInternalSubServers(ctx context.Context,
 			}
 		}
 
-		if err = g.autopilotClient.Start(withLndVersion); err != nil {
+		err = g.autopilotClient.Start(ctx, withLndVersion)
+		if err != nil {
 			return fmt.Errorf("could not start the autopilot "+
 				"client: %v", err)
 		}

--- a/terminal.go
+++ b/terminal.go
@@ -1042,7 +1042,7 @@ func (g *LightningTerminal) startInternalSubServers(ctx context.Context,
 	log.Infof("Starting LiT account service")
 	if !g.cfg.Accounts.Disable {
 		err = g.accountService.Start(
-			g.lndClient.Client, g.lndClient.Router,
+			ctx, g.lndClient.Client, g.lndClient.Router,
 			g.lndClient.ChainParams,
 		)
 		if err != nil {


### PR DESCRIPTION
In this PR, we remove as many uses of `context.Background` as possible. By the end of 
this PR, the litd has a single parent context. We also let the CLI use the `getContext` helper that
we use in other repos that cancels the context used if an appropriate OS signal is caught. 