### PR TITLE
[sql-3] accounts: replace calls to UpdateAccount

### DIFF
--- a/accounts/errors.go
+++ b/accounts/errors.go
@@ -8,4 +8,9 @@ var (
 	ErrLabelAlreadyExists = errors.New(
 		"account label uniqueness constraint violation",
 	)
+
+	// ErrAlreadySucceeded is returned by the UpsertAccountPayment method
+	// if the WithErrAlreadySucceeded option is used and the payment has
+	// already succeeded.
+	ErrAlreadySucceeded = errors.New("payment has already succeeded")
 )

--- a/accounts/errors.go
+++ b/accounts/errors.go
@@ -13,4 +13,10 @@ var (
 	// if the WithErrAlreadySucceeded option is used and the payment has
 	// already succeeded.
 	ErrAlreadySucceeded = errors.New("payment has already succeeded")
+
+	// ErrPaymentNotAssociated indicate that the payment with the given hash
+	// has not yet been associated with the account in question.
+	ErrPaymentNotAssociated = errors.New(
+		"payment not associated with account",
+	)
 )

--- a/accounts/errors.go
+++ b/accounts/errors.go
@@ -15,7 +15,9 @@ var (
 	ErrAlreadySucceeded = errors.New("payment has already succeeded")
 
 	// ErrPaymentNotAssociated indicate that the payment with the given hash
-	// has not yet been associated with the account in question.
+	// has not yet been associated with the account in question. It is also
+	// returned when the WithErrIfUnknown option is used with
+	// UpsertAccountPayment if the payment is not yet known.
 	ErrPaymentNotAssociated = errors.New(
 		"payment not associated with account",
 	)

--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -246,6 +246,12 @@ type Store interface {
 		status lnrpc.Payment_PaymentStatus,
 		options ...UpsertPaymentOption) (bool, error)
 
+	// DeleteAccountPayment removes a payment entry from the account with
+	// the given ID. It will return the ErrPaymentNotAssociated error if the
+	// payment is not associated with the account.
+	DeleteAccountPayment(_ context.Context, id AccountID,
+		hash lntypes.Hash) error
+
 	// RemoveAccount finds an account by its ID and removes it from the¨
 	// store.
 	RemoveAccount(ctx context.Context, id AccountID) error

--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -345,6 +345,7 @@ type upsertAcctPaymentOption struct {
 	errIfAlreadyPending   bool
 	usePendingAmount      bool
 	errIfAlreadySucceeded bool
+	errIfUnknown          bool
 }
 
 // newUpsertPaymentOption creates a new upsertAcctPaymentOption with default
@@ -355,6 +356,7 @@ func newUpsertPaymentOption() *upsertAcctPaymentOption {
 		errIfAlreadyPending:   false,
 		usePendingAmount:      false,
 		errIfAlreadySucceeded: false,
+		errIfUnknown:          false,
 	}
 }
 
@@ -392,5 +394,14 @@ func WithErrIfAlreadySucceeded() UpsertPaymentOption {
 func WithPendingAmount() UpsertPaymentOption {
 	return func(o *upsertAcctPaymentOption) {
 		o.usePendingAmount = true
+	}
+}
+
+// WithErrIfUnknown is a functional option that can be passed to the
+// UpsertAccountPayment method to indicate that the ErrPaymentNotAssociated
+// error should be returned if the payment is not associated with the account.
+func WithErrIfUnknown() UpsertPaymentOption {
+	return func(o *upsertAcctPaymentOption) {
+		o.errIfUnknown = true
 	}
 }

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -467,26 +467,7 @@ func (s *InterceptorService) PaymentErrored(ctx context.Context, id AccountID,
 			"has already started")
 	}
 
