### PR TITLE
Custom channels itest: Use group keys on some payments & invoices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/lightninglabs/pool v0.6.5-beta.0.20250305125211-4e860ec4e77f
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.3-0.20250305125211-4e860ec4e77f
 	github.com/lightninglabs/pool/poolrpc v1.0.1-0.20250305125211-4e860ec4e77f
-	github.com/lightninglabs/taproot-assets v0.5.2-0.20250401150538-a9ea76a9ed3c
+	github.com/lightninglabs/taproot-assets v0.5.2-0.20250416114205-2da076df4b4e
 	github.com/lightningnetwork/lnd v0.19.0-beta.rc1.0.20250327183348-eb822a5e117f
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1181,8 +1181,8 @@ github.com/lightninglabs/pool/poolrpc v1.0.1-0.20250305125211-4e860ec4e77f h1:5p
 github.com/lightninglabs/pool/poolrpc v1.0.1-0.20250305125211-4e860ec4e77f/go.mod h1:lGs2hSVZ+GFpdv3btaIl9icG5/gz7BBRfvmD2iqqNl0=
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display h1:w7FM5LH9Z6CpKxl13mS48idsu6F+cEZf0lkyiV+Dq9g=
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
-github.com/lightninglabs/taproot-assets v0.5.2-0.20250401150538-a9ea76a9ed3c h1:Rebx5DVZx3u327vKRrueFjZNlei1RzdGzFmOZmenkiQ=
-github.com/lightninglabs/taproot-assets v0.5.2-0.20250401150538-a9ea76a9ed3c/go.mod h1:e3SjXbbi4xKhOzq54c672Z/j9UTRq5DLJGx/URgVTJo=
+github.com/lightninglabs/taproot-assets v0.5.2-0.20250416114205-2da076df4b4e h1:37sk9Wmkh9QFjnqR8eHIhCi8x0uIQL0F2fpcQI25I9g=
+github.com/lightninglabs/taproot-assets v0.5.2-0.20250416114205-2da076df4b4e/go.mod h1:e3SjXbbi4xKhOzq54c672Z/j9UTRq5DLJGx/URgVTJo=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb h1:yfM05S8DXKhuCBp5qSMZdtSwvJ+GFzl94KbXMNB1JDY=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
 github.com/lightningnetwork/lnd v0.19.0-beta.rc1.0.20250327183348-eb822a5e117f h1:+Bejv2Ij/ryUjLacBd5au0acMH0AYs0lhb7ki5rx9ms=

--- a/itest/litd_test_list_on_test.go
+++ b/itest/litd_test_list_on_test.go
@@ -49,6 +49,10 @@ var allTestCases = []*testCase{
 		test: testCustomChannelsLiquidityEdgeCases,
 	},
 	{
+		name: "test custom channels liquidity group",
+		test: testCustomChannelsLiquidityEdgeCasesGroup,
+	},
+	{
 		name: "test custom channels htlc force close",
 		test: testCustomChannelsHtlcForceClose,
 	},


### PR DESCRIPTION
## Description

We sprinkle around some group keys across the grouped asset custom channels test. Some of the invoices and payments in that test now use a group key instead of a specific asset ID.

Related tapd PR: https://github.com/lightninglabs/taproot-assets/pull/1423/commits

For the liquidity edge cases itest, we now support running it in assetID & groupKey mode, meaning we can go through the full suite of edge cases by using either a single assetID or a groupKey.