### PR TITLE
[sql-5] accounts: use clock.Clock

### DIFF
--- a/accounts/checkers_test.go
+++ b/accounts/checkers_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -523,7 +524,8 @@ func testSendPayment(t *testing.T, uri string) {
 	errFunc := func(err error) {
 		lndMock.mainErrChan <- err
 	}
-	store := NewTestDB(t)
+	clock := clock.NewTestClock(time.Now())
+	store := NewTestDB(t, clock)
 	service, err := NewService(store, errFunc)
 	require.NoError(t, err)
 
@@ -546,7 +548,7 @@ func testSendPayment(t *testing.T, uri string) {
 
 	// Create an account and add it to the context.
 	acct, err := service.NewAccount(
-		ctx, 5000, time.Now().Add(time.Hour), "test",
+		ctx, 5000, clock.Now().Add(time.Hour), "test",
 	)
 	require.NoError(t, err)
 
@@ -720,7 +722,8 @@ func TestSendPaymentV2(t *testing.T) {
 	errFunc := func(err error) {
 		lndMock.mainErrChan <- err
 	}
-	store := NewTestDB(t)
+	clock := clock.NewTestClock(time.Now())
+	store := NewTestDB(t, clock)
 	service, err := NewService(store, errFunc)
 	require.NoError(t, err)
 
@@ -743,7 +746,7 @@ func TestSendPaymentV2(t *testing.T) {
 
 	// Create an account and add it to the context.
 	acct, err := service.NewAccount(
-		ctx, 5000, time.Now().Add(time.Hour), "test",
+		ctx, 5000, clock.Now().Add(time.Hour), "test",
 	)
 	require.NoError(t, err)
 
@@ -908,7 +911,8 @@ func TestSendToRouteV2(t *testing.T) {
 	errFunc := func(err error) {
 		lndMock.mainErrChan <- err
 	}
-	store := NewTestDB(t)
+	clock := clock.NewTestClock(time.Now())
+	store := NewTestDB(t, clock)
 	service, err := NewService(store, errFunc)
 	require.NoError(t, err)
 
@@ -931,7 +935,7 @@ func TestSendToRouteV2(t *testing.T) {
 
 	// Create an account and add it to the context.
 	acct, err := service.NewAccount(
-		ctx, 5000, time.Now().Add(time.Hour), "test",
+		ctx, 5000, clock.Now().Add(time.Hour), "test",
 	)
 	require.NoError(t, err)
 

--- a/accounts/service_test.go
+++ b/accounts/service_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/clock"
 	invpkg "github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
@@ -832,7 +833,7 @@ func TestAccountService(t *testing.T) {
 			errFunc := func(err error) {
 				lndMock.mainErrChan <- err
 			}
-			store := NewTestDB(t)
+			store := NewTestDB(t, clock.NewTestClock(time.Now()))
 			service, err := NewService(store, errFunc)
 			require.NoError(t, err)
 

--- a/accounts/test_kvdb.go
+++ b/accounts/test_kvdb.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/lightningnetwork/lnd/clock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,14 +13,16 @@ import (
 var ErrDBClosed = errors.New("database not open")
 
 // NewTestDB is a helper function that creates an BBolt database for testing.
-func NewTestDB(t *testing.T) *BoltStore {
-	return NewTestDBFromPath(t, t.TempDir())
+func NewTestDB(t *testing.T, clock clock.Clock) *BoltStore {
+	return NewTestDBFromPath(t, t.TempDir(), clock)
 }
 
 // NewTestDBFromPath is a helper function that creates a new BoltStore with a
 // connection to an existing BBolt database for testing.
-func NewTestDBFromPath(t *testing.T, dbPath string) *BoltStore {
-	store, err := NewBoltStore(dbPath, DBFilename)
+func NewTestDBFromPath(t *testing.T, dbPath string,
+	clock clock.Clock) *BoltStore {
+
+	store, err := NewBoltStore(dbPath, DBFilename, clock)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/lightninglabs/taproot-assets v0.5.1-rc1
 	github.com/lightningnetwork/lnd v0.18.4-beta
 	github.com/lightningnetwork/lnd/cert v1.2.2
+	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn v1.2.3
 	github.com/lightningnetwork/lnd/kvdb v1.4.10
 	github.com/lightningnetwork/lnd/tlv v1.2.6
@@ -137,7 +138,6 @@ require (
 	github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd // indirect
 	github.com/lightninglabs/neutrino/cache v1.1.2 // indirect
 	github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb // indirect
-	github.com/lightningnetwork/lnd/clock v1.1.1 // indirect
 	github.com/lightningnetwork/lnd/healthcheck v1.2.5 // indirect
 	github.com/lightningnetwork/lnd/queue v1.1.1 // indirect
 	github.com/lightningnetwork/lnd/sqldb v1.0.4 // indirect

--- a/terminal.go
+++ b/terminal.go
@@ -38,6 +38,7 @@ import (
 	"github.com/lightningnetwork/lnd"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/chainreg"
+	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/funding"
 	"github.com/lightningnetwork/lnd/htlcswitch"
@@ -415,6 +416,7 @@ func (g *LightningTerminal) start(ctx context.Context) error {
 
 	g.accountsStore, err = accounts.NewBoltStore(
 		filepath.Dir(g.cfg.MacaroonPath), accounts.DBFilename,
+		clock.NewDefaultClock(),
 	)
 	if err != nil {
 		return fmt.Errorf("error creating accounts store: %w", err)


### PR DESCRIPTION
In this commit, we use the clock.Clock type instead of directly calling time.Now().
This is in preparation for cleaner testing against different SQL backends later on in the series. 