### PR TITLE
[sql-2] accounts: start replacing calls to UpdateAccount

### DIFF
--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -230,6 +230,11 @@ type Store interface {
 	AddAccountInvoice(ctx context.Context, id AccountID,
 		hash lntypes.Hash) error
 
+	// IncreaseAccountBalance increases the balance of the account with the
+	// given ID by the given amount.
+	IncreaseAccountBalance(ctx context.Context, id AccountID,
+		amount lnwire.MilliSatoshi) error
+
 	// RemoveAccount finds an account by its ID and removes it from the¨
 	// store.
 	RemoveAccount(ctx context.Context, id AccountID) error

--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -226,6 +226,10 @@ type Store interface {
 		newBalance fn.Option[lnwire.MilliSatoshi],
 		newExpiry fn.Option[time.Time]) error
 
+	// AddAccountInvoice adds an invoice hash to an account.
+	AddAccountInvoice(ctx context.Context, id AccountID,
+		hash lntypes.Hash) error
+
 	// RemoveAccount finds an account by its ID and removes it from the¨
 	// store.
 	RemoveAccount(ctx context.Context, id AccountID) error

--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -218,6 +219,12 @@ type Store interface {
 
 	// Accounts retrieves all accounts from the store and un-marshals them.
 	Accounts(ctx context.Context) ([]*OffChainBalanceAccount, error)
+
+	// UpdateAccountBalanceAndExpiry updates the balance and/or expiry of an
+	// account.
+	UpdateAccountBalanceAndExpiry(ctx context.Context, id AccountID,
+		newBalance fn.Option[lnwire.MilliSatoshi],
+		newExpiry fn.Option[time.Time]) error
 
 	// RemoveAccount finds an account by its ID and removes it from the¨
 	// store.

--- a/accounts/rpcserver.go
+++ b/accounts/rpcserver.go
@@ -122,7 +122,8 @@ func (s *RPCServer) UpdateAccount(ctx context.Context,
 
 	// Ask the service to update the account.
 	account, err := s.service.UpdateAccount(
-		ctx, accountID, req.AccountBalance, req.ExpirationDate,
+		ctx, accountID, btcutil.Amount(req.AccountBalance),
+		req.ExpirationDate,
 	)
 	if err != nil {
 		return nil, err

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -299,7 +300,7 @@ func (s *InterceptorService) NewAccount(ctx context.Context,
 // UpdateAccount writes an account to the database, overwriting the existing one
 // if it exists.
 func (s *InterceptorService) UpdateAccount(ctx context.Context,
-	accountID AccountID, accountBalance,
+	accountID AccountID, accountBalance btcutil.Amount,
 	expirationDate int64) (*OffChainBalanceAccount, error) {
 
 	s.Lock()

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -598,21 +598,13 @@ func (s *InterceptorService) invoiceUpdate(ctx context.Context,
 		return nil
 	}
 
-	account, err := s.store.Account(ctx, acctID)
-	if err != nil {
-		return s.disableAndErrorfUnsafe(
-			"error fetching account: %w", err,
-		)
-	}
-
 	// If we get here, the current account has the invoice associated with
 	// it that was just paid. Credit the amount to the account and update it
 	// in the DB.
-	account.CurrentBalance += int64(invoice.AmountPaid)
-	if err := s.store.UpdateAccount(ctx, account); err != nil {
-		return s.disableAndErrorfUnsafe(
-			"error updating account: %w", err,
-		)
+	err := s.store.IncreaseAccountBalance(ctx, acctID, invoice.AmountPaid)
+	if err != nil {
+		return s.disableAndErrorfUnsafe("error increasing account "+
+			"balance account: %w", err)
 	}
 
 	// We've now fully processed the invoice and don't need to keep it

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -438,15 +438,15 @@ func (s *InterceptorService) AssociateInvoice(ctx context.Context, id AccountID,
 	s.Lock()
 	defer s.Unlock()
 
-	account, err := s.store.Account(ctx, id)
+	err := s.store.AddAccountInvoice(ctx, id, hash)
 	if err != nil {
-		return err
+		return fmt.Errorf("error adding invoice to account: %w", err)
 	}
 
-	account.Invoices[hash] = struct{}{}
+	// If the above was successful, then we update our in-memory map.
 	s.invoiceToAccount[hash] = id
 
-	return s.store.UpdateAccount(ctx, account)
+	return nil
 }
 
 // PaymentErrored removes a pending payment from the account's registered

--- a/accounts/store_kvdb.go
+++ b/accounts/store_kvdb.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"go.etcd.io/bbolt"
@@ -194,6 +195,56 @@ func (s *BoltStore) UpdateAccount(_ context.Context,
 	}, func() {})
 }
 
+// UpdateAccountBalanceAndExpiry updates the balance and/or expiry of an
+// account.
+//
+// NOTE: This is part of the Store interface.
+func (s *BoltStore) UpdateAccountBalanceAndExpiry(_ context.Context,
+	id AccountID, newBalance fn.Option[lnwire.MilliSatoshi],
+	newExpiry fn.Option[time.Time]) error {
+
+	update := func(account *OffChainBalanceAccount) error {
+		newBalance.WhenSome(func(balance lnwire.MilliSatoshi) {
+			account.CurrentBalance = int64(balance)
+		})
+		newExpiry.WhenSome(func(expiry time.Time) {
+			account.ExpirationDate = expiry
+		})
+
+		return nil
+	}
+
+	return s.updateAccount(id, update)
+}
+
+func (s *BoltStore) updateAccount(id AccountID,
+	updateFn func(*OffChainBalanceAccount) error) error {
+
+	return s.db.Update(func(tx kvdb.RwTx) error {
+		bucket := tx.ReadWriteBucket(accountBucketName)
+		if bucket == nil {
+			return ErrAccountBucketNotFound
+		}
+
+		account, err := getAccount(bucket, id)
+		if err != nil {
+			return fmt.Errorf("error fetching account, %w", err)
+		}
+
+		err = updateFn(account)
+		if err != nil {
+			return fmt.Errorf("error updating account, %w", err)
+		}
+
+		err = storeAccount(bucket, account)
+		if err != nil {
+			return fmt.Errorf("error storing account, %w", err)
+		}
+
+		return nil
+	}, func() {})
+}
+
 // storeAccount serializes and writes the given account to the given account
 // bucket.
 func storeAccount(accountBucket kvdb.RwBucket,
@@ -207,6 +258,19 @@ func storeAccount(accountBucket kvdb.RwBucket,
 	}
 
 	return accountBucket.Put(account.ID[:], accountBinary)
+}
+
+// getAccount retrieves an account from the given account bucket and
+// deserializes it.
+func getAccount(accountBucket kvdb.RwBucket, id AccountID) (
+	*OffChainBalanceAccount, error) {
+
+	accountBinary := accountBucket.Get(id[:])
+	if len(accountBinary) == 0 {
+		return nil, ErrAccNotFound
+	}
+
+	return deserializeAccount(accountBinary)
 }
 
 // uniqueRandomAccountID generates a new random ID and makes sure it does not

--- a/accounts/store_kvdb.go
+++ b/accounts/store_kvdb.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"os"
 	"time"
 
@@ -226,6 +227,27 @@ func (s *BoltStore) AddAccountInvoice(_ context.Context, id AccountID,
 
 	update := func(account *OffChainBalanceAccount) error {
 		account.Invoices[hash] = struct{}{}
+
+		return nil
+	}
+
+	return s.updateAccount(id, update)
+}
+
+// IncreaseAccountBalance increases the balance of the account with the given ID
+// by the given amount.
+//
+// NOTE: This is part of the Store interface.
+func (s *BoltStore) IncreaseAccountBalance(_ context.Context, id AccountID,
+	amount lnwire.MilliSatoshi) error {
+
+	update := func(account *OffChainBalanceAccount) error {
+		if amount > math.MaxInt64 {
+			return fmt.Errorf("amount %d exceeds the maximum of %d",
+				amount, math.MaxInt64)
+		}
+
+		account.CurrentBalance += int64(amount)
 
 		return nil
 	}

--- a/accounts/store_kvdb.go
+++ b/accounts/store_kvdb.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"go.etcd.io/bbolt"
 )
@@ -210,6 +211,21 @@ func (s *BoltStore) UpdateAccountBalanceAndExpiry(_ context.Context,
 		newExpiry.WhenSome(func(expiry time.Time) {
 			account.ExpirationDate = expiry
 		})
+
+		return nil
+	}
+
+	return s.updateAccount(id, update)
+}
+
+// AddAccountInvoice adds an invoice hash to the account with the given ID.
+//
+// NOTE: This is part of the Store interface.
+func (s *BoltStore) AddAccountInvoice(_ context.Context, id AccountID,
+	hash lntypes.Hash) error {
+
+	update := func(account *OffChainBalanceAccount) error {
+		account.Invoices[hash] = struct{}{}
 
 		return nil
 	}


### PR DESCRIPTION
To prepare the `accounts.Store` to be more SQL compatible, we will want to replace the current
`UpdateAccount` method. Today it takes a full `OffChainAccount` struct, serialises it and replaces
any existing in the DB. This method is not very SQL appropriate as the better pattern is to instead
have specific update methods that read: "Update field X and account with ID Y". 

So this PR starts this process of adding more SQL friendly methods to the interface and thereby 
phasing out the use of `UpdateAccount`. By doing so, we also move very kvdb specific logic out
of the `accounts.InterceptorService`. 

I'm splitting this up over about 3 or 4 PRs since some of the replacements are more complicated than 
others. 

This PR focuses on just replacing the simple ones:
- `UpdateAccountBalanceAndExpiry`
- `AddAccountInvoice`
- `IncreaseAccountBalance`