### PR TITLE
itest: ensure peer is connected before channel open

### DIFF
--- a/itest/litd_firewall_test.go
+++ b/itest/litd_firewall_test.go
@@ -1399,6 +1399,9 @@ func testChannelOpening(net *NetworkHarness, ht *harnessTest, t *testing.T) {
 
 	caveatCreds = metaDataInjector.addCaveat(caveat)
 
+	// Wait for alice to reconnect to charlie.
+	net.EnsureConnected(t, net.Alice, charlie)
+
 	memoBefore := lastMemo
 	openResp, err = lndConn2.OpenChannelSync(
 		ctx, &lnrpc.OpenChannelRequest{


### PR DESCRIPTION
This fixes a flake that has been occurring in our itests more and more frequently where we try
to open a second channel with one of our channel peers immediately after a restart. But we might
not yet have connected with them. So we should wait for the reconnect before we attempt to open 
the channel.