### PR TITLE
accounts: Credit and debit accounts `kvdb` additions prep

### DIFF
--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -225,9 +225,9 @@ type Store interface {
 	AddAccountInvoice(ctx context.Context, id AccountID,
 		hash lntypes.Hash) error
 
-	// IncreaseAccountBalance increases the balance of the account with the
+	// CreditAccount increases the balance of the account with the
 	// given ID by the given amount.
-	IncreaseAccountBalance(ctx context.Context, id AccountID,
+	CreditAccount(ctx context.Context, id AccountID,
 		amount lnwire.MilliSatoshi) error
 
 	// UpsertAccountPayment updates or inserts a payment entry for the given

--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -230,6 +230,11 @@ type Store interface {
 	CreditAccount(ctx context.Context, id AccountID,
 		amount lnwire.MilliSatoshi) error
 
+	// DebitAccount decreases the balance of the account with the
+	// given ID by the given amount.
+	DebitAccount(ctx context.Context, id AccountID,
+		amount lnwire.MilliSatoshi) error
+
 	// UpsertAccountPayment updates or inserts a payment entry for the given
 	// account. Various functional options can be passed to modify the
 	// behavior of the method. The returned boolean is true if the payment

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -563,7 +563,7 @@ func (s *InterceptorService) invoiceUpdate(ctx context.Context,
 	// If we get here, the current account has the invoice associated with
 	// it that was just paid. Credit the amount to the account and update it
 	// in the DB.
-	err := s.store.IncreaseAccountBalance(ctx, acctID, invoice.AmountPaid)
+	err := s.store.CreditAccount(ctx, acctID, invoice.AmountPaid)
 	if err != nil {
 		return s.disableAndErrorfUnsafe("error increasing account "+
 			"balance account: %w", err)

--- a/accounts/store_kvdb.go
+++ b/accounts/store_kvdb.go
@@ -223,11 +223,11 @@ func (s *BoltStore) AddAccountInvoice(_ context.Context, id AccountID,
 	return s.updateAccount(id, update)
 }
 
-// IncreaseAccountBalance increases the balance of the account with the given ID
+// CreditAccount increases the balance of the account with the given ID
 // by the given amount.
 //
 // NOTE: This is part of the Store interface.
-func (s *BoltStore) IncreaseAccountBalance(_ context.Context, id AccountID,
+func (s *BoltStore) CreditAccount(_ context.Context, id AccountID,
 	amount lnwire.MilliSatoshi) error {
 
 	update := func(account *OffChainBalanceAccount) error {

--- a/accounts/store_kvdb.go
+++ b/accounts/store_kvdb.go
@@ -244,6 +244,33 @@ func (s *BoltStore) CreditAccount(_ context.Context, id AccountID,
 	return s.updateAccount(id, update)
 }
 
+// DebitAccount decreases the balance of the account with the given ID
+// by the given amount.
+//
+// NOTE: This is part of the Store interface.
+func (s *BoltStore) DebitAccount(_ context.Context, id AccountID,
+	amount lnwire.MilliSatoshi) error {
+
+	if amount > math.MaxInt64 {
+		return fmt.Errorf("amount %v exceeds the maximum of %v",
+			amount, int64(math.MaxInt64))
+	}
+
+	update := func(account *OffChainBalanceAccount) error {
+		if account.CurrentBalance-int64(amount) < 0 {
+			return fmt.Errorf("cannot debit %v from the account "+
+				"balance, as the resulting balance would be "+
+				"below 0", int64(amount/1000))
+		}
+
+		account.CurrentBalance -= int64(amount)
+
+		return nil
+	}
+
+	return s.updateAccount(id, update)
+}
+
 // UpsertAccountPayment updates or inserts a payment entry for the given
 // account. Various functional options can be passed to modify the behavior of
 // the method. The returned boolean is true if the payment was already known

--- a/accounts/store_test.go
+++ b/accounts/store_test.go
@@ -262,12 +262,12 @@ func TestAccountUpdateMethods(t *testing.T) {
 		assertInvoices(hash1, hash2)
 	})
 
-	t.Run("IncreaseAccountBalance", func(t *testing.T) {
+	t.Run("CreditAccount", func(t *testing.T) {
 		store := NewTestDB(t, clock.NewTestClock(time.Now()))
 
 		// Increasing the balance of an account that doesn't exist
 		// should error out.
-		err := store.IncreaseAccountBalance(ctx, AccountID{}, 100)
+		err := store.CreditAccount(ctx, AccountID{}, 100)
 		require.ErrorIs(t, err, ErrAccNotFound)
 
 		acct, err := store.NewAccount(ctx, 123, time.Time{}, "foo")
@@ -284,7 +284,7 @@ func TestAccountUpdateMethods(t *testing.T) {
 
 		// Increase the balance by 100 and assert that the new balance
 		// is 223.
-		err = store.IncreaseAccountBalance(ctx, acct.ID, 100)
+		err = store.CreditAccount(ctx, acct.ID, 100)
 		require.NoError(t, err)
 
 		assertBalance(223)


### PR DESCRIPTION
Part of https://github.com/lightninglabs/lightning-terminal/issues/648

This PR adds DB preparation required for the KVDB store, in order to support functionality which allows crediting or debiting an account's balance by a given amount.