### PR TITLE
golangci: enable line length linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,7 @@ linters-settings:
 
 linters:
   enable:
+    - lll
     - gofmt
     - tagliatelle
     - whitespace

--- a/autopilotserver/client.go
+++ b/autopilotserver/client.go
@@ -26,6 +26,8 @@ var ErrVersionIncompatible = fmt.Errorf("litd version is not compatible " +
 	"with the minimum version required by the autopilot server")
 
 // Config holds the configuration options for the autopilot server client.
+//
+//nolint:lll
 type Config struct {
 	// Disable will disable the autopilot client.
 	Disable bool `long:"disable" description:"disable the autopilot client"`

--- a/config.go
+++ b/config.go
@@ -147,6 +147,8 @@ var (
 // Config is the main configuration struct of lightning-terminal. It contains
 // all config items of its enveloping subservers, each prefixed with their
 // daemon's short name.
+//
+//nolint:lll
 type Config struct {
 	ShowVersion bool `long:"version" description:"Display version information and exit."`
 

--- a/firewall/config.go
+++ b/firewall/config.go
@@ -1,11 +1,15 @@
 package firewall
 
 // Config holds all config options for the firewall.
+//
+//nolint:lll
 type Config struct {
 	RequestLogger *RequestLoggerConfig `group:"request-logger" namespace:"request-logger" description:"request logger settings"`
 }
 
 // RequestLoggerConfig holds all the config options for the request logger.
+//
+//nolint:lll
 type RequestLoggerConfig struct {
 	RequestLoggerLevel RequestLoggerLevel `long:"level" description:"Set the request logger level. Options include 'all', 'full' and 'interceptor''"`
 }

--- a/firewall/privacy_mapper_test.go
+++ b/firewall/privacy_mapper_test.go
@@ -1308,6 +1308,8 @@ func TestHideBool(t *testing.T) {
 
 // TestObfuscateConfig tests that we substitute substrings in the config
 // correctly.
+//
+//nolint:lll
 func TestObfuscateConfig(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/rpcmiddleware/config.go
+++ b/rpcmiddleware/config.go
@@ -9,6 +9,8 @@ const (
 )
 
 // Config is the configuration struct for the RPC middleware.
+//
+//nolint:lll
 type Config struct {
 	Disabled         bool          `long:"disabled" description:"Disable the RPC middleware"`
 	InterceptTimeout time.Duration `long:"intercept-timeout" description:"The maximum time the RPC middleware is allowed to take for intercepting each RPC request"`

--- a/subservers/config.go
+++ b/subservers/config.go
@@ -2,6 +2,8 @@ package subservers
 
 // RemoteConfig holds the configuration parameters that are needed when running
 // LiT in the "remote" lnd mode.
+//
+//nolint:lll
 type RemoteConfig struct {
 	LitLogDir         string `long:"lit-logdir" description:"For lnd remote mode only: Directory to log output."`
 	LitMaxLogFiles    int    `long:"lit-maxlogfiles" description:"For lnd remote mode only: Maximum logfiles to keep (0 for no rotation)"`
@@ -18,6 +20,8 @@ type RemoteConfig struct {
 
 // RemoteDaemonConfig holds the configuration parameters that are needed to
 // connect to a remote daemon like lnd for example.
+//
+//nolint:lll
 type RemoteDaemonConfig struct {
 	// RPCServer is host:port that the remote daemon's RPC server is
 	// listening on.


### PR DESCRIPTION
Activate the line-length-too-long linter