### PR TITLE
multi: be consistent with UTC conversion of timestamp

### DIFF
--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -130,7 +130,7 @@ func (a *OffChainBalanceAccount) HasExpired() bool {
 		return false
 	}
 
-	return a.ExpirationDate.Before(time.Now())
+	return a.ExpirationDate.Before(time.Now().UTC())
 }
 
 // CurrentBalanceSats returns the current account balance in satoshis.

--- a/cmd/litcli/autopilot.go
+++ b/cmd/litcli/autopilot.go
@@ -251,7 +251,7 @@ func listFeatures(cli *cli.Context) error {
 
 func initAutopilotSession(cli *cli.Context) error {
 	sessionLength := time.Second * time.Duration(cli.Uint64("expiry"))
-	sessionExpiry := time.Now().Add(sessionLength).Unix()
+	sessionExpiry := time.Now().UTC().Add(sessionLength).Unix()
 
 	ctx := getContext()
 	clientConn, cleanup, err := connectClient(cli, false)

--- a/docs/release-notes/release-notes-0.14.1.md
+++ b/docs/release-notes/release-notes-0.14.1.md
@@ -20,6 +20,17 @@
   quotes](https://github.com/lightninglabs/lightning-terminal/pull/920).
   Fixes fee estimation bug when using Loop In for a specific channel.
 
+* [Fix inconsistent timestamp local such that we strictly use UTC 
+  time](https://github.com/lightninglabs/lightning-terminal/pull/976). 
+  This will mean that previously serialised timestamps that were not first 
+  converted to UTC will not be interpreted as UTC and so may be off by a few
+  hours depending on the timezone of where the server is running. This should 
+  not be an issue for majority of cases. The possible side effects are that an 
+  LNC session's expiry may differ by a few hours. There is an unlikely edge case
+  that can happen if an LNC session is created, not connected to, and then LiT
+  is upgraded all within a 10 min timespan. If this happens then the session may
+  immediately be revoked. The solution to this is just to recreate the session. 
+
 ### Functional Changes/Additions
 
 ### Technical and Architectural Updates

--- a/firewall/request_logger.go
+++ b/firewall/request_logger.go
@@ -195,7 +195,7 @@ func (r *RequestLogger) addNewAction(ri *RequestInfo,
 
 	action := &firewalldb.Action{
 		RPCMethod:   ri.URI,
-		AttemptedAt: time.Now(),
+		AttemptedAt: time.Now().UTC(),
 		State:       firewalldb.ActionStateInit,
 	}
 

--- a/rules/rate_limit.go
+++ b/rules/rate_limit.go
@@ -134,7 +134,7 @@ func (r *RateLimitEnforcer) HandleRequest(ctx context.Context, uri string,
 	// Determine the start time of the actions window.
 	startTime := time.Now().Add(
 		-time.Duration(rateLim.NumHours) * time.Hour,
-	)
+	).UTC()
 
 	// Now count all relevant actions which have taken place after the
 	// start time.


### PR DESCRIPTION
Since we convert to UTC timestamps at persistence read/write time, we gotta make sure to compare against a consistent `Local` when comparing against `time.Now()` in the code. 