### PR TITLE
[sql-14] sessions: atomic session creation

### DIFF
--- a/session/interface.go
+++ b/session/interface.go
@@ -216,12 +216,6 @@ type Store interface {
 	// GetSessionByID fetches the session with the given ID.
 	GetSessionByID(id ID) (*Session, error)
 
-	// CheckSessionGroupPredicate iterates over all the sessions in a group
-	// and checks if each one passes the given predicate function. True is
-	// returned if each session passes.
-	CheckSessionGroupPredicate(groupID ID,
-		fn func(s *Session) bool) (bool, error)
-
 	// DeleteReservedSessions deletes all sessions that are in the
 	// StateReserved state.
 	DeleteReservedSessions() error

--- a/session/kvdb_store.go
+++ b/session/kvdb_store.go
@@ -182,41 +182,42 @@ func getSessionKey(session *Session) []byte {
 	return session.LocalPublicKey.SerializeCompressed()
 }
 
-// NewSession creates a new session with the given user-defined parameters.
-//
-// NOTE: currently this purely a constructor of the Session type and does not
-// make any database calls. This will be changed in a future commit.
-//
-// NOTE: this is part of the Store interface.
-func (db *BoltStore) NewSession(id ID, localPrivKey *btcec.PrivateKey,
-	label string, typ Type, expiry time.Time, serverAddr string,
-	devServer bool, perms []bakery.Op, caveats []macaroon.Caveat,
-	featureConfig FeaturesConfig, privacy bool, linkedGroupID *ID,
-	flags PrivacyFlags) (*Session, error) {
-
-	return buildSession(
-		id, localPrivKey, label, typ, db.clock.Now(), expiry,
-		serverAddr, devServer, perms, caveats, featureConfig, privacy,
-		linkedGroupID, flags,
-	)
-}
-
-// CreateSession adds a new session to the store. If a session with the same
-// local public key already exists an error is returned.
+// NewSession creates and persists a new session with the given user-defined
+// parameters. The initial state of the session will be Reserved until
+// ShiftState is called with StateCreated.
 //
 // NOTE: this is part of the Store interface.
-func (db *BoltStore) CreateSession(session *Session) error {
-	sessionKey := getSessionKey(session)
+func (db *BoltStore) NewSession(label string, typ Type, expiry time.Time,
+	serverAddr string, devServer bool, perms []bakery.Op,
+	caveats []macaroon.Caveat, featureConfig FeaturesConfig, privacy bool,
+	linkedGroupID *ID, flags PrivacyFlags) (*Session, error) {
 
-	return db.Update(func(tx *bbolt.Tx) error {
+	var session *Session
+	err := db.Update(func(tx *bbolt.Tx) error {
 		sessionBucket, err := getBucket(tx, sessionBucketKey)
 		if err != nil {
 			return err
 		}
 
+		id, localPrivKey, err := getUnusedIDAndKeyPair(sessionBucket)
+		if err != nil {
+			return err
+		}
+
+		session, err = buildSession(
+			id, localPrivKey, label, typ, db.clock.Now(), expiry,
+			serverAddr, devServer, perms, caveats, featureConfig,
+			privacy, linkedGroupID, flags,
+		)
+		if err != nil {
+			return err
+		}
+
+		sessionKey := getSessionKey(session)
+
 		if len(sessionBucket.Get(sessionKey)) != 0 {
-			return fmt.Errorf("session with local public "+
-				"key(%x) already exists",
+			return fmt.Errorf("session with local public key(%x) "+
+				"already exists",
 				session.LocalPublicKey.SerializeCompressed())
 		}
 
@@ -275,6 +276,11 @@ func (db *BoltStore) CreateSession(session *Session) error {
 
 		return putSession(sessionBucket, session)
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	return session, nil
 }
 
 // UpdateSessionRemotePubKey can be used to add the given remote pub key
@@ -577,53 +583,35 @@ func (db *BoltStore) GetSessionByID(id ID) (*Session, error) {
 	return session, nil
 }
 
-// GetUnusedIDAndKeyPair can be used to generate a new, unused, local private
+// getUnusedIDAndKeyPair can be used to generate a new, unused, local private
 // key and session ID pair. Care must be taken to ensure that no other thread
 // calls this before the returned ID and key pair from this method are either
 // used or discarded.
-//
-// NOTE: this is part of the Store interface.
-func (db *BoltStore) GetUnusedIDAndKeyPair() (ID, *btcec.PrivateKey, error) {
-	var (
-		id      ID
-		privKey *btcec.PrivateKey
-	)
-	err := db.Update(func(tx *bbolt.Tx) error {
-		sessionBucket, err := getBucket(tx, sessionBucketKey)
-		if err != nil {
-			return err
-		}
+func getUnusedIDAndKeyPair(bucket *bbolt.Bucket) (ID, *btcec.PrivateKey,
+	error) {
 
-		idIndexBkt := sessionBucket.Bucket(idIndexKey)
-		if idIndexBkt == nil {
-			return ErrDBInitErr
-		}
-
-		// Spin until we find a key with an ID that does not collide
-		// with any of our existing IDs.
-		for {
-			// Generate a new private key and ID pair.
-			privKey, id, err = NewSessionPrivKeyAndID()
-			if err != nil {
-				return err
-			}
-
-			// Check that no such ID exits in our id-to-key index.
-			idBkt := idIndexBkt.Bucket(id[:])
-			if idBkt != nil {
-				continue
-			}
-
-			break
-		}
-
-		return nil
-	})
-	if err != nil {
-		return id, nil, err
+	idIndexBkt := bucket.Bucket(idIndexKey)
+	if idIndexBkt == nil {
+		return ID{}, nil, ErrDBInitErr
 	}
 
-	return id, privKey, nil
+	// Spin until we find a key with an ID that does not collide with any of
+	// our existing IDs.
+	for {
+		// Generate a new private key and ID pair.
+		privKey, id, err := NewSessionPrivKeyAndID()
+		if err != nil {
+			return ID{}, nil, err
+		}
+
+		// Check that no such ID exits in our id-to-key index.
+		idBkt := idIndexBkt.Bucket(id[:])
+		if idBkt != nil {
+			continue
+		}
+
+		return id, privKey, nil
+	}
 }
 
 // GetGroupID will return the group ID for the given session ID.

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -874,23 +874,6 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 				"group %x", groupSess.ID, groupSess.GroupID)
 		}
 
-		// Now we need to check that all the sessions in the group are
-		// no longer active.
-		ok, err := s.cfg.db.CheckSessionGroupPredicate(
-			groupID, func(s *session.Session) bool {
-				return s.State == session.StateRevoked ||
-					s.State == session.StateExpired
-			},
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		if !ok {
-			return nil, fmt.Errorf("a linked session in group "+
-				"%x is still active", groupID)
-		}
-
 		linkedGroupID = &groupID
 		linkedGroupSession = groupSess
 

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -46,11 +46,6 @@ type sessionRpcServer struct {
 	cfg           *sessionRpcServerConfig
 	sessionServer *session.Server
 
-	// sessRegMu is a mutex that should be held between acquiring an unused
-	// session ID and key pair from the session store and persisting that
-	// new session.
-	sessRegMu sync.Mutex
-
 	quit     chan struct{}
 	wg       sync.WaitGroup
 	stopOnce sync.Once
@@ -313,16 +308,8 @@ func (s *sessionRpcServer) AddSession(ctx context.Context,
 		}
 	}
 
-	s.sessRegMu.Lock()
-	defer s.sessRegMu.Unlock()
-
-	id, localPrivKey, err := s.cfg.db.GetUnusedIDAndKeyPair()
-	if err != nil {
-		return nil, err
-	}
-
 	sess, err := s.cfg.db.NewSession(
-		id, localPrivKey, req.Label, typ, expiry, req.MailboxServerAddr,
+		req.Label, typ, expiry, req.MailboxServerAddr,
 		req.DevServer, uniquePermissions, caveats, nil, false, nil,
 		session.PrivacyFlags{},
 	)
@@ -330,12 +317,21 @@ func (s *sessionRpcServer) AddSession(ctx context.Context,
 		return nil, fmt.Errorf("error creating new session: %v", err)
 	}
 
-	if err := s.cfg.db.CreateSession(sess); err != nil {
-		return nil, fmt.Errorf("error storing session: %v", err)
+	err = s.cfg.db.ShiftState(sess.ID, session.StateCreated)
+	if err != nil {
+		return nil, fmt.Errorf("error shifting session state to "+
+			"Created: %v", err)
 	}
 
 	if err := s.resumeSession(ctx, sess); err != nil {
 		return nil, fmt.Errorf("error starting session: %v", err)
+	}
+
+	// Re-fetch the session to get the latest state of it before marshaling
+	// it.
+	sess, err = s.cfg.db.GetSessionByID(sess.ID)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching session: %v", err)
 	}
 
 	rpcSession, err := s.marshalRPCSession(sess)
@@ -1141,16 +1137,8 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 		caveats = append(caveats, firewall.MetaPrivacyCaveat)
 	}
 
-	s.sessRegMu.Lock()
-	defer s.sessRegMu.Unlock()
-
-	id, localPrivKey, err := s.cfg.db.GetUnusedIDAndKeyPair()
-	if err != nil {
-		return nil, err
-	}
-
 	sess, err := s.cfg.db.NewSession(
-		id, localPrivKey, req.Label, session.TypeAutopilot, expiry,
+		req.Label, session.TypeAutopilot, expiry,
 		req.MailboxServerAddr, req.DevServer, perms, caveats,
 		clientConfig, privacy, linkedGroupID, privacyFlags,
 	)
@@ -1233,15 +1221,31 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 			"autopilot server: %v", err)
 	}
 
-	// We only persist this session if we successfully retrieved the
-	// autopilot's static key.
+	err = s.cfg.db.UpdateSessionRemotePubKey(sess.LocalPublicKey, remoteKey)
+	if err != nil {
+		return nil, fmt.Errorf("error setting remote pubkey: %v", err)
+	}
+
+	// Update our in-memory session with the remote key.
 	sess.RemotePublicKey = remoteKey
-	if err := s.cfg.db.CreateSession(sess); err != nil {
-		return nil, fmt.Errorf("error storing session: %v", err)
+
+	// We only activate the session if the Autopilot server registration
+	// was successful.
+	err = s.cfg.db.ShiftState(sess.ID, session.StateCreated)
+	if err != nil {
+		return nil, fmt.Errorf("error shifting session state to "+
+			"Created: %v", err)
 	}
 
 	if err := s.resumeSession(ctx, sess); err != nil {
 		return nil, fmt.Errorf("error starting session: %v", err)
+	}
+
+	// Re-fetch the session to get the latest state of it before marshaling
+	// it.
+	sess, err = s.cfg.db.GetSessionByID(sess.ID)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching session: %v", err)
 	}
 
 	rpcSession, err := s.marshalRPCSession(sess)


### PR DESCRIPTION
See https://github.com/lightninglabs/lightning-terminal/issues/979 for more context. 

In this PR, we do the refactor to make session creation happen in 1 atomic DB transaction as described in the issue above. 

Fixes https://github.com/lightninglabs/lightning-terminal/issues/979