### PR TITLE
[sql-15] sessions:  various functional options for NewSession

### DIFF
--- a/session/kvdb_store.go
+++ b/session/kvdb_store.go
@@ -13,8 +13,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightningnetwork/lnd/clock"
 	"go.etcd.io/bbolt"
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon.v2"
 )
 
 var (
@@ -188,9 +186,7 @@ func getSessionKey(session *Session) []byte {
 //
 // NOTE: this is part of the Store interface.
 func (db *BoltStore) NewSession(label string, typ Type, expiry time.Time,
-	serverAddr string, devServer bool, perms []bakery.Op,
-	caveats []macaroon.Caveat, featureConfig FeaturesConfig, privacy bool,
-	linkedGroupID *ID, flags PrivacyFlags) (*Session, error) {
+	serverAddr string, opts ...Option) (*Session, error) {
 
 	var session *Session
 	err := db.Update(func(tx *bbolt.Tx) error {
@@ -206,8 +202,7 @@ func (db *BoltStore) NewSession(label string, typ Type, expiry time.Time,
 
 		session, err = buildSession(
 			id, localPrivKey, label, typ, db.clock.Now(), expiry,
-			serverAddr, devServer, perms, caveats, featureConfig,
-			privacy, linkedGroupID, flags,
+			serverAddr, opts...,
 		)
 		if err != nil {
 			return err

--- a/session/store_test.go
+++ b/session/store_test.go
@@ -374,8 +374,10 @@ func reserveSession(db Store, label string,
 
 	return db.NewSession(label, opts.sessType,
 		time.Date(99999, 1, 1, 0, 0, 0, 0, time.UTC),
-		"foo.bar.baz:1234", true, nil, nil, nil, true, opts.groupID,
-		[]PrivacyFlag{ClearPubkeys},
+		"foo.bar.baz:1234",
+		WithDevServer(),
+		WithPrivacy(PrivacyFlags{ClearPubkeys}),
+		WithLinkedGroupID(opts.groupID),
 	)
 }
 

--- a/session/tlv_test.go
+++ b/session/tlv_test.go
@@ -133,10 +133,12 @@ func TestSerializeDeserializeSession(t *testing.T) {
 				id, priv, test.name, test.sessType,
 				time.Now(),
 				time.Date(99999, 1, 1, 0, 0, 0, 0, time.UTC),
-				"foo.bar.baz:1234", true, test.perms,
-				test.caveats, test.featureConfig, true,
-				test.linkedGroupID,
-				[]PrivacyFlag{ClearPubkeys},
+				"foo.bar.baz:1234",
+				WithDevServer(),
+				WithPrivacy(PrivacyFlags{ClearPubkeys}),
+				WithMacaroonRecipe(test.caveats, test.perms),
+				WithFeatureConfig(test.featureConfig),
+				WithLinkedGroupID(test.linkedGroupID),
 			)
 			require.NoError(t, err)
 
@@ -188,8 +190,8 @@ func TestGroupIDForOlderSessions(t *testing.T) {
 		id, priv, "test-session", TypeMacaroonAdmin,
 		time.Now(),
 		time.Date(99999, 1, 1, 0, 0, 0, 0, time.UTC),
-		"foo.bar.baz:1234", true, nil, nil, nil, false, nil,
-		PrivacyFlags{},
+		"foo.bar.baz:1234",
+		WithDevServer(),
 	)
 	require.NoError(t, err)
 
@@ -224,8 +226,8 @@ func TestGroupID(t *testing.T) {
 		id, priv, "test-session", TypeMacaroonAdmin,
 		time.Now(),
 		time.Date(99999, 1, 1, 0, 0, 0, 0, time.UTC),
-		"foo.bar.baz:1234", true, nil, nil, nil, false, nil,
-		PrivacyFlags{},
+		"foo.bar.baz:1234",
+		WithDevServer(),
 	)
 	require.NoError(t, err)
 
@@ -239,8 +241,9 @@ func TestGroupID(t *testing.T) {
 		id, priv, "test-session", TypeMacaroonAdmin,
 		time.Now(),
 		time.Date(99999, 1, 1, 0, 0, 0, 0, time.UTC),
-		"foo.bar.baz:1234", true, nil, nil, nil, false,
-		&session1.GroupID, PrivacyFlags{},
+		"foo.bar.baz:1234",
+		WithLinkedGroupID(&session1.ID),
+		WithDevServer(),
 	)
 	require.NoError(t, err)
 

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -911,6 +911,11 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 	// Determine privacy flags to use for session registration.
 	var privacyFlags session.PrivacyFlags
 	if req.PrivacyFlagsSet {
+		if !privacy {
+			return nil, fmt.Errorf("privacy flags can only be " +
+				"set when the privacy mapper is enabled")
+		}
+
 		// We apply privacy flags from the session request in order to
 		// to be able to set flags resulting from non-standard feature
 		// configurations.


### PR DESCRIPTION
For a cleaner interface, adjust the NewSession method of the Session
store such that all optional arguments are functional options.

We also now will error out in `AddAutopilotSession` if the caller specifies privacy map flags without actually
activating the privacy mapper. 