### PR TITLE
[sql-8]: run itests against all DB types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -275,6 +275,17 @@ jobs:
   itest:
     name: integration test
     runs-on: ubuntu-latest
+    strategy:
+      # Allow other tests in the matrix to continue if one fails.
+      fail-fast: false
+      matrix:
+        include:
+          - name: bbolt
+            args: dbbackend=bbolt
+          - name: sqlite
+            args: dbbackend=sqlite
+          - name: postgres
+            args: dbbackend=postgres
     steps:
       - name: git checkout
         uses: actions/checkout@v4
@@ -295,8 +306,8 @@ jobs:
         working-directory: ./app
         run: yarn
 
-      - name: run check
-        run: make itest
+      - name: run itest ${{ matrix.name }}
+        run: make itest ${{ matrix.args }}
 
       - name: Zip log files on failure
         if: ${{ failure() }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ run:
     - watchtowerrpc
     - neutrinorpc
     - peersrpc
+    - dev
 
 linters-settings:
   govet:

--- a/config_dev.go
+++ b/config_dev.go
@@ -6,7 +6,29 @@ import (
 	"path/filepath"
 
 	"github.com/lightninglabs/lightning-terminal/accounts"
+	"github.com/lightninglabs/lightning-terminal/db"
 	"github.com/lightningnetwork/lnd/clock"
+)
+
+const (
+	// DatabaseBackendSqlite is the name of the SQLite database backend.
+	DatabaseBackendSqlite = "sqlite"
+
+	// DatabaseBackendPostgres is the name of the Postgres database backend.
+	DatabaseBackendPostgres = "postgres"
+
+	// DatabaseBackendBbolt is the name of the bbolt database backend.
+	DatabaseBackendBbolt = "bbolt"
+
+	// defaultSqliteDatabaseFileName is the default name of the SQLite
+	// database file.
+	defaultSqliteDatabaseFileName = "litd.db"
+)
+
+// defaultSqliteDatabasePath is the default path under which we store
+// the SQLite database file.
+var defaultSqliteDatabasePath = filepath.Join(
+	DefaultLitDir, DefaultNetwork, defaultSqliteDatabaseFileName,
 )
 
 // DevConfig is a struct that holds the configuration options for a development
@@ -16,23 +38,80 @@ import (
 //
 // nolint:lll
 type DevConfig struct {
+	// DatabaseBackend is the database backend we will use for storing all
+	// account related data. While this feature is still in development, we
+	// include the bbolt type here so that our itests can continue to be
+	// tested against a bbolt backend. Once the full bbolt to SQL migration
+	// is complete, however, we will remove the bbolt option.
+	DatabaseBackend string `long:"databasebackend" description:"The database backend to use for storing all account related data." choice:"bbolt" choice:"sqlite" choice:"postgres"`
+
+	// Sqlite holds the configuration options for a SQLite database
+	// backend.
+	Sqlite *db.SqliteConfig `group:"sqlite" namespace:"sqlite"`
+
+	// Postgres holds the configuration options for a Postgres database
+	Postgres *db.PostgresConfig `group:"postgres" namespace:"postgres"`
 }
 
 // Validate checks that all the values set in our DevConfig are valid and uses
 // the passed parameters to override any defaults if necessary.
 func (c *DevConfig) Validate(dbDir, network string) error {
+	// We'll update the database file location if it wasn't set.
+	if c.Sqlite.DatabaseFileName == defaultSqliteDatabasePath {
+		c.Sqlite.DatabaseFileName = filepath.Join(
+			dbDir, network, defaultSqliteDatabaseFileName,
+		)
+	}
+
 	return nil
 }
 
 // defaultDevConfig returns a new DevConfig with default values set.
 func defaultDevConfig() *DevConfig {
-	return &DevConfig{}
+	return &DevConfig{
+		Sqlite: &db.SqliteConfig{
+			DatabaseFileName: defaultSqliteDatabasePath,
+		},
+		Postgres: &db.PostgresConfig{
+			Host:               "localhost",
+			Port:               5432,
+			MaxOpenConnections: 10,
+		},
+	}
 }
 
 // NewAccountStore creates a new account store based on the chosen database
 // backend.
 func NewAccountStore(cfg *Config, clock clock.Clock) (accounts.Store, error) {
-	return accounts.NewBoltStore(
-		filepath.Dir(cfg.MacaroonPath), accounts.DBFilename, clock,
-	)
+	switch cfg.DatabaseBackend {
+	case DatabaseBackendSqlite:
+		// Before we initialize the SQLite store, we'll make sure that
+		// the directory where we will store the database file exists.
+		networkDir := filepath.Join(cfg.LitDir, cfg.Network)
+		err := makeDirectories(networkDir)
+		if err != nil {
+			return nil, err
+		}
+
+		sqlStore, err := db.NewSqliteStore(cfg.Sqlite)
+		if err != nil {
+			return nil, err
+		}
+
+		return accounts.NewSQLStore(sqlStore.BaseDB, clock), nil
+
+	case DatabaseBackendPostgres:
+		sqlStore, err := db.NewPostgresStore(cfg.Postgres)
+		if err != nil {
+			return nil, err
+		}
+
+		return accounts.NewSQLStore(sqlStore.BaseDB, clock), nil
+
+	default:
+		return accounts.NewBoltStore(
+			filepath.Dir(cfg.MacaroonPath), accounts.DBFilename,
+			clock,
+		)
+	}
 }

--- a/config_dev.go
+++ b/config_dev.go
@@ -1,0 +1,38 @@
+//go:build dev
+
+package terminal
+
+import (
+	"path/filepath"
+
+	"github.com/lightninglabs/lightning-terminal/accounts"
+	"github.com/lightningnetwork/lnd/clock"
+)
+
+// DevConfig is a struct that holds the configuration options for a development
+// environment. The purpose of this struct is to hold config options for
+// features not yet available in production. Since our itests are built with
+// the dev tag, we can test these features in our itests.
+//
+// nolint:lll
+type DevConfig struct {
+}
+
+// Validate checks that all the values set in our DevConfig are valid and uses
+// the passed parameters to override any defaults if necessary.
+func (c *DevConfig) Validate(dbDir, network string) error {
+	return nil
+}
+
+// defaultDevConfig returns a new DevConfig with default values set.
+func defaultDevConfig() *DevConfig {
+	return &DevConfig{}
+}
+
+// NewAccountStore creates a new account store based on the chosen database
+// backend.
+func NewAccountStore(cfg *Config, clock clock.Clock) (accounts.Store, error) {
+	return accounts.NewBoltStore(
+		filepath.Dir(cfg.MacaroonPath), accounts.DBFilename, clock,
+	)
+}

--- a/config_prod.go
+++ b/config_prod.go
@@ -1,0 +1,33 @@
+//go:build !dev
+
+package terminal
+
+import (
+	"path/filepath"
+
+	"github.com/lightninglabs/lightning-terminal/accounts"
+	"github.com/lightningnetwork/lnd/clock"
+)
+
+// DevConfig is an empty shell struct that allows us to build without the dev
+// tag. This struct is embedded in the main Config struct, and it adds no new
+// functionality in a production build.
+type DevConfig struct{}
+
+// defaultDevConfig returns an empty DevConfig struct.
+func defaultDevConfig() *DevConfig {
+	return &DevConfig{}
+}
+
+// Validate is a no-op function during a production build.
+func (c *DevConfig) Validate(_, _ string) error {
+	return nil
+}
+
+// NewAccountStore creates a new account store using the default Bolt backend
+// since in production, this is the only backend supported currently.
+func NewAccountStore(cfg *Config, clock clock.Clock) (accounts.Store, error) {
+	return accounts.NewBoltStore(
+		filepath.Dir(cfg.MacaroonPath), accounts.DBFilename, clock,
+	)
+}

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -1,12 +1,16 @@
 include make/compile_flags.mk
 
-ITEST_FLAGS =
 TEST_FLAGS =
 DEV_TAGS = dev
 
 # Define the integration test.run filter if the icase argument was provided.
 ifneq ($(icase),)
 ITEST_FLAGS += -test.run="TestLightningTerminal/$(icase)"
+endif
+
+# Run itests with specified db backend.
+ifneq ($(dbbackend),)
+ITEST_FLAGS += -litdbbackend=$(dbbackend)
 endif
 
 # If a specific unit test case is being targeted, construct test.run filter.

--- a/terminal.go
+++ b/terminal.go
@@ -216,7 +216,7 @@ type LightningTerminal struct {
 	middleware        *mid.Manager
 	middlewareStarted bool
 
-	accountsStore         *accounts.BoltStore
+	accountsStore         accounts.Store
 	accountService        *accounts.InterceptorService
 	accountServiceStarted bool
 
@@ -415,10 +415,14 @@ func (g *LightningTerminal) start(ctx context.Context) error {
 		)
 	}
 
-	g.accountsStore, err = accounts.NewBoltStore(
-		filepath.Dir(g.cfg.MacaroonPath), accounts.DBFilename,
-		clock.NewDefaultClock(),
-	)
+	networkDir := filepath.Join(g.cfg.LitDir, g.cfg.Network)
+	err = makeDirectories(networkDir)
+	if err != nil {
+		return fmt.Errorf("could not create network directory: %v", err)
+	}
+
+	clock := clock.NewDefaultClock()
+	g.accountsStore, err = NewAccountStore(g.cfg, clock)
 	if err != nil {
 		return fmt.Errorf("error creating accounts store: %w", err)
 	}
@@ -445,10 +449,7 @@ func (g *LightningTerminal) start(ctx context.Context) error {
 	g.ruleMgrs = rules.NewRuleManagerSet()
 
 	// Create an instance of the local Terminal Connect session store DB.
-	networkDir := filepath.Join(g.cfg.LitDir, g.cfg.Network)
-	g.sessionDB, err = session.NewDB(
-		networkDir, session.DBFilename, clock.NewDefaultClock(),
-	)
+	g.sessionDB, err = session.NewDB(networkDir, session.DBFilename, clock)
 	if err != nil {
 		return fmt.Errorf("error creating session DB: %v", err)
 	}


### PR DESCRIPTION
This completes the final step of the accounts section in phase 1 of https://github.com/lightninglabs/lightning-terminal/issues/917

Here we run our CI itests against all DB types. As of this PR, that means that the accounts store is spun up with different DB backends for the various iterations. 

(more detailed description to follow) 