### PR TITLE
[sql-23] firewalldb: thread contexts through for kv-store interfaces

### DIFF
--- a/firewalldb/interface.go
+++ b/firewalldb/interface.go
@@ -14,3 +14,24 @@ type SessionDB interface {
 	// GetSession returns the session for a specific id.
 	GetSession(context.Context, session.ID) (*session.Session, error)
 }
+
+// DBExecutor provides an Update and View method that will allow the caller
+// to perform atomic read and write transactions defined by PrivacyMapTx on the
+// underlying BoltDB.
+type DBExecutor[T any] interface {
+	// Update opens a database read/write transaction and executes the
+	// function f with the transaction passed as a parameter. After f exits,
+	// if f did not error, the transaction is committed. Otherwise, if f did
+	// error, the transaction is rolled back. If the rollback fails, the
+	// original error returned by f is still returned. If the commit fails,
+	// the commit error is returned.
+	Update(ctx context.Context, f func(ctx context.Context,
+		tx T) error) error
+
+	// View opens a database read transaction and executes the function f
+	// with the transaction passed as a parameter. After f exits, the
+	// transaction is rolled back. If f errors, its error is returned, not a
+	// rollback error (if any occur).
+	View(ctx context.Context, f func(ctx context.Context,
+		tx T) error) error
+}

--- a/firewalldb/kvstores.go
+++ b/firewalldb/kvstores.go
@@ -54,23 +54,7 @@ var (
 // KVStores provides an Update and View method that will allow the caller to
 // perform atomic read and write transactions on and of the key value stores
 // offered the KVStoreTx.
-type KVStores interface {
-	// Update opens a database read/write transaction and executes the
-	// function f with the transaction passed as a parameter. After f exits,
-	// if f did not error, the transaction is committed. Otherwise, if f did
-	// error, the transaction is rolled back. If the rollback fails, the
-	// original error returned by f is still returned. If the commit fails,
-	// the commit error is returned.
-	Update(ctx context.Context, f func(ctx context.Context,
-		tx KVStoreTx) error) error
-
-	// View opens a database read transaction and executes the function f
-	// with the transaction passed as a parameter. After f exits, the
-	// transaction is rolled back. If f errors, its error is returned, not a
-	// rollback error (if any occur).
-	View(ctx context.Context, f func(ctx context.Context,
-		tx KVStoreTx) error) error
-}
+type KVStores = DBExecutor[KVStoreTx]
 
 // KVStoreTx represents a database transaction that can be used for both read
 // and writes of the various different key value stores offered for the rule.

--- a/rules/mock.go
+++ b/rules/mock.go
@@ -47,12 +47,16 @@ type mockKVStores struct {
 	tx *mockKVStoresTX
 }
 
-func (m *mockKVStores) Update(f func(tx firewalldb.KVStoreTx) error) error {
-	return f(m.tx)
+func (m *mockKVStores) Update(ctx context.Context, f func(ctx context.Context,
+	tx firewalldb.KVStoreTx) error) error {
+
+	return f(ctx, m.tx)
 }
 
-func (m *mockKVStores) View(f func(tx firewalldb.KVStoreTx) error) error {
-	return f(m.tx)
+func (m *mockKVStores) View(ctx context.Context, f func(ctx context.Context,
+	tx firewalldb.KVStoreTx) error) error {
+
+	return f(ctx, m.tx)
 }
 
 var _ firewalldb.KVStores = (*mockKVStores)(nil)

--- a/rules/onchain_budget.go
+++ b/rules/onchain_budget.go
@@ -531,7 +531,9 @@ func (o *OnChainBudgetEnforcer) handleBatchOpenChannelRequest(
 func (o *OnChainBudgetEnforcer) handlePendingPayment(ctx context.Context,
 	request *onChainAction, reqID string) error {
 
-	return o.GetStores().Update(func(tx firewalldb.KVStoreTx) error {
+	return o.GetStores().Update(ctx, func(ctx context.Context,
+		tx firewalldb.KVStoreTx) error {
+
 		// First, we fetch the current state of the budget.
 		spent, pending, err := o.getBudgetState(ctx, tx)
 		if err != nil {
@@ -586,7 +588,9 @@ type onChainAction struct {
 func (o *OnChainBudgetEnforcer) cancelPendingPayment(
 	ctx context.Context) error {
 
-	return o.GetStores().Update(func(tx firewalldb.KVStoreTx) error {
+	return o.GetStores().Update(ctx, func(ctx context.Context,
+		tx firewalldb.KVStoreTx) error {
+
 		// First, we get our current budget state.
 		_, pending, err := o.getBudgetState(ctx, tx)
 		if err != nil {
@@ -643,7 +647,9 @@ func (o *OnChainBudgetEnforcer) cancelPendingPayment(
 func (o *OnChainBudgetEnforcer) handlePaymentConfirmed(
 	ctx context.Context) error {
 
-	return o.GetStores().Update(func(tx firewalldb.KVStoreTx) error {
+	return o.GetStores().Update(ctx, func(ctx context.Context,
+		tx firewalldb.KVStoreTx) error {
+
 		// First, we get our current budget state.
 		complete, pending, err := o.getBudgetState(ctx, tx)
 		if err != nil {


### PR DESCRIPTION
This PR does 1 main things:

1) updates various of the rule db kv-store interfaces to take contexts and then threads contexts through where necessary. 
2) creates a generic `DBExecutor` interface and use init the KVStores interface. Later on we will use it to replace the PrivacyMap interface too.

part of https://github.com/lightninglabs/lightning-terminal/issues/917