### PR TITLE
[sql-23] db/sqlc: only use named UNIQUE indices

### DIFF
--- a/db/sqlc/migrations/000001_accounts.down.sql
+++ b/db/sqlc/migrations/000001_accounts.down.sql
@@ -1,3 +1,5 @@
+DROP INDEX IF EXISTS account_invoices_unique;
+DROP INDEX IF EXISTS account_payments_unique;
 DROP TABLE IF EXISTS account_payments;
 DROP TABLE IF EXISTS account_invoices;
 DROP TABLE IF EXISTS account_indices;

--- a/db/sqlc/migrations/000001_accounts.up.sql
+++ b/db/sqlc/migrations/000001_accounts.up.sql
@@ -42,9 +42,11 @@ CREATE TABLE IF NOT EXISTS account_payments (
 
     -- The total amount of the payment in millisatoshis.
     -- This includes the payment amount and estimated routing fee.
-    full_amount_msat BIGINT NOT NULL,
+    full_amount_msat BIGINT NOT NULL
+);
 
-    UNIQUE(account_id, hash)
+CREATE UNIQUE INDEX account_payments_unique ON account_payments (
+    account_id, hash
 );
 
 -- The account_invoices table stores all the invoice payment hashes that
@@ -55,9 +57,11 @@ CREATE TABLE IF NOT EXISTS account_invoices (
     account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
 
     -- The payment hash of the invoice.
-    hash BLOB NOT NULL,
+    hash BLOB NOT NULL
+);
 
-    UNIQUE(account_id, hash)
+CREATE UNIQUE INDEX account_invoices_unique ON account_invoices (
+    account_id, hash
 );
 
 -- The account_indices table stores any string-to-integer mappings that are


### PR DESCRIPTION
Replace any named UNIQUE indices in the accounts tables and replace with named ones. This is for a future where we want to be able to edit these indices without having to drop the table.
It is fine for us to just edit these tables since these are not available in "prod" yet.