### PR TITLE
[sql-18] sessions: tightly couple sessions & accounts

### DIFF
--- a/accounts/interceptor.go
+++ b/accounts/interceptor.go
@@ -1,12 +1,15 @@
 package accounts
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 
 	mid "github.com/lightninglabs/lightning-terminal/rpcmiddleware"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"google.golang.org/protobuf/proto"
@@ -21,6 +24,15 @@ const (
 	// accountMiddlewareName is the name that is used for the account system
 	// when registering it to lnd as an RPC middleware.
 	accountMiddlewareName = "lit-account"
+)
+
+var (
+	// caveatPrefix is the prefix that is used for custom caveats that are
+	// used by the account system. This prefix is used to identify the
+	// custom caveat and extract the condition (the AccountID) from it.
+	caveatPrefix = []byte(fmt.Sprintf(
+		"%s %s ", macaroons.CondLndCustom, CondAccount,
+	))
 )
 
 // Name returns the name of the interceptor.
@@ -199,22 +211,58 @@ func parseRPCMessage(msg *lnrpc.RPCMessage) (proto.Message, error) {
 // accountFromMacaroon attempts to extract an account ID from the custom account
 // caveat in the macaroon.
 func accountFromMacaroon(mac *macaroon.Macaroon) (*AccountID, error) {
-	// Extract the account caveat from the macaroon.
-	macaroonAccount := macaroons.GetCustomCaveatCondition(mac, CondAccount)
-	if macaroonAccount == "" {
-		// There is no condition that locks the macaroon to an account,
-		// so there is nothing to check.
+	if mac == nil {
 		return nil, nil
 	}
 
-	// The macaroon is indeed locked to an account. Fetch the account and
-	// validate its balance.
-	accountIDBytes, err := hex.DecodeString(macaroonAccount)
+	// Extract the account caveat from the macaroon.
+	accountID, err := IDFromCaveats(mac.Caveats())
 	if err != nil {
 		return nil, err
 	}
 
+	var id *AccountID
+	accountID.WhenSome(func(aID AccountID) {
+		id = &aID
+	})
+
+	return id, nil
+}
+
+// IDFromCaveats attempts to extract an AccountID from the given set of caveats
+// by looking for the custom caveat that binds a macaroon to a certain account.
+func IDFromCaveats(caveats []macaroon.Caveat) (fn.Option[AccountID], error) {
+	var accountIDStr string
+	for _, caveat := range caveats {
+		// The caveat id has a format of
+		// "lnd-custom [custom-caveat-name] [custom-caveat-condition]"
+		// and we only want the condition part. If we match the prefix
+		// part we return the condition that comes after the prefix.
+		if bytes.HasPrefix(caveat.Id, caveatPrefix) {
+			caveatSplit := strings.SplitN(
+				string(caveat.Id),
+				string(caveatPrefix),
+				2,
+			)
+			if len(caveatSplit) == 2 {
+				accountIDStr = caveatSplit[1]
+
+				break
+			}
+		}
+	}
+
+	if accountIDStr == "" {
+		return fn.None[AccountID](), nil
+	}
+
 	var accountID AccountID
+	accountIDBytes, err := hex.DecodeString(accountIDStr)
+	if err != nil {
+		return fn.None[AccountID](), err
+	}
+
 	copy(accountID[:], accountIDBytes)
-	return &accountID, nil
+
+	return fn.Some(accountID), nil
 }

--- a/itest/litd_accounts_test.go
+++ b/itest/litd_accounts_test.go
@@ -199,6 +199,7 @@ func testAccountRestrictionsLNC(ctxm context.Context, t *harnessTest,
 		AccountId:         accountID,
 	})
 	require.NoError(t.t, err)
+	require.Equal(t.t, accountID, sessResp.Session.AccountId)
 
 	// Try the LNC connection now.
 	connectPhrase := strings.Split(

--- a/itest/litd_firewall_test.go
+++ b/itest/litd_firewall_test.go
@@ -866,7 +866,9 @@ func testSessionLinking(net *NetworkHarness, t *harnessTest) {
 			LinkedGroupId:     sessResp.Session.GroupId,
 		},
 	)
-	require.ErrorContains(t.t, err, "is still active")
+	require.ErrorContains(
+		t.t, err, session.ErrSessionsInGroupStillActive.Error(),
+	)
 
 	// Revoke the previous one and repeat.
 	_, err = litAutopilotClient.RevokeAutopilotSession(

--- a/session/errors.go
+++ b/session/errors.go
@@ -6,4 +6,16 @@ var (
 	// ErrSessionNotFound is an error returned when we attempt to retrieve
 	// information about a session but it is not found.
 	ErrSessionNotFound = errors.New("session not found")
+
+	// ErrUnknownGroup is returned when an attempt is made to insert a
+	// session and link it to an existing group where the group is not
+	// known.
+	ErrUnknownGroup = errors.New("unknown group")
+
+	// ErrSessionsInGroupStillActive is returned when an attempt is made to
+	// insert a session and link it to a group that still has other active
+	// sessions.
+	ErrSessionsInGroupStillActive = errors.New(
+		"group has active sessions",
+	)
 )

--- a/session/interface.go
+++ b/session/interface.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/lightning-node-connect/mailbox"
+	"github.com/lightninglabs/lightning-terminal/accounts"
 	"github.com/lightninglabs/lightning-terminal/macaroons"
+	"github.com/lightningnetwork/lnd/fn"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon.v2"
 )
@@ -116,6 +118,9 @@ type Session struct {
 	// group of sessions. If this is the very first session in the group
 	// then this will be the same as ID.
 	GroupID ID
+
+	// AccountID is an optional account that the session has been linked to.
+	AccountID fn.Option[accounts.AccountID]
 }
 
 // buildSession creates a new session with the given user-defined parameters.
@@ -123,7 +128,8 @@ func buildSession(id ID, localPrivKey *btcec.PrivateKey, label string, typ Type,
 	created, expiry time.Time, serverAddr string, devServer bool,
 	perms []bakery.Op, caveats []macaroon.Caveat,
 	featureConfig FeaturesConfig, privacy bool, linkedGroupID *ID,
-	flags PrivacyFlags) (*Session, error) {
+	flags PrivacyFlags, account fn.Option[accounts.AccountID]) (*Session,
+	error) {
 
 	_, pairingSecret, err := mailbox.NewPassphraseEntropy()
 	if err != nil {
@@ -158,6 +164,7 @@ func buildSession(id ID, localPrivKey *btcec.PrivateKey, label string, typ Type,
 		WithPrivacyMapper: privacy,
 		PrivacyFlags:      flags,
 		GroupID:           groupID,
+		AccountID:         account,
 	}
 
 	if perms != nil || caveats != nil {
@@ -193,7 +200,8 @@ type Store interface {
 	NewSession(label string, typ Type, expiry time.Time, serverAddr string,
 		devServer bool, perms []bakery.Op, caveats []macaroon.Caveat,
 		featureConfig FeaturesConfig, privacy bool, linkedGroupID *ID,
-		flags PrivacyFlags) (*Session, error)
+		flags PrivacyFlags,
+		account fn.Option[accounts.AccountID]) (*Session, error)
 
 	// GetSession fetches the session with the given key.
 	GetSession(key *btcec.PublicKey) (*Session, error)

--- a/session/kvdb_store.go
+++ b/session/kvdb_store.go
@@ -229,8 +229,9 @@ func (db *BoltStore) NewSession(label string, typ Type, expiry time.Time,
 		if session.ID != session.GroupID {
 			_, err = getKeyForID(sessionBucket, session.GroupID)
 			if err != nil {
-				return fmt.Errorf("unknown linked session "+
-					"%x: %w", session.GroupID, err)
+				return fmt.Errorf("%w: unknown linked "+
+					"session %x: %w", ErrUnknownGroup,
+					session.GroupID, err)
 			}
 
 			// Fetch all the session IDs for this group. This will
@@ -242,18 +243,22 @@ func (db *BoltStore) NewSession(label string, typ Type, expiry time.Time,
 				return err
 			}
 
+			// Ensure that the all the linked sessions are no longer
+			// active.
 			for _, id := range sessionIDs {
 				sess, err := getSessionByID(sessionBucket, id)
 				if err != nil {
 					return err
 				}
 
-				// Ensure that the session is no longer active.
-				if !sess.State.Terminal() {
-					return fmt.Errorf("session (id=%x) "+
-						"in group %x is still active",
-						sess.ID, sess.GroupID)
+				if sess.State.Terminal() {
+					continue
 				}
+
+				return fmt.Errorf("%w: session (id=%x) in "+
+					"group %x is still active",
+					ErrSessionsInGroupStillActive, sess.ID,
+					sess.GroupID)
 			}
 		}
 
@@ -630,14 +635,14 @@ func (db *BoltStore) GetGroupID(sessionID ID) (ID, error) {
 
 		sessionIDBkt := idIndex.Bucket(sessionID[:])
 		if sessionIDBkt == nil {
-			return fmt.Errorf("no index entry for session ID: %x",
-				sessionID)
+			return fmt.Errorf("%w: no index entry for session "+
+				"ID: %x", ErrUnknownGroup, sessionID)
 		}
 
 		groupIDBytes := sessionIDBkt.Get(groupIDKey)
 		if len(groupIDBytes) == 0 {
-			return fmt.Errorf("group ID not found for session "+
-				"ID %x", sessionID)
+			return fmt.Errorf("%w: group ID not found for "+
+				"session ID %x", ErrUnknownGroup, sessionID)
 		}
 
 		copy(groupID[:], groupIDBytes)
@@ -806,7 +811,7 @@ func addIDToGroupIDPair(sessionBkt *bbolt.Bucket, id, groupID ID) error {
 func getSessionByID(bucket *bbolt.Bucket, id ID) (*Session, error) {
 	keyBytes, err := getKeyForID(bucket, id)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrSessionNotFound, err)
 	}
 
 	v := bucket.Get(keyBytes)

--- a/session/kvdb_store.go
+++ b/session/kvdb_store.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/lightning-terminal/accounts"
 	"github.com/lightningnetwork/lnd/clock"
 	"go.etcd.io/bbolt"
 	"gopkg.in/macaroon-bakery.v2/bakery"
@@ -83,13 +84,17 @@ type BoltStore struct {
 	*bbolt.DB
 
 	clock clock.Clock
+
+	accounts accounts.Store
 }
 
 // A compile-time check to ensure that BoltStore implements the Store interface.
 var _ Store = (*BoltStore)(nil)
 
 // NewDB creates a new bolt database that can be found at the given directory.
-func NewDB(dir, fileName string, clock clock.Clock) (*BoltStore, error) {
+func NewDB(dir, fileName string, clock clock.Clock,
+	store accounts.Store) (*BoltStore, error) {
+
 	firstInit := false
 	path := filepath.Join(dir, fileName)
 
@@ -113,8 +118,9 @@ func NewDB(dir, fileName string, clock clock.Clock) (*BoltStore, error) {
 	}
 
 	return &BoltStore{
-		DB:    db,
-		clock: clock,
+		DB:       db,
+		clock:    clock,
+		accounts: store,
 	}, nil
 }
 

--- a/session/kvdb_store.go
+++ b/session/kvdb_store.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/lightning-terminal/accounts"
 	"github.com/lightningnetwork/lnd/clock"
+	"github.com/lightningnetwork/lnd/fn"
 	"go.etcd.io/bbolt"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon.v2"
@@ -196,7 +198,10 @@ func getSessionKey(session *Session) []byte {
 func (db *BoltStore) NewSession(label string, typ Type, expiry time.Time,
 	serverAddr string, devServer bool, perms []bakery.Op,
 	caveats []macaroon.Caveat, featureConfig FeaturesConfig, privacy bool,
-	linkedGroupID *ID, flags PrivacyFlags) (*Session, error) {
+	linkedGroupID *ID, flags PrivacyFlags,
+	account fn.Option[accounts.AccountID]) (*Session, error) {
+
+	ctx := context.TODO()
 
 	var session *Session
 	err := db.Update(func(tx *bbolt.Tx) error {
@@ -213,13 +218,23 @@ func (db *BoltStore) NewSession(label string, typ Type, expiry time.Time,
 		session, err = buildSession(
 			id, localPrivKey, label, typ, db.clock.Now(), expiry,
 			serverAddr, devServer, perms, caveats, featureConfig,
-			privacy, linkedGroupID, flags,
+			privacy, linkedGroupID, flags, account,
 		)
 		if err != nil {
 			return err
 		}
 
 		sessionKey := getSessionKey(session)
+
+		// If an account is being linked, we first need to check that
+		// it exists.
+		account.WhenSome(func(account accounts.AccountID) {
+			session.AccountID = fn.Some(account)
+			_, err = db.accounts.Account(ctx, account)
+		})
+		if err != nil {
+			return err
+		}
 
 		if len(sessionBucket.Get(sessionKey)) != 0 {
 			return fmt.Errorf("session with local public key(%x) "+

--- a/session/store_test.go
+++ b/session/store_test.go
@@ -16,14 +16,10 @@ var testTime = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 func TestBasicSessionStore(t *testing.T) {
 	// Set up a new DB.
 	clock := clock.NewTestClock(testTime)
-	db, err := NewDB(t.TempDir(), "test.db", clock)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = db.Close()
-	})
+	db := NewTestDB(t, clock)
 
 	// Try fetch a session that doesn't exist yet.
-	_, err = db.GetSessionByID(ID{1, 3, 4, 4})
+	_, err := db.GetSessionByID(ID{1, 3, 4, 4})
 	require.ErrorIs(t, err, ErrSessionNotFound)
 
 	// Reserve a session. This should succeed.
@@ -201,11 +197,7 @@ func TestLinkingSessions(t *testing.T) {
 
 	// Set up a new DB.
 	clock := clock.NewTestClock(testTime)
-	db, err := NewDB(t.TempDir(), "test.db", clock)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = db.Close()
-	})
+	db := NewTestDB(t, clock)
 
 	groupID, err := IDFromBytes([]byte{1, 2, 3, 4})
 	require.NoError(t, err)
@@ -242,11 +234,7 @@ func TestLinkedSessions(t *testing.T) {
 
 	// Set up a new DB.
 	clock := clock.NewTestClock(testTime)
-	db, err := NewDB(t.TempDir(), "test.db", clock)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = db.Close()
-	})
+	db := NewTestDB(t, clock)
 
 	// Create a few sessions. The first one is a new session and the two
 	// after are all linked to the prior one. All these sessions belong to
@@ -298,18 +286,14 @@ func TestLinkedSessions(t *testing.T) {
 func TestStateShift(t *testing.T) {
 	// Set up a new DB.
 	clock := clock.NewTestClock(testTime)
-	db, err := NewDB(t.TempDir(), "test.db", clock)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = db.Close()
-	})
+	db := NewTestDB(t, clock)
 
 	// Add a new session to the DB.
 	s1 := createSession(t, db, "label 1")
 
 	// Check that the session is in the StateCreated state. Also check that
 	// the "RevokedAt" time has not yet been set.
-	s1, err = db.GetSession(s1.LocalPublicKey)
+	s1, err := db.GetSession(s1.LocalPublicKey)
 	require.NoError(t, err)
 	require.Equal(t, StateCreated, s1.State)
 	require.Equal(t, time.Time{}, s1.RevokedAt)

--- a/session/store_test.go
+++ b/session/store_test.go
@@ -1,12 +1,19 @@
 package session
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/lightning-terminal/accounts"
 	"github.com/lightningnetwork/lnd/clock"
+	"github.com/lightningnetwork/lnd/fn"
+	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"gopkg.in/macaroon.v2"
 )
 
 var testTime = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -324,9 +331,49 @@ func TestStateShift(t *testing.T) {
 	require.ErrorContains(t, err, "illegal session state transition")
 }
 
+// TestLinkedAccount tests that linking a session to an account works as
+// expected.
+func TestLinkedAccount(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	clock := clock.NewTestClock(testTime)
+
+	accts := accounts.NewTestDB(t, clock)
+	db := NewTestDBWithAccounts(t, clock, accts)
+
+	// Reserve a session. Link it to an account that does not yet exist.
+	// This should fail.
+	acctID := accounts.AccountID{1, 2, 3, 4}
+	_, err := reserveSession(db, "session 1", withAccount(acctID))
+	require.ErrorIs(t, err, accounts.ErrAccNotFound)
+
+	// Now, add a new account
+	acct, err := accts.NewAccount(ctx, 1234, clock.Now().Add(time.Hour), "")
+	require.NoError(t, err)
+
+	// Reserve a session. Link it to the account that was just created.
+	// This should succeed.
+
+	s1, err := reserveSession(db, "session 1", withAccount(acct.ID))
+	require.NoError(t, err)
+	require.True(t, s1.AccountID.IsSome())
+	s1.AccountID.WhenSome(func(id accounts.AccountID) {
+		require.Equal(t, acct.ID, id)
+	})
+
+	// Make sure that a fetched session includes the account ID.
+	s1, err = db.GetSessionByID(s1.ID)
+	require.NoError(t, err)
+	require.True(t, s1.AccountID.IsSome())
+	s1.AccountID.WhenSome(func(id accounts.AccountID) {
+		require.Equal(t, acct.ID, id)
+	})
+}
+
 type testSessionOpts struct {
 	groupID  *ID
 	sessType Type
+	account  fn.Option[accounts.AccountID]
 }
 
 func defaultTestSessOpts() *testSessionOpts {
@@ -352,6 +399,12 @@ func withType(t Type) testSessionModifier {
 	}
 }
 
+func withAccount(alias accounts.AccountID) testSessionModifier {
+	return func(s *testSessionOpts) {
+		s.account = fn.Some(alias)
+	}
+}
+
 func reserveSession(db Store, label string,
 	mods ...testSessionModifier) (*Session, error) {
 
@@ -360,10 +413,25 @@ func reserveSession(db Store, label string,
 		mod(opts)
 	}
 
-	return db.NewSession(label, opts.sessType,
+	var caveats []macaroon.Caveat
+	opts.account.WhenSome(func(id accounts.AccountID) {
+		// For now, we manually add the account caveat for bbolt
+		// compatibility.
+		accountCaveat := checkers.Condition(
+			macaroons.CondLndCustom,
+			fmt.Sprintf("%s %x", accounts.CondAccount, id[:]),
+		)
+
+		caveats = append(caveats, macaroon.Caveat{
+			Id: []byte(accountCaveat),
+		})
+	})
+
+	return db.NewSession(
+		label, opts.sessType,
 		time.Date(99999, 1, 1, 0, 0, 0, 0, time.UTC),
-		"foo.bar.baz:1234", true, nil, nil, nil, true, opts.groupID,
-		[]PrivacyFlag{ClearPubkeys},
+		"foo.bar.baz:1234", true, nil, caveats, nil, true, opts.groupID,
+		[]PrivacyFlag{ClearPubkeys}, opts.account,
 	)
 }
 

--- a/session/test_kvdb.go
+++ b/session/test_kvdb.go
@@ -1,0 +1,28 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/stretchr/testify/require"
+)
+
+// NewTestDB is a helper function that creates an BBolt database for testing.
+func NewTestDB(t *testing.T, clock clock.Clock) *BoltStore {
+	return NewTestDBFromPath(t, t.TempDir(), clock)
+}
+
+// NewTestDBFromPath is a helper function that creates a new BoltStore with a
+// connection to an existing BBolt database for testing.
+func NewTestDBFromPath(t *testing.T, dbPath string,
+	clock clock.Clock) *BoltStore {
+
+	store, err := NewDB(dbPath, DBFilename, clock)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, store.DB.Close())
+	})
+
+	return store
+}

--- a/session/test_kvdb.go
+++ b/session/test_kvdb.go
@@ -3,6 +3,7 @@ package session
 import (
 	"testing"
 
+	"github.com/lightninglabs/lightning-terminal/accounts"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +18,24 @@ func NewTestDB(t *testing.T, clock clock.Clock) *BoltStore {
 func NewTestDBFromPath(t *testing.T, dbPath string,
 	clock clock.Clock) *BoltStore {
 
-	store, err := NewDB(dbPath, DBFilename, clock)
+	acctStore := accounts.NewTestDB(t, clock)
+
+	store, err := NewDB(dbPath, DBFilename, clock, acctStore)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, store.DB.Close())
+	})
+
+	return store
+}
+
+// NewTestDBWithAccounts creates a new test session Store with access to an
+// existing accounts DB.
+func NewTestDBWithAccounts(t *testing.T, clock clock.Clock,
+	acctStore accounts.Store) *BoltStore {
+
+	store, err := NewDB(t.TempDir(), DBFilename, clock, acctStore)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/session/tlv.go
+++ b/session/tlv.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/lightning-terminal/accounts"
 	"github.com/lightningnetwork/lnd/tlv"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon.v2"
@@ -276,6 +277,18 @@ func DeserializeSession(r io.Reader) (*Session, error) {
 		copy(session.GroupID[:], groupID)
 	} else {
 		session.GroupID = session.ID
+	}
+
+	// For any sessions stored in the BBolt store, a coupled account (if
+	// any) is linked implicitly via the macaroon recipe caveat. So we
+	// need to extract it from there.
+	if session.MacaroonRecipe != nil {
+		session.AccountID, err = accounts.IDFromCaveats(
+			session.MacaroonRecipe.Caveats,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return session, nil

--- a/session/tlv_test.go
+++ b/session/tlv_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/lightning-terminal/accounts"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/macaroon-bakery.v2/bakery"
@@ -137,6 +139,7 @@ func TestSerializeDeserializeSession(t *testing.T) {
 				test.caveats, test.featureConfig, true,
 				test.linkedGroupID,
 				[]PrivacyFlag{ClearPubkeys},
+				fn.None[accounts.AccountID](),
 			)
 			require.NoError(t, err)
 
@@ -189,7 +192,7 @@ func TestGroupIDForOlderSessions(t *testing.T) {
 		time.Now(),
 		time.Date(99999, 1, 1, 0, 0, 0, 0, time.UTC),
 		"foo.bar.baz:1234", true, nil, nil, nil, false, nil,
-		PrivacyFlags{},
+		PrivacyFlags{}, fn.None[accounts.AccountID](),
 	)
 	require.NoError(t, err)
 
@@ -225,7 +228,7 @@ func TestGroupID(t *testing.T) {
 		time.Now(),
 		time.Date(99999, 1, 1, 0, 0, 0, 0, time.UTC),
 		"foo.bar.baz:1234", true, nil, nil, nil, false, nil,
-		PrivacyFlags{},
+		PrivacyFlags{}, fn.None[accounts.AccountID](),
 	)
 	require.NoError(t, err)
 
@@ -241,6 +244,7 @@ func TestGroupID(t *testing.T) {
 		time.Date(99999, 1, 1, 0, 0, 0, 0, time.UTC),
 		"foo.bar.baz:1234", true, nil, nil, nil, false,
 		&session1.GroupID, PrivacyFlags{},
+		fn.None[accounts.AccountID](),
 	)
 	require.NoError(t, err)
 

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lightninglabs/lightning-terminal/perms"
 	"github.com/lightninglabs/lightning-terminal/rules"
 	"github.com/lightninglabs/lightning-terminal/session"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"google.golang.org/grpc"
 	"gopkg.in/macaroon-bakery.v2/bakery"
@@ -212,7 +213,10 @@ func (s *sessionRpcServer) AddSession(ctx context.Context,
 		permissions[entity][action] = struct{}{}
 	}
 
-	var caveats []macaroon.Caveat
+	var (
+		caveats   []macaroon.Caveat
+		accountID fn.Option[accounts.AccountID]
+	)
 	switch typ {
 	// For the default session types we use empty caveats and permissions,
 	// the macaroons are baked correctly when creating the session.
@@ -232,6 +236,7 @@ func (s *sessionRpcServer) AddSession(ctx context.Context,
 		caveats = append(caveats, macaroon.Caveat{
 			Id: []byte(cav),
 		})
+		accountID = fn.Some(*id)
 
 	// For the custom macaroon type, we use the custom permissions specified
 	// in the request. For the time being, the caveats list will be empty
@@ -311,7 +316,7 @@ func (s *sessionRpcServer) AddSession(ctx context.Context,
 	sess, err := s.cfg.db.NewSession(
 		req.Label, typ, expiry, req.MailboxServerAddr,
 		req.DevServer, uniquePermissions, caveats, nil, false, nil,
-		session.PrivacyFlags{},
+		session.PrivacyFlags{}, accountID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating new session: %v", err)
@@ -1124,6 +1129,7 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 		req.Label, session.TypeAutopilot, expiry,
 		req.MailboxServerAddr, req.DevServer, perms, caveats,
 		clientConfig, privacy, linkedGroupID, privacyFlags,
+		fn.None[accounts.AccountID](),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating new session: %v", err)

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -2,6 +2,7 @@ package terminal
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1473,6 +1474,11 @@ func (s *sessionRpcServer) marshalRPCSession(sess *session.Session) (
 		}
 	}
 
+	var accountID string
+	sess.AccountID.WhenSome(func(id accounts.AccountID) {
+		accountID = hex.EncodeToString(id[:])
+	})
+
 	return &litrpc.Session{
 		Id:                     sess.ID[:],
 		Label:                  sess.Label,
@@ -1492,6 +1498,7 @@ func (s *sessionRpcServer) marshalRPCSession(sess *session.Session) (
 		GroupId:                sess.GroupID[:],
 		FeatureConfigs:         clientConfig,
 		PrivacyFlags:           sess.PrivacyFlags.Serialize(),
+		AccountId:              accountID,
 	}, nil
 }
 

--- a/terminal.go
+++ b/terminal.go
@@ -449,7 +449,9 @@ func (g *LightningTerminal) start(ctx context.Context) error {
 	g.ruleMgrs = rules.NewRuleManagerSet()
 
 	// Create an instance of the local Terminal Connect session store DB.
-	g.sessionDB, err = session.NewDB(networkDir, session.DBFilename, clock)
+	g.sessionDB, err = session.NewDB(
+		networkDir, session.DBFilename, clock, g.accountsStore,
+	)
 	if err != nil {
 		return fmt.Errorf("error creating session DB: %v", err)
 	}


### PR DESCRIPTION
Depends on https://github.com/lightninglabs/lightning-terminal/pull/988

In this commit, we more tightly & explicitly link a session to an
account. At a persitance layer, we have always only linked a session to
an account by encoding the AccountID within the macaroon caveat that we
store with the session. We still keep this persistence the same but now
we first ensure that the account exists and we also add an AccountID
field to the Session struct.

This is in preparation for adding a SQL implementation of the session Store 
where this link will be done at a relational DB level. 