-	account, err := s.store.Account(ctx, id)
-	if err != nil {
-		return err
-	}
-
-	// Check that this payment is actually associated with this account.
-	_, ok = account.Payments[hash]
-	if !ok {
-		return fmt.Errorf("payment with hash %s is not associated "+
-			"with this account", hash)
-	}
-
-	// Delete the payment and update the persisted account.
-	delete(account.Payments, hash)
-
-	if err := s.store.UpdateAccount(ctx, account); err != nil {
-		return fmt.Errorf("error updating account: %w", err)
-	}
-
-	return nil
+	return s.store.DeleteAccountPayment(ctx, id, hash)
 }
 
 // AssociatePayment associates a payment (hash) with the given account,

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -860,6 +860,18 @@ func (s *InterceptorService) removePayment(ctx context.Context,
 	return nil
 }
 
+// hasPayment returns true if the payment is currently being tracked by the
+// service.
+//
+// NOTE: this is currently used only for tests.
+func (s *InterceptorService) hasPayment(hash lntypes.Hash) bool {
+	s.RLock()
+	defer s.RUnlock()
+
+	_, ok := s.pendingPayments[hash]
+	return ok
+}
+
 // successState returns true if a payment was completed successfully.
 func successState(status lnrpc.Payment_PaymentStatus) bool {
 	return status == lnrpc.Payment_SUCCEEDED

--- a/accounts/service_test.go
+++ b/accounts/service_test.go
@@ -383,13 +383,14 @@ func TestAccountService(t *testing.T) {
 			// Assert that the invoice subscription succeeded.
 			require.Contains(t, s.invoiceToAccount, testHash)
 
-			// But setting up the payment tracking should have failed.
+			// But setting up the payment tracking should have
+			// failed.
 			require.False(t, s.IsRunning())
 
-			// Finally let's assert that we didn't successfully add the
-			// payment to pending payment, and that lnd isn't awaiting
-			// the payment request.
-			require.NotContains(t, s.pendingPayments, testHash)
+			// Finally let's assert that we didn't successfully add
+			// the payment to pending payment, and that lnd isn't
+			// awaiting the payment request.
+			require.False(t, s.hasPayment(testHash))
 			r.assertNoPaymentRequest(t)
 		},
 	}, {
@@ -426,7 +427,9 @@ func TestAccountService(t *testing.T) {
 			// This will cause an error send an update over
 			// the payment channel, which should disable the
 			// service.
-			s.pendingPayments = make(map[lntypes.Hash]*trackedPayment)
+			s.pendingPayments = make(
+				map[lntypes.Hash]*trackedPayment,
+			)
 
 			// Send an invalid payment over the payment chan
 			// which should error and disable the service
@@ -568,7 +571,7 @@ func TestAccountService(t *testing.T) {
 				return p.Status == lnrpc.Payment_FAILED
 			})
 
-			require.NotContains(t, s.pendingPayments, testHash2)
+			require.False(t, s.hasPayment(testHash2))
 
 			// Finally, if an unknown payment turns out to be
 			// a non-initiated payment, we should stop the tracking
@@ -616,7 +619,7 @@ func TestAccountService(t *testing.T) {
 
 			// Ensure that the payment was removed from the pending
 			// payments.
-			require.NotContains(t, s.pendingPayments, testHash3)
+			require.False(t, s.hasPayment(testHash3))
 		},
 	}, {
 		name: "keep track of invoice indexes",

--- a/accounts/store_kvdb.go
+++ b/accounts/store_kvdb.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"go.etcd.io/bbolt"
@@ -248,6 +249,52 @@ func (s *BoltStore) IncreaseAccountBalance(_ context.Context, id AccountID,
 		}
 
 		account.CurrentBalance += int64(amount)
+
+		return nil
+	}
+
+	return s.updateAccount(id, update)
+}
+
+// UpsertAccountPayment updates or inserts a payment entry for the given
+// account. Various functional options can be passed to modify the behavior of
+// the method.
+//
+// NOTE: This is part of the Store interface.
+func (s *BoltStore) UpsertAccountPayment(_ context.Context, id AccountID,
+	paymentHash lntypes.Hash, fullAmount lnwire.MilliSatoshi,
+	status lnrpc.Payment_PaymentStatus,
+	options ...UpsertPaymentOption) error {
+
+	opts := newUpsertPaymentOption()
+	for _, o := range options {
+		o(opts)
+	}
+
+	update := func(account *OffChainBalanceAccount) error {
+		entry, ok := account.Payments[paymentHash]
+		if ok {
+			// If the errIfAlreadyPending option is set, we return
+			// an error if the payment is already in-flight or
+			// succeeded.
+			if opts.errIfAlreadyPending &&
+				entry.Status != lnrpc.Payment_FAILED {
+
+				return fmt.Errorf("payment with hash %s is "+
+					"already in flight or succeeded "+
+					"(status %v)", paymentHash,
+					account.Payments[paymentHash].Status)
+			}
+		}
+
+		account.Payments[paymentHash] = &PaymentEntry{
+			Status:     status,
+			FullAmount: fullAmount,
+		}
+
+		if opts.debitAccount {
+			account.CurrentBalance -= int64(fullAmount)
+		}
 
 		return nil
 	}

--- a/accounts/store_kvdb.go
+++ b/accounts/store_kvdb.go
@@ -300,6 +300,8 @@ func (s *BoltStore) UpsertAccountPayment(_ context.Context, id AccountID,
 			if opts.usePendingAmount {
 				fullAmount = entry.FullAmount
 			}
+		} else if opts.errIfUnknown {
+			return ErrPaymentNotAssociated
 		}
 
 		account.Payments[paymentHash] = &PaymentEntry{

--- a/accounts/store_test.go
+++ b/accounts/store_test.go
@@ -257,6 +257,123 @@ func TestAccountUpdateMethods(t *testing.T) {
 
 		assertBalance(223)
 	})
+
+	t.Run("UpsertAccountPayment", func(t *testing.T) {
+		store := NewTestDB(t)
+
+		acct, err := store.NewAccount(ctx, 1000, time.Time{}, "foo")
+		require.NoError(t, err)
+
+		assertBalanceAndPayments := func(balance int64,
+			payments AccountPayments) {
+
+			dbAcct, err := store.Account(ctx, acct.ID)
+			require.NoError(t, err)
+			require.EqualValues(t, balance, dbAcct.CurrentBalance)
+
+			require.Len(t, dbAcct.Payments, len(payments))
+			for hash, payment := range payments {
+				dbPayment, ok := dbAcct.Payments[hash]
+				require.True(t, ok)
+				require.Equal(t, payment, dbPayment)
+			}
+		}
+
+		// The account initially has a balance of 1000 and no payments.
+		assertBalanceAndPayments(1000, nil)
+
+		// Assert that calling the method for a non-existent account
+		// errors out.
+		err = store.UpsertAccountPayment(
+			ctx, AccountID{}, lntypes.Hash{}, 0,
+			lnrpc.Payment_UNKNOWN,
+		)
+		require.ErrorIs(t, err, ErrAccNotFound)
+
+		// Add a payment to the account but don't update the balance.
+		// We do add a WithErrIfAlreadyPending option here just to show
+		// that no error is returned since the payment does not exist
+		// yet.
+		hash1 := lntypes.Hash{1, 2, 3, 4}
+		err = store.UpsertAccountPayment(
+			ctx, acct.ID, hash1, 600, lnrpc.Payment_UNKNOWN,
+			WithErrIfAlreadyPending(),
+		)
+		require.NoError(t, err)
+
+		assertBalanceAndPayments(1000, AccountPayments{
+			hash1: &PaymentEntry{
+				Status:     lnrpc.Payment_UNKNOWN,
+				FullAmount: 600,
+			},
+		})
+
+		// Add a second payment to the account and again don't update
+		// the balance.
+		hash2 := lntypes.Hash{5, 6, 7, 8}
+		err = store.UpsertAccountPayment(
+			ctx, acct.ID, hash2, 100, lnrpc.Payment_UNKNOWN,
+		)
+		require.NoError(t, err)
+
+		assertBalanceAndPayments(1000, AccountPayments{
+			hash1: &PaymentEntry{
+				Status:     lnrpc.Payment_UNKNOWN,
+				FullAmount: 600,
+			},
+			hash2: &PaymentEntry{
+				Status:     lnrpc.Payment_UNKNOWN,
+				FullAmount: 100,
+			},
+		})
+
+		// Now, update the first payment to have a new status and this
+		// time, debit the account.
+		err = store.UpsertAccountPayment(
+			ctx, acct.ID, hash1, 600, lnrpc.Payment_SUCCEEDED,
+			WithDebitAccount(),
+		)
+		require.NoError(t, err)
+
+		// The account should now have a balance of 400 and the first
+		// payment should have a status of succeeded.
+		assertBalanceAndPayments(400, AccountPayments{
+			hash1: &PaymentEntry{
+				Status:     lnrpc.Payment_SUCCEEDED,
+				FullAmount: 600,
+			},
+			hash2: &PaymentEntry{
+				Status:     lnrpc.Payment_UNKNOWN,
+				FullAmount: 100,
+			},
+		})
+
+		// Calling the same method again with the same payment hash
+		// should have no effect by default.
+		err = store.UpsertAccountPayment(
+			ctx, acct.ID, hash1, 600, lnrpc.Payment_SUCCEEDED,
+		)
+		require.NoError(t, err)
+
+		assertBalanceAndPayments(400, AccountPayments{
+			hash1: &PaymentEntry{
+				Status:     lnrpc.Payment_SUCCEEDED,
+				FullAmount: 600,
+			},
+			hash2: &PaymentEntry{
+				Status:     lnrpc.Payment_UNKNOWN,
+				FullAmount: 100,
+			},
+		})
+
+		// But, if we use the WithErrIfAlreadyPending option, we should
+		// get an error since the payment already exists.
+		err = store.UpsertAccountPayment(
+			ctx, acct.ID, hash1, 600, lnrpc.Payment_SUCCEEDED,
+			WithErrIfAlreadyPending(),
+		)
+		require.ErrorContains(t, err, "is already in flight")
+	})
 }
 
 // TestLastInvoiceIndexes makes sure the last known invoice indexes can be

