### PR TITLE
[sql-4] accounts: remove last usages of `UpdateAccount`

### DIFF
--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -207,11 +207,6 @@ type Store interface {
 		expirationDate time.Time, label string) (
 		*OffChainBalanceAccount, error)
 
-	// UpdateAccount writes an account to the database, overwriting the
-	// existing one if it exists.
-	UpdateAccount(ctx context.Context,
-		account *OffChainBalanceAccount) error
-
 	// Account retrieves an account from the Store and un-marshals it. If
 	// the account cannot be found, then ErrAccNotFound is returned.
 	Account(ctx context.Context, id AccountID) (*OffChainBalanceAccount,

--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -223,7 +223,7 @@ type Store interface {
 	// UpdateAccountBalanceAndExpiry updates the balance and/or expiry of an
 	// account.
 	UpdateAccountBalanceAndExpiry(ctx context.Context, id AccountID,
-		newBalance fn.Option[lnwire.MilliSatoshi],
+		newBalance fn.Option[int64],
 		newExpiry fn.Option[time.Time]) error
 
 	// AddAccountInvoice adds an invoice hash to an account.

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -328,10 +328,10 @@ func (s *InterceptorService) UpdateAccount(ctx context.Context,
 
 	// If the new account balance was set, parse it as millisatoshis. A
 	// value of -1 signals "don't update the balance".
-	var balance fn.Option[lnwire.MilliSatoshi]
+	var balance fn.Option[int64]
 	if accountBalance >= 0 {
 		// Convert from satoshis to millisatoshis for storage.
-		balance = fn.Some(lnwire.MilliSatoshi(accountBalance) * 1000)
+		balance = fn.Some(int64(accountBalance) * 1000)
 	}
 
 	// Create the actual account in the macaroon account store.

--- a/accounts/service_test.go
+++ b/accounts/service_test.go
@@ -372,6 +372,7 @@ func TestAccountService(t *testing.T) {
 
 			return []AccountID{acct.ID}
 		},
+		startupErr: testErr.Error(),
 		validate: func(t *testing.T, lnd *mockLnd, r *mockRouter,
 			ids []AccountID, s *InterceptorService) {
 
@@ -852,6 +853,8 @@ func TestAccountService(t *testing.T) {
 				}
 
 				return
+			} else {
+				require.NoError(t, err)
 			}
 
 			// Any post execution validation that we need to run?

--- a/accounts/store_kvdb.go
+++ b/accounts/store_kvdb.go
@@ -208,12 +208,12 @@ func (s *BoltStore) UpdateAccount(_ context.Context,
 //
 // NOTE: This is part of the Store interface.
 func (s *BoltStore) UpdateAccountBalanceAndExpiry(_ context.Context,
-	id AccountID, newBalance fn.Option[lnwire.MilliSatoshi],
+	id AccountID, newBalance fn.Option[int64],
 	newExpiry fn.Option[time.Time]) error {
 
 	update := func(account *OffChainBalanceAccount) error {
-		newBalance.WhenSome(func(balance lnwire.MilliSatoshi) {
-			account.CurrentBalance = int64(balance)
+		newBalance.WhenSome(func(balance int64) {
+			account.CurrentBalance = balance
 		})
 		newExpiry.WhenSome(func(expiry time.Time) {
 			account.ExpirationDate = expiry

--- a/accounts/store_kvdb.go
+++ b/accounts/store_kvdb.go
@@ -186,23 +186,6 @@ func (s *BoltStore) NewAccount(ctx context.Context, balance lnwire.MilliSatoshi,
 	return account, nil
 }
 
-// UpdateAccount writes an account to the database, overwriting the existing one
-// if it exists.
-//
-// NOTE: This is part of the Store interface.
-func (s *BoltStore) UpdateAccount(_ context.Context,
-	account *OffChainBalanceAccount) error {
-
-	return s.db.Update(func(tx kvdb.RwTx) error {
-		bucket := tx.ReadWriteBucket(accountBucketName)
-		if bucket == nil {
-			return ErrAccountBucketNotFound
-		}
-
-		return s.storeAccount(bucket, account)
-	}, func() {})
-}
-
 // UpdateAccountBalanceAndExpiry updates the balance and/or expiry of an
 // account.
 //

--- a/accounts/store_test.go
+++ b/accounts/store_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
-	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
 )
 
@@ -122,7 +121,7 @@ func TestAccountUpdateMethods(t *testing.T) {
 		// Ensure that the function errors out if we try update an
 		// account that does not exist.
 		err := store.UpdateAccountBalanceAndExpiry(
-			ctx, AccountID{}, fn.None[lnwire.MilliSatoshi](),
+			ctx, AccountID{}, fn.None[int64](),
 			fn.None[time.Time](),
 		)
 		require.ErrorIs(t, err, ErrAccNotFound)
@@ -130,7 +129,7 @@ func TestAccountUpdateMethods(t *testing.T) {
 		acct, err := store.NewAccount(ctx, 0, time.Time{}, "foo")
 		require.NoError(t, err)
 
-		assertBalanceAndExpiry := func(balance lnwire.MilliSatoshi,
+		assertBalanceAndExpiry := func(balance int64,
 			expiry time.Time) {
 
 			dbAcct, err := store.Account(ctx, acct.ID)
@@ -146,7 +145,7 @@ func TestAccountUpdateMethods(t *testing.T) {
 		assertBalanceAndExpiry(0, time.Time{})
 
 		// Now, update just the balance of the account.
-		newBalance := lnwire.MilliSatoshi(123)
+		newBalance := int64(123)
 		err = store.UpdateAccountBalanceAndExpiry(
 			ctx, acct.ID, fn.Some(newBalance), fn.None[time.Time](),
 		)
@@ -156,8 +155,7 @@ func TestAccountUpdateMethods(t *testing.T) {
 		// Now update just the expiry of the account.
 		newExpiry := clock.Now().Add(time.Hour)
 		err = store.UpdateAccountBalanceAndExpiry(
-			ctx, acct.ID, fn.None[lnwire.MilliSatoshi](),
-			fn.Some(newExpiry),
+			ctx, acct.ID, fn.None[int64](), fn.Some(newExpiry),
 		)
 		require.NoError(t, err)
 		assertBalanceAndExpiry(newBalance, newExpiry)
@@ -174,8 +172,7 @@ func TestAccountUpdateMethods(t *testing.T) {
 		// Finally, test an update that has no net changes to the
 		// balance or expiry.
 		err = store.UpdateAccountBalanceAndExpiry(
-			ctx, acct.ID, fn.None[lnwire.MilliSatoshi](),
-			fn.None[time.Time](),
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
 		)
 		require.NoError(t, err)
 		assertBalanceAndExpiry(newBalance, newExpiry)

--- a/accounts/store_test.go
+++ b/accounts/store_test.go
@@ -38,7 +38,41 @@ func TestAccountStore(t *testing.T) {
 	_, err = store.NewAccount(ctx, 123, time.Time{}, "0011223344556677")
 	require.ErrorContains(t, err, "is not allowed as it can be mistaken")
 
+	now := clock.Now()
+
 	// Update all values of the account that we can modify.
+	//
+	// Update the balance and expiry.
+	err = store.UpdateAccountBalanceAndExpiry(
+		ctx, acct1.ID, fn.Some(int64(-500)), fn.Some(now),
+	)
+	require.NoError(t, err)
+
+	// Add 2 payments.
+	_, err = store.UpsertAccountPayment(
+		ctx, acct1.ID, lntypes.Hash{12, 34, 56, 78}, 123456,
+		lnrpc.Payment_FAILED,
+	)
+	require.NoError(t, err)
+
+	_, err = store.UpsertAccountPayment(
+		ctx, acct1.ID, lntypes.Hash{34, 56, 78, 90}, 789456123789,
+		lnrpc.Payment_SUCCEEDED,
+	)
+	require.NoError(t, err)
+
+	// Add 2 invoices.
+	err = store.AddAccountInvoice(
+		ctx, acct1.ID, lntypes.Hash{12, 34, 56, 78},
+	)
+	require.NoError(t, err)
+	err = store.AddAccountInvoice(
+		ctx, acct1.ID, lntypes.Hash{34, 56, 78, 90},
+	)
+	require.NoError(t, err)
+
+	// Update the in-memory account so that we can compare it with the
+	// account we get from the store.
 	acct1.CurrentBalance = -500
 	acct1.ExpirationDate = clock.Now()
 	acct1.Payments[lntypes.Hash{12, 34, 56, 78}] = &PaymentEntry{
@@ -51,8 +85,6 @@ func TestAccountStore(t *testing.T) {
 	}
 	acct1.Invoices[lntypes.Hash{12, 34, 56, 78}] = struct{}{}
 	acct1.Invoices[lntypes.Hash{34, 56, 78, 90}] = struct{}{}
-	err = store.UpdateAccount(ctx, acct1)
-	require.NoError(t, err)
 
 	dbAccount, err = store.Account(ctx, acct1.ID)
 	require.NoError(t, err)


### PR DESCRIPTION
With this PR, we complete the `Prepare the accounts Store interface to be ready for a SQL impl` & `Prep unit tests to be ready to pass against a different backend` steps in #917 .

We do 2 things here:
1) we [revert one of the changes](https://github.com/lightninglabs/lightning-terminal/pull/938#discussion_r1918123976) from a previous PR where we change the balance type of `UpdateAccountBalanceAndExpiry` from an int64 to a more strict lnwire.Millisatoshi type. We revert that here though so that we can use the `UpdateAccountBalanceAndExpiry` in a unit test that uses `UpdateAccount` to set the balance to a negative value (which currently _is_ allowed). 

2) The rest of the PR removes the last couple of usages of `UpdateAccount` from tests. 