--- a/accounts/store_test.go
+++ b/accounts/store_test.go
@@ -258,7 +258,7 @@ func TestAccountUpdateMethods(t *testing.T) {
 		assertBalance(223)
 	})
 
-	t.Run("UpsertAccountPayment", func(t *testing.T) {
+	t.Run("Upsert and Delete AccountPayment", func(t *testing.T) {
 		store := NewTestDB(t)
 
 		acct, err := store.NewAccount(ctx, 1000, time.Time{}, "foo")
@@ -413,6 +413,23 @@ func TestAccountUpdateMethods(t *testing.T) {
 				FullAmount: 100,
 			},
 		})
+
+		// Delete the first payment and make sure it is removed from the
+		// account.
+		err = store.DeleteAccountPayment(ctx, acct.ID, hash1)
+		require.NoError(t, err)
+
+		assertBalanceAndPayments(400, AccountPayments{
+			hash2: &PaymentEntry{
+				Status:     lnrpc.Payment_SUCCEEDED,
+				FullAmount: 100,
+			},
+		})
+
+		// Test that deleting a payment that does not exist returns an
+		// error.
+		err = store.DeleteAccountPayment(ctx, acct.ID, hash1)
+		require.ErrorIs(t, err, ErrPaymentNotAssociated)
 	})
 }
 


### PR DESCRIPTION
(similar PR description to #938 but they are not dependent on each other)

To prepare the `accounts.Store` to be more SQL compatible, we will want to replace the current
`UpdateAccount` method. Today it takes a full `OffChainAccount` struct, serialises it and replaces
any existing in the DB. This method is not very SQL appropriate as the better pattern is to instead
have specific update methods that read: "Update field X and account with ID Y".

So this PR starts this process of adding more SQL friendly methods to the interface and thereby
phasing out the use of `UpdateAccount`. By doing so, we also move very kvdb specific logic out
of the `accounts.InterceptorService`.

I'm splitting this up over about 3 or 4 PRs since some of the replacements are more complicated than
others.

This PR focuses on the calls that edit/add account payments:

- `UpsertAccountPayment`
- `DeleteAccountPayment`