### PR TITLE
[sql-24] firewalldb: thread contexts through for privacy mapper interfaces

### DIFF
--- a/firewall/privacy_mapper.go
+++ b/firewall/privacy_mapper.go
@@ -336,8 +336,8 @@ func handleGetInfoResponse(db firewalldb.PrivacyMapDB,
 					tx firewalldb.PrivacyMapTx) error {
 
 					var err error
-					pseudoPubKey, err = firewalldb.HideString(
-						tx, r.IdentityPubkey,
+					pseudoPubKey, err = firewalldb.HideString( //nolint:lll
+						ctx, tx, r.IdentityPubkey,
 					)
 
 					return err
@@ -397,14 +397,14 @@ func handleFwdHistoryResponse(db firewalldb.PrivacyMapDB,
 				if !flags.Contains(session.ClearChanIDs) {
 					// Deterministically hide channel ids.
 					chanIn, err = firewalldb.HideUint64(
-						tx, chanIn,
+						ctx, tx, chanIn,
 					)
 					if err != nil {
 						return err
 					}
 
 					chanOut, err = firewalldb.HideUint64(
-						tx, chanOut,
+						ctx, tx, chanOut,
 					)
 					if err != nil {
 						return err
@@ -500,7 +500,7 @@ func handleFeeReportResponse(db firewalldb.PrivacyMapDB,
 				chanID := c.ChanId
 				if !flags.Contains(session.ClearChanIDs) {
 					chanID, err = firewalldb.HideUint64(
-						tx, chanID,
+						ctx, tx, chanID,
 					)
 					if err != nil {
 						return err
@@ -510,7 +510,7 @@ func handleFeeReportResponse(db firewalldb.PrivacyMapDB,
 				chanPoint := c.ChannelPoint
 				if !flags.Contains(session.ClearChanIDs) {
 					chanPoint, err = firewalldb.HideChanPointStr(
-						tx, chanPoint,
+						ctx, tx, chanPoint,
 					)
 					if err != nil {
 						return err
@@ -599,7 +599,7 @@ func handleListChannelsResponse(db firewalldb.PrivacyMapDB,
 				remotePub := c.RemotePubkey
 				if hidePubkeys {
 					remotePub, err = firewalldb.HideString(
-						tx, c.RemotePubkey,
+						ctx, tx, c.RemotePubkey,
 					)
 					if err != nil {
 						return err
@@ -610,14 +610,14 @@ func handleListChannelsResponse(db firewalldb.PrivacyMapDB,
 				chanID := c.ChanId
 				if hideChanIds {
 					chanPoint, err = firewalldb.HideChanPointStr(
-						tx, c.ChannelPoint,
+						ctx, tx, c.ChannelPoint,
 					)
 					if err != nil {
 						return err
 					}
 
 					chanID, err = firewalldb.HideUint64(
-						tx, c.ChanId,
+						ctx, tx, c.ChanId,
 					)
 					if err != nil {
 						return err
@@ -830,7 +830,7 @@ func handleUpdatePolicyResponse(db firewalldb.PrivacyMapDB,
 				}
 
 				txid, index, err := firewalldb.HideChanPoint(
-					tx, u.Outpoint.TxidStr,
+					ctx, tx, u.Outpoint.TxidStr,
 					u.Outpoint.OutputIndex,
 				)
 				if err != nil {
@@ -957,7 +957,7 @@ func handleClosedChannelsResponse(db firewalldb.PrivacyMapDB,
 				remotePub := c.RemotePubkey
 				if !flags.Contains(session.ClearPubkeys) {
 					remotePub, err = firewalldb.HideString(
-						tx, remotePub,
+						ctx, tx, remotePub,
 					)
 					if err != nil {
 						return err
@@ -985,7 +985,7 @@ func handleClosedChannelsResponse(db firewalldb.PrivacyMapDB,
 				channelPoint := c.ChannelPoint
 				if !flags.Contains(session.ClearChanIDs) {
 					channelPoint, err = firewalldb.HideChanPointStr(
-						tx, c.ChannelPoint,
+						ctx, tx, c.ChannelPoint,
 					)
 					if err != nil {
 						return err
@@ -995,7 +995,7 @@ func handleClosedChannelsResponse(db firewalldb.PrivacyMapDB,
 				chanID := c.ChanId
 				if !flags.Contains(session.ClearChanIDs) {
 					chanID, err = firewalldb.HideUint64(
-						tx, c.ChanId,
+						ctx, tx, c.ChanId,
 					)
 					if err != nil {
 						return err
@@ -1005,7 +1005,7 @@ func handleClosedChannelsResponse(db firewalldb.PrivacyMapDB,
 				closingTxid := c.ClosingTxHash
 				if !flags.Contains(session.ClearClosingTxIds) {
 					closingTxid, err = firewalldb.HideString(
-						tx, c.ClosingTxHash,
+						ctx, tx, c.ClosingTxHash,
 					)
 					if err != nil {
 						return err
@@ -1052,7 +1052,8 @@ func handleClosedChannelsResponse(db firewalldb.PrivacyMapDB,
 
 // obfuscatePendingChannel is a helper to obfuscate the fields of a pending
 // channel.
-func obfuscatePendingChannel(c *lnrpc.PendingChannelsResponse_PendingChannel,
+func obfuscatePendingChannel(ctx context.Context,
+	c *lnrpc.PendingChannelsResponse_PendingChannel,
 	tx firewalldb.PrivacyMapTx, randIntn func(int) (int, error),
 	flags session.PrivacyFlags) (
 	*lnrpc.PendingChannelsResponse_PendingChannel, error) {
@@ -1062,7 +1063,7 @@ func obfuscatePendingChannel(c *lnrpc.PendingChannelsResponse_PendingChannel,
 	remotePub := c.RemoteNodePub
 	if !flags.Contains(session.ClearPubkeys) {
 		remotePub, err = firewalldb.HideString(
-			tx, remotePub,
+			ctx, tx, remotePub,
 		)
 		if err != nil {
 			return nil, err
@@ -1099,7 +1100,7 @@ func obfuscatePendingChannel(c *lnrpc.PendingChannelsResponse_PendingChannel,
 	chanPoint := c.ChannelPoint
 	if !flags.Contains(session.ClearChanIDs) {
 		chanPoint, err = firewalldb.HideChanPointStr(
-			tx, c.ChannelPoint,
+			ctx, tx, c.ChannelPoint,
 		)
 		if err != nil {
 			return nil, err
@@ -1163,7 +1164,7 @@ func handlePendingChannelsResponse(db firewalldb.PrivacyMapDB,
 				var err error
 
 				pendingChannel, err := obfuscatePendingChannel(
-					c.Channel, tx, randIntn, flags,
+					ctx, c.Channel, tx, randIntn, flags,
 				)
 				if err != nil {
 					return err
@@ -1187,7 +1188,7 @@ func handlePendingChannelsResponse(db firewalldb.PrivacyMapDB,
 				var err error
 
 				pendingChannel, err := obfuscatePendingChannel(
-					c.Channel, tx, randIntn, flags,
+					ctx, c.Channel, tx, randIntn, flags,
 				)
 				if err != nil {
 					return err
@@ -1195,8 +1196,8 @@ func handlePendingChannelsResponse(db firewalldb.PrivacyMapDB,
 
 				closingTxid := c.ClosingTxid
 				if !flags.Contains(session.ClearClosingTxIds) {
-					closingTxid, err = firewalldb.HideString(
-						tx, c.ClosingTxid,
+					closingTxid, err = firewalldb.HideString( //nolint:lll
+						ctx, tx, c.ClosingTxid,
 					)
 					if err != nil {
 						return err
@@ -1216,7 +1217,7 @@ func handlePendingChannelsResponse(db firewalldb.PrivacyMapDB,
 				var err error
 
 				pendingChannel, err := obfuscatePendingChannel(
-					c.Channel, tx, randIntn, flags,
+					ctx, c.Channel, tx, randIntn, flags,
 				)
 				if err != nil {
 					return err
@@ -1225,7 +1226,7 @@ func handlePendingChannelsResponse(db firewalldb.PrivacyMapDB,
 				closingTxid := c.ClosingTxid
 				if !flags.Contains(session.ClearClosingTxIds) {
 					closingTxid, err = firewalldb.HideString(
-						tx, c.ClosingTxid,
+						ctx, tx, c.ClosingTxid,
 					)
 					if err != nil {
 						return err
@@ -1277,7 +1278,7 @@ func handlePendingChannelsResponse(db firewalldb.PrivacyMapDB,
 				var err error
 
 				pendingChannel, err := obfuscatePendingChannel(
-					c.Channel, tx, randIntn, flags,
+					ctx, c.Channel, tx, randIntn, flags,
 				)
 				if err != nil {
 					return err
@@ -1297,7 +1298,7 @@ func handlePendingChannelsResponse(db firewalldb.PrivacyMapDB,
 				closingTxid := c.ClosingTxid
 				if !flags.Contains(session.ClearClosingTxIds) {
 					closingTxid, err = firewalldb.HideString(
-						tx, closingTxid,
+						ctx, tx, closingTxid,
 					)
 					if err != nil {
 						return err
@@ -1314,7 +1315,7 @@ func handlePendingChannelsResponse(db firewalldb.PrivacyMapDB,
 					) {
 
 					closingTxHex, err = firewalldb.HideString(
-						tx, closingTxHex,
+						ctx, tx, closingTxHex,
 					)
 					if err != nil {
 						return err
@@ -1454,8 +1455,9 @@ func handleBatchOpenChannelResponse(db firewalldb.PrivacyMapDB,
 						return err
 					}
 
-					txID, outIdx, err := firewalldb.HideChanPoint(
-						tx, txId.String(), p.OutputIndex,
+					txID, outIdx, err := firewalldb.HideChanPoint( //nolint:lll
+						ctx, tx, txId.String(),
+						p.OutputIndex,
 					)
 					if err != nil {
 						return err
@@ -1600,7 +1602,7 @@ func handleChannelOpenResponse(db firewalldb.PrivacyMapDB,
 
 			if !flags.Contains(session.ClearChanIDs) {
 				txid, index, err = firewalldb.HideChanPoint(
-					tx, txid, index,
+					ctx, tx, txid, index,
 				)
 				if err != nil {
 					return err

--- a/firewall/privacy_mapper.go
+++ b/firewall/privacy_mapper.go
@@ -559,7 +559,7 @@ func handleListChannelsRequest(db firewalldb.PrivacyMapDB,
 		err := db.View(ctx, func(ctx context.Context,
 			tx firewalldb.PrivacyMapTx) error {
 
-			peer, err := firewalldb.RevealBytes(tx, r.Peer)
+			peer, err := firewalldb.RevealBytes(ctx, tx, r.Peer)
 			if err != nil {
 				return err
 			}
@@ -778,8 +778,8 @@ func handleUpdatePolicyRequest(db firewalldb.PrivacyMapDB,
 				tx firewalldb.PrivacyMapTx) error {
 
 				var err error
-				newTxid, newIndex, err = firewalldb.RevealChanPoint(
-					tx, newTxid, newIndex,
+				newTxid, newIndex, err = firewalldb.RevealChanPoint( //nolint:lll
+					ctx, tx, newTxid, newIndex,
 				)
 				return err
 			})
@@ -1380,7 +1380,7 @@ func handleBatchOpenChannelRequest(db firewalldb.PrivacyMapDB,
 				nodePubkey := c.NodePubkey
 				if !flags.Contains(session.ClearPubkeys) {
 					nodePubkey, err = firewalldb.RevealBytes(
-						tx, c.NodePubkey,
+						ctx, tx, c.NodePubkey,
 					)
 					if err != nil {
 						return err
@@ -1518,7 +1518,7 @@ func handleChannelOpenRequest(db firewalldb.PrivacyMapDB,
 
 			if !flags.Contains(session.ClearPubkeys) {
 				nodePubkey, err = firewalldb.RevealBytes(
-					tx, nodePubkey,
+					ctx, tx, nodePubkey,
 				)
 				if err != nil {
 					return err
@@ -1665,7 +1665,7 @@ func handleConnectPeerRequest(db firewalldb.PrivacyMapDB,
 			pubkey := r.Addr.Pubkey
 			if !flags.Contains(session.ClearPubkeys) {
 				pubkey, err = firewalldb.RevealString(
-					tx, r.Addr.Pubkey,
+					ctx, tx, r.Addr.Pubkey,
 				)
 				if err != nil {
 					return err
@@ -1675,7 +1675,7 @@ func handleConnectPeerRequest(db firewalldb.PrivacyMapDB,
 			host := r.Addr.Host
 			if !flags.Contains(session.ClearNetworkAddresses) {
 				host, err = firewalldb.RevealString(
-					tx, r.Addr.Host,
+					ctx, tx, r.Addr.Host,
 				)
 				if err != nil {
 					return err

--- a/firewall/privacy_mapper_test.go
+++ b/firewall/privacy_mapper_test.go
@@ -1129,7 +1129,9 @@ func (m *mockPrivacyMapDB) NewPair(_ context.Context, real,
 	return nil
 }
 
-func (m *mockPrivacyMapDB) PseudoToReal(pseudo string) (string, error) {
+func (m *mockPrivacyMapDB) PseudoToReal(_ context.Context, pseudo string) (
+	string, error) {
+
 	r, ok := m.p2r[pseudo]
 	if !ok {
 		return "", firewalldb.ErrNoSuchKeyFound

--- a/firewall/privacy_mapper_test.go
+++ b/firewall/privacy_mapper_test.go
@@ -1073,7 +1073,9 @@ func newMockDB(t *testing.T, preloadRealToPseudo map[string]string,
 	db := mockDB{privDB: make(map[string]*mockPrivacyMapDB)}
 	sessDB := db.NewSessionDB(sessID)
 
-	_ = sessDB.Update(func(tx firewalldb.PrivacyMapTx) error {
+	_ = sessDB.Update(context.Background(), func(ctx context.Context,
+		tx firewalldb.PrivacyMapTx) error {
+
 		for r, p := range preloadRealToPseudo {
 			require.NoError(t, tx.NewPair(r, p))
 		}
@@ -1107,16 +1109,16 @@ type mockPrivacyMapDB struct {
 	p2r map[string]string
 }
 
-func (m *mockPrivacyMapDB) Update(
-	f func(tx firewalldb.PrivacyMapTx) error) error {
+func (m *mockPrivacyMapDB) Update(ctx context.Context,
+	f func(ctx context.Context, tx firewalldb.PrivacyMapTx) error) error {
 
-	return f(m)
+	return f(ctx, m)
 }
 
-func (m *mockPrivacyMapDB) View(
-	f func(tx firewalldb.PrivacyMapTx) error) error {
+func (m *mockPrivacyMapDB) View(ctx context.Context,
+	f func(ctx context.Context, tx firewalldb.PrivacyMapTx) error) error {
 
-	return f(m)
+	return f(ctx, m)
 }
 
 func (m *mockPrivacyMapDB) NewPair(real, pseudo string) error {

--- a/firewall/privacy_mapper_test.go
+++ b/firewall/privacy_mapper_test.go
@@ -1077,7 +1077,7 @@ func newMockDB(t *testing.T, preloadRealToPseudo map[string]string,
 		tx firewalldb.PrivacyMapTx) error {
 
 		for r, p := range preloadRealToPseudo {
-			require.NoError(t, tx.NewPair(r, p))
+			require.NoError(t, tx.NewPair(ctx, r, p))
 		}
 		return nil
 	})
@@ -1121,7 +1121,9 @@ func (m *mockPrivacyMapDB) View(ctx context.Context,
 	return f(ctx, m)
 }
 
-func (m *mockPrivacyMapDB) NewPair(real, pseudo string) error {
+func (m *mockPrivacyMapDB) NewPair(_ context.Context, real,
+	pseudo string) error {
+
 	m.r2p[real] = pseudo
 	m.p2r[pseudo] = real
 	return nil

--- a/firewall/privacy_mapper_test.go
+++ b/firewall/privacy_mapper_test.go
@@ -1140,7 +1140,9 @@ func (m *mockPrivacyMapDB) PseudoToReal(_ context.Context, pseudo string) (
 	return r, nil
 }
 
-func (m *mockPrivacyMapDB) RealToPseudo(real string) (string, error) {
+func (m *mockPrivacyMapDB) RealToPseudo(_ context.Context, real string) (string,
+	error) {
+
 	p, ok := m.r2p[real]
 	if !ok {
 		return "", firewalldb.ErrNoSuchKeyFound

--- a/firewall/privacy_mapper_test.go
+++ b/firewall/privacy_mapper_test.go
@@ -1151,8 +1151,8 @@ func (m *mockPrivacyMapDB) RealToPseudo(_ context.Context, real string) (string,
 	return p, nil
 }
 
-func (m *mockPrivacyMapDB) FetchAllPairs() (*firewalldb.PrivacyMapPairs,
-	error) {
+func (m *mockPrivacyMapDB) FetchAllPairs(_ context.Context) (
+	*firewalldb.PrivacyMapPairs, error) {
 
 	return firewalldb.NewPrivacyMapPairs(m.r2p), nil
 }

--- a/firewall/rule_enforcer.go
+++ b/firewall/rule_enforcer.go
@@ -395,7 +395,7 @@ func (r *RuleEnforcer) initRule(ctx context.Context, reqID uint64, name string,
 		privMap := r.newPrivMap(session.GroupID)
 
 		ruleValues, err = ruleValues.PseudoToReal(
-			privMap, session.PrivacyFlags,
+			ctx, privMap, session.PrivacyFlags,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("could not prepare rule "+

--- a/firewalldb/kvdb_store.go
+++ b/firewalldb/kvdb_store.go
@@ -1,0 +1,44 @@
+package firewalldb
+
+import (
+	"context"
+
+	"go.etcd.io/bbolt"
+)
+
+// kvdbExecutor is a concrete implementation of the DBExecutor interface that
+// uses a bbolt database as its backing store.
+type kvdbExecutor[T any] struct {
+	db     *bbolt.DB
+	wrapTx func(tx *bbolt.Tx) T
+}
+
+// Update opens a database read/write transaction and executes the function f
+// with the transaction passed as a parameter. After f exits, if f did not
+// error, the transaction is committed. Otherwise, if f did error, the
+// transaction is rolled back. If the rollback fails, the original error
+// returned by f is still returned. If the commit fails, the commit error is
+// returned.
+//
+// NOTE: this is part of the DBExecutor interface.
+func (e *kvdbExecutor[T]) Update(ctx context.Context,
+	fn func(ctx context.Context, tx T) error) error {
+
+	return e.db.Update(func(tx *bbolt.Tx) error {
+		return fn(ctx, e.wrapTx(tx))
+	})
+}
+
+// View opens a database read transaction and executes the function f with the
+// transaction passed as a parameter. After f exits, the transaction is rolled
+// back. If f errors, its error is returned, not a rollback error (if any
+// occur).
+//
+// NOTE: this is part of the DBExecutor interface.
+func (e *kvdbExecutor[T]) View(ctx context.Context,
+	fn func(ctx context.Context, tx T) error) error {
+
+	return e.db.View(func(tx *bbolt.Tx) error {
+		return fn(ctx, e.wrapTx(tx))
+	})
+}

--- a/firewalldb/privacy_mapper.go
+++ b/firewalldb/privacy_mapper.go
@@ -79,7 +79,7 @@ type PrivacyMapTx interface {
 
 	// RealToPseudo returns the pseudo value associated with the given real
 	// value. If no such pair is found, then ErrNoSuchKeyFound is returned.
-	RealToPseudo(real string) (string, error)
+	RealToPseudo(ctx context.Context, real string) (string, error)
 
 	// FetchAllPairs loads and returns the real-to-pseudo pairs in the form
 	// of a PrivacyMapPairs struct.
@@ -258,7 +258,9 @@ func (p *privacyMapTx) PseudoToReal(_ context.Context, pseudo string) (string,
 // it does then the pseudo value is returned, else an error is returned.
 //
 // NOTE: this is part of the PrivacyMapTx interface.
-func (p *privacyMapTx) RealToPseudo(real string) (string, error) {
+func (p *privacyMapTx) RealToPseudo(_ context.Context, real string) (string,
+	error) {
+
 	privacyBucket, err := getBucket(p.boltTx, privacyBucketKey)
 	if err != nil {
 		return "", err
@@ -319,7 +321,7 @@ func (p *privacyMapTx) FetchAllPairs() (*PrivacyMapPairs, error) {
 func HideString(ctx context.Context, tx PrivacyMapTx, real string) (string,
 	error) {
 
-	pseudo, err := tx.RealToPseudo(real)
+	pseudo, err := tx.RealToPseudo(ctx, real)
 	if err != nil && err != ErrNoSuchKeyFound {
 		return "", err
 	}
@@ -370,7 +372,7 @@ func HideUint64(ctx context.Context, tx PrivacyMapTx, real uint64) (uint64,
 	error) {
 
 	str := Uint64ToStr(real)
-	pseudo, err := tx.RealToPseudo(str)
+	pseudo, err := tx.RealToPseudo(ctx, str)
 	if err != nil && err != ErrNoSuchKeyFound {
 		return 0, err
 	}
@@ -405,7 +407,7 @@ func HideChanPoint(ctx context.Context, tx PrivacyMapTx, txid string,
 	index uint32) (string, uint32, error) {
 
 	cp := fmt.Sprintf("%s:%d", txid, index)
-	pseudo, err := tx.RealToPseudo(cp)
+	pseudo, err := tx.RealToPseudo(ctx, cp)
 	if err != nil && err != ErrNoSuchKeyFound {
 		return "", 0, err
 	}

--- a/firewalldb/privacy_mapper.go
+++ b/firewalldb/privacy_mapper.go
@@ -83,7 +83,7 @@ type PrivacyMapTx interface {
 
 	// FetchAllPairs loads and returns the real-to-pseudo pairs in the form
 	// of a PrivacyMapPairs struct.
-	FetchAllPairs() (*PrivacyMapPairs, error)
+	FetchAllPairs(ctx context.Context) (*PrivacyMapPairs, error)
 }
 
 // privacyMapDB is an implementation of PrivacyMapDB.
@@ -287,7 +287,9 @@ func (p *privacyMapTx) RealToPseudo(_ context.Context, real string) (string,
 // FetchAllPairs loads and returns the real-to-pseudo pairs.
 //
 // NOTE: this is part of the PrivacyMapTx interface.
-func (p *privacyMapTx) FetchAllPairs() (*PrivacyMapPairs, error) {
+func (p *privacyMapTx) FetchAllPairs(_ context.Context) (*PrivacyMapPairs,
+	error) {
+
 	privacyBucket, err := getBucket(p.boltTx, privacyBucketKey)
 	if err != nil {
 		return nil, err

--- a/firewalldb/privacy_mapper_test.go
+++ b/firewalldb/privacy_mapper_test.go
@@ -29,7 +29,7 @@ func TestPrivacyMapStorage(t *testing.T) {
 		_, err = tx.PseudoToReal("pseudo")
 		require.ErrorIs(t, err, ErrNoSuchKeyFound)
 
-		err = tx.NewPair("real", "pseudo")
+		err = tx.NewPair(ctx, "real", "pseudo")
 		require.NoError(t, err)
 
 		pseudo, err := tx.RealToPseudo("real")
@@ -59,7 +59,7 @@ func TestPrivacyMapStorage(t *testing.T) {
 		_, err = tx.PseudoToReal("pseudo")
 		require.ErrorIs(t, err, ErrNoSuchKeyFound)
 
-		err = tx.NewPair("real 2", "pseudo 2")
+		err = tx.NewPair(ctx, "real 2", "pseudo 2")
 		require.NoError(t, err)
 
 		pseudo, err := tx.RealToPseudo("real 2")
@@ -90,29 +90,29 @@ func TestPrivacyMapStorage(t *testing.T) {
 		require.Empty(t, m.pairs)
 
 		// Add a new pair.
-		err = tx.NewPair("real 1", "pseudo 1")
+		err = tx.NewPair(ctx, "real 1", "pseudo 1")
 		require.NoError(t, err)
 
 		// Try to add a new pair that has the same real value as the
 		// first pair. This should fail.
-		err = tx.NewPair("real 1", "pseudo 2")
+		err = tx.NewPair(ctx, "real 1", "pseudo 2")
 		require.ErrorContains(t, err, "an entry already exists for "+
 			"real value")
 
 		// Try to add a new pair that has the same pseudo value as the
 		// first pair. This should fail.
-		err = tx.NewPair("real 2", "pseudo 1")
+		err = tx.NewPair(ctx, "real 2", "pseudo 1")
 		require.ErrorContains(t, err, "an entry already exists for "+
 			"pseudo value")
 
 		// Add a few more pairs.
-		err = tx.NewPair("real 2", "pseudo 2")
+		err = tx.NewPair(ctx, "real 2", "pseudo 2")
 		require.NoError(t, err)
 
-		err = tx.NewPair("real 3", "pseudo 3")
+		err = tx.NewPair(ctx, "real 3", "pseudo 3")
 		require.NoError(t, err)
 
-		err = tx.NewPair("real 4", "pseudo 4")
+		err = tx.NewPair(ctx, "real 4", "pseudo 4")
 		require.NoError(t, err)
 
 		// Check that FetchAllPairs correctly returns all the pairs.
@@ -201,7 +201,7 @@ func TestPrivacyMapTxs(t *testing.T) {
 	err = pdb1.Update(ctx, func(ctx context.Context,
 		tx PrivacyMapTx) error {
 
-		err := tx.NewPair("real", "pseudo")
+		err := tx.NewPair(ctx, "real", "pseudo")
 		if err != nil {
 			return err
 		}

--- a/firewalldb/privacy_mapper_test.go
+++ b/firewalldb/privacy_mapper_test.go
@@ -40,7 +40,7 @@ func TestPrivacyMapStorage(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "real", real)
 
-		pairs, err := tx.FetchAllPairs()
+		pairs, err := tx.FetchAllPairs(ctx)
 		require.NoError(t, err)
 
 		require.EqualValues(t, pairs.pairs, map[string]string{
@@ -70,7 +70,7 @@ func TestPrivacyMapStorage(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "real 2", real)
 
-		pairs, err := tx.FetchAllPairs()
+		pairs, err := tx.FetchAllPairs(ctx)
 		require.NoError(t, err)
 
 		require.EqualValues(t, pairs.pairs, map[string]string{
@@ -85,7 +85,7 @@ func TestPrivacyMapStorage(t *testing.T) {
 	_ = pdb3.Update(ctx, func(ctx context.Context, tx PrivacyMapTx) error {
 		// Check that calling FetchAllPairs returns an empty map if
 		// nothing exists in the DB yet.
-		m, err := tx.FetchAllPairs()
+		m, err := tx.FetchAllPairs(ctx)
 		require.NoError(t, err)
 		require.Empty(t, m.pairs)
 
@@ -116,7 +116,7 @@ func TestPrivacyMapStorage(t *testing.T) {
 		require.NoError(t, err)
 
 		// Check that FetchAllPairs correctly returns all the pairs.
-		pairs, err := tx.FetchAllPairs()
+		pairs, err := tx.FetchAllPairs(ctx)
 		require.NoError(t, err)
 
 		require.EqualValues(t, pairs.pairs, map[string]string{

--- a/firewalldb/privacy_mapper_test.go
+++ b/firewalldb/privacy_mapper_test.go
@@ -23,7 +23,7 @@ func TestPrivacyMapStorage(t *testing.T) {
 	pdb1 := db.PrivacyDB([4]byte{1, 1, 1, 1})
 
 	_ = pdb1.Update(ctx, func(ctx context.Context, tx PrivacyMapTx) error {
-		_, err = tx.RealToPseudo("real")
+		_, err = tx.RealToPseudo(ctx, "real")
 		require.ErrorIs(t, err, ErrNoSuchKeyFound)
 
 		_, err = tx.PseudoToReal(ctx, "pseudo")
@@ -32,7 +32,7 @@ func TestPrivacyMapStorage(t *testing.T) {
 		err = tx.NewPair(ctx, "real", "pseudo")
 		require.NoError(t, err)
 
-		pseudo, err := tx.RealToPseudo("real")
+		pseudo, err := tx.RealToPseudo(ctx, "real")
 		require.NoError(t, err)
 		require.Equal(t, "pseudo", pseudo)
 
@@ -53,7 +53,7 @@ func TestPrivacyMapStorage(t *testing.T) {
 	pdb2 := db.PrivacyDB([4]byte{2, 2, 2, 2})
 
 	_ = pdb2.Update(ctx, func(ctx context.Context, tx PrivacyMapTx) error {
-		_, err = tx.RealToPseudo("real")
+		_, err = tx.RealToPseudo(ctx, "real")
 		require.ErrorIs(t, err, ErrNoSuchKeyFound)
 
 		_, err = tx.PseudoToReal(ctx, "pseudo")
@@ -62,7 +62,7 @@ func TestPrivacyMapStorage(t *testing.T) {
 		err = tx.NewPair(ctx, "real 2", "pseudo 2")
 		require.NoError(t, err)
 
-		pseudo, err := tx.RealToPseudo("real 2")
+		pseudo, err := tx.RealToPseudo(ctx, "real 2")
 		require.NoError(t, err)
 		require.Equal(t, "pseudo 2", pseudo)
 
@@ -206,7 +206,7 @@ func TestPrivacyMapTxs(t *testing.T) {
 			return err
 		}
 
-		p, err := tx.RealToPseudo("real")
+		p, err := tx.RealToPseudo(ctx, "real")
 		if err != nil {
 			return err
 		}
@@ -218,7 +218,7 @@ func TestPrivacyMapTxs(t *testing.T) {
 	require.Error(t, err)
 
 	err = pdb1.View(ctx, func(ctx context.Context, tx PrivacyMapTx) error {
-		_, err := tx.RealToPseudo("real")
+		_, err := tx.RealToPseudo(ctx, "real")
 		return err
 	})
 	require.ErrorIs(t, err, ErrNoSuchKeyFound)

--- a/firewalldb/privacy_mapper_test.go
+++ b/firewalldb/privacy_mapper_test.go
@@ -26,7 +26,7 @@ func TestPrivacyMapStorage(t *testing.T) {
 		_, err = tx.RealToPseudo("real")
 		require.ErrorIs(t, err, ErrNoSuchKeyFound)
 
-		_, err = tx.PseudoToReal("pseudo")
+		_, err = tx.PseudoToReal(ctx, "pseudo")
 		require.ErrorIs(t, err, ErrNoSuchKeyFound)
 
 		err = tx.NewPair(ctx, "real", "pseudo")
@@ -36,7 +36,7 @@ func TestPrivacyMapStorage(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "pseudo", pseudo)
 
-		real, err := tx.PseudoToReal("pseudo")
+		real, err := tx.PseudoToReal(ctx, "pseudo")
 		require.NoError(t, err)
 		require.Equal(t, "real", real)
 
@@ -56,7 +56,7 @@ func TestPrivacyMapStorage(t *testing.T) {
 		_, err = tx.RealToPseudo("real")
 		require.ErrorIs(t, err, ErrNoSuchKeyFound)
 
-		_, err = tx.PseudoToReal("pseudo")
+		_, err = tx.PseudoToReal(ctx, "pseudo")
 		require.ErrorIs(t, err, ErrNoSuchKeyFound)
 
 		err = tx.NewPair(ctx, "real 2", "pseudo 2")
@@ -66,7 +66,7 @@ func TestPrivacyMapStorage(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "pseudo 2", pseudo)
 
-		real, err := tx.PseudoToReal("pseudo 2")
+		real, err := tx.PseudoToReal(ctx, "pseudo 2")
 		require.NoError(t, err)
 		require.Equal(t, "real 2", real)
 

--- a/rules/chan_policy_bounds.go
+++ b/rules/chan_policy_bounds.go
@@ -396,8 +396,8 @@ func (f *ChanPolicyBounds) RuleName() string {
 // find the real values. This is a no-op for the ChanPolicyBounds rule.
 //
 // NOTE: this is part of the Values interface.
-func (f *ChanPolicyBounds) PseudoToReal(_ firewalldb.PrivacyMapDB,
-	_ session.PrivacyFlags) (Values, error) {
+func (f *ChanPolicyBounds) PseudoToReal(_ context.Context,
+	_ firewalldb.PrivacyMapDB, _ session.PrivacyFlags) (Values, error) {
 
 	return f, nil
 }
@@ -407,8 +407,9 @@ func (f *ChanPolicyBounds) PseudoToReal(_ firewalldb.PrivacyMapDB,
 // that should be persisted. This is a no-op for the ChanPolicyBounds rule.
 //
 // NOTE: this is part of the Values interface.
-func (f *ChanPolicyBounds) RealToPseudo(_ firewalldb.PrivacyMapReader,
-	_ session.PrivacyFlags) (Values, map[string]string, error) {
+func (f *ChanPolicyBounds) RealToPseudo(_ context.Context,
+	_ firewalldb.PrivacyMapReader, _ session.PrivacyFlags) (Values,
+	map[string]string, error) {
 
 	return f, nil, nil
 }

--- a/rules/channel_constraints.go
+++ b/rules/channel_constraints.go
@@ -333,8 +333,8 @@ func (v *ChannelConstraint) RuleName() string {
 // find the real values. This is a no-op for the ChannelConstraint rule.
 //
 // NOTE: this is part of the Values interface.
-func (v *ChannelConstraint) PseudoToReal(_ firewalldb.PrivacyMapDB,
-	_ session.PrivacyFlags) (Values, error) {
+func (v *ChannelConstraint) PseudoToReal(_ context.Context,
+	_ firewalldb.PrivacyMapDB, _ session.PrivacyFlags) (Values, error) {
 
 	return v, nil
 }
@@ -344,8 +344,9 @@ func (v *ChannelConstraint) PseudoToReal(_ firewalldb.PrivacyMapDB,
 // that should be persisted. This is a no-op for the ChannelConstraint rule.
 //
 // NOTE: this is part of the Values interface.
-func (v *ChannelConstraint) RealToPseudo(_ firewalldb.PrivacyMapReader,
-	_ session.PrivacyFlags) (Values, map[string]string, error) {
+func (v *ChannelConstraint) RealToPseudo(_ context.Context,
+	_ firewalldb.PrivacyMapReader, _ session.PrivacyFlags) (Values,
+	map[string]string, error) {
 
 	return v, nil, nil
 }

--- a/rules/channel_restrictions.go
+++ b/rules/channel_restrictions.go
@@ -336,8 +336,9 @@ func (c *ChannelRestrict) ToProto() *litrpc.RuleValue {
 // It constructs a new ChannelRestrict instance with these real channel IDs.
 //
 // NOTE: this is part of the Values interface.
-func (c *ChannelRestrict) PseudoToReal(db firewalldb.PrivacyMapDB,
-	flags session.PrivacyFlags) (Values, error) {
+func (c *ChannelRestrict) PseudoToReal(ctx context.Context,
+	db firewalldb.PrivacyMapDB, flags session.PrivacyFlags) (Values,
+	error) {
 
 	restrictList := make([]uint64, len(c.DenyList))
 
@@ -348,7 +349,9 @@ func (c *ChannelRestrict) PseudoToReal(db firewalldb.PrivacyMapDB,
 		return &ChannelRestrict{DenyList: restrictList}, nil
 	}
 
-	err := db.View(func(tx firewalldb.PrivacyMapTx) error {
+	err := db.View(ctx, func(ctx context.Context,
+		tx firewalldb.PrivacyMapTx) error {
+
 		for i, chanID := range c.DenyList {
 			real, err := firewalldb.RevealUint64(tx, chanID)
 			if err != nil {
@@ -372,7 +375,8 @@ func (c *ChannelRestrict) PseudoToReal(db firewalldb.PrivacyMapDB,
 // not find in the given PrivacyMapReader.
 //
 // NOTE: this is part of the Values interface.
-func (c *ChannelRestrict) RealToPseudo(db firewalldb.PrivacyMapReader,
+func (c *ChannelRestrict) RealToPseudo(_ context.Context,
+	db firewalldb.PrivacyMapReader,
 	flags session.PrivacyFlags) (Values, map[string]string, error) {
 
 	pseudoIDs := make([]uint64, len(c.DenyList))

--- a/rules/channel_restrictions.go
+++ b/rules/channel_restrictions.go
@@ -353,7 +353,7 @@ func (c *ChannelRestrict) PseudoToReal(ctx context.Context,
 		tx firewalldb.PrivacyMapTx) error {
 
 		for i, chanID := range c.DenyList {
-			real, err := firewalldb.RevealUint64(tx, chanID)
+			real, err := firewalldb.RevealUint64(ctx, tx, chanID)
 			if err != nil {
 				return err
 			}

--- a/rules/channel_restrictions_test.go
+++ b/rules/channel_restrictions_test.go
@@ -167,6 +167,9 @@ func (m *mockLndClient) ListChannels(_ context.Context, _, _ bool) (
 // method correctly determines which real strings to generate pseudo pairs for
 // based on the privacy map db passed to it.
 func TestChannelRestrictRealToPseudo(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
 	chanID1 := firewalldb.Uint64ToStr(1)
 	chanID2 := firewalldb.Uint64ToStr(2)
 	chanID3 := firewalldb.Uint64ToStr(3)
@@ -249,7 +252,7 @@ func TestChannelRestrictRealToPseudo(t *testing.T) {
 			// form along with any new privacy map pairs that should
 			// be added to the DB.
 			v, newPairs, err := cr.RealToPseudo(
-				privMapPairDB, test.privacyFlags,
+				ctx, privMapPairDB, test.privacyFlags,
 			)
 			require.NoError(t, err)
 			require.Len(t, newPairs, len(test.expectNewPairs))

--- a/rules/history_limit.go
+++ b/rules/history_limit.go
@@ -256,8 +256,8 @@ func (h *HistoryLimit) GetStartDate() time.Time {
 // find the real values. This is a no-op for the HistoryLimit rule.
 //
 // NOTE: this is part of the Values interface.
-func (h *HistoryLimit) PseudoToReal(_ firewalldb.PrivacyMapDB,
-	_ session.PrivacyFlags) (Values, error) {
+func (h *HistoryLimit) PseudoToReal(_ context.Context,
+	_ firewalldb.PrivacyMapDB, _ session.PrivacyFlags) (Values, error) {
 
 	return h, nil
 }
@@ -267,8 +267,9 @@ func (h *HistoryLimit) PseudoToReal(_ firewalldb.PrivacyMapDB,
 // that should be persisted. This is a no-op for the HistoryLimit rule.
 //
 // NOTE: this is part of the Values interface.
-func (h *HistoryLimit) RealToPseudo(_ firewalldb.PrivacyMapReader,
-	_ session.PrivacyFlags) (Values, map[string]string, error) {
+func (h *HistoryLimit) RealToPseudo(_ context.Context,
+	_ firewalldb.PrivacyMapReader, _ session.PrivacyFlags) (Values,
+	map[string]string, error) {
 
 	return h, nil, nil
 }

--- a/rules/interfaces.go
+++ b/rules/interfaces.go
@@ -64,13 +64,13 @@ type Values interface {
 	// keys, channel IDs, channel points etc. It returns a map of any new
 	// real to pseudo strings that should be persisted that it did not find
 	// in the given PrivacyMapReader.
-	RealToPseudo(db firewalldb.PrivacyMapReader,
+	RealToPseudo(ctx context.Context, db firewalldb.PrivacyMapReader,
 		flags session.PrivacyFlags) (Values, map[string]string, error)
 
 	// PseudoToReal attempts to convert any appropriate pseudo fields in
 	// the rule Values to their corresponding real values. It uses the
 	// passed PrivacyMapDB to find the real values.
-	PseudoToReal(db firewalldb.PrivacyMapDB,
+	PseudoToReal(ctx context.Context, db firewalldb.PrivacyMapDB,
 		flags session.PrivacyFlags) (Values, error)
 }
 

--- a/rules/onchain_budget.go
+++ b/rules/onchain_budget.go
@@ -363,8 +363,8 @@ func (o *OnChainBudget) ToProto() *litrpc.RuleValue {
 // find the real values. This is a no-op for the OnChainBudget rule.
 //
 // NOTE: this is part of the Values interface.
-func (o *OnChainBudget) PseudoToReal(_ firewalldb.PrivacyMapDB,
-	_ session.PrivacyFlags) (Values, error) {
+func (o *OnChainBudget) PseudoToReal(_ context.Context,
+	_ firewalldb.PrivacyMapDB, _ session.PrivacyFlags) (Values, error) {
 
 	return o, nil
 }
@@ -374,8 +374,9 @@ func (o *OnChainBudget) PseudoToReal(_ firewalldb.PrivacyMapDB,
 // that should be persisted. This is a no-op for the OnChainBudget rule.
 //
 // NOTE: this is part of the Values interface.
-func (o *OnChainBudget) RealToPseudo(db firewalldb.PrivacyMapReader,
-	flags session.PrivacyFlags) (Values, map[string]string, error) {
+func (o *OnChainBudget) RealToPseudo(_ context.Context,
+	_ firewalldb.PrivacyMapReader, _ session.PrivacyFlags) (Values,
+	map[string]string, error) {
 
 	return o, nil, nil
 }

--- a/rules/peer_restrictions.go
+++ b/rules/peer_restrictions.go
@@ -394,11 +394,13 @@ func (c *PeerRestrict) PseudoToReal(ctx context.Context,
 		return &PeerRestrict{DenyList: restrictList}, nil
 	}
 
-	err := db.View(ctx, func(_ context.Context,
+	err := db.View(ctx, func(ctx context.Context,
 		tx firewalldb.PrivacyMapTx) error {
 
 		for i, peerPubKey := range c.DenyList {
-			real, err := firewalldb.RevealString(tx, peerPubKey)
+			real, err := firewalldb.RevealString(
+				ctx, tx, peerPubKey,
+			)
 			if err != nil {
 				return err
 			}

--- a/rules/peer_restrictions.go
+++ b/rules/peer_restrictions.go
@@ -381,8 +381,9 @@ func (c *PeerRestrict) ToProto() *litrpc.RuleValue {
 // It constructs a new PeerRestrict instance with these real peer IDs.
 //
 // NOTE: this is part of the Values interface.
-func (c *PeerRestrict) PseudoToReal(db firewalldb.PrivacyMapDB,
-	flags session.PrivacyFlags) (Values, error) {
+func (c *PeerRestrict) PseudoToReal(ctx context.Context,
+	db firewalldb.PrivacyMapDB, flags session.PrivacyFlags) (Values,
+	error) {
 
 	restrictList := make([]string, len(c.DenyList))
 
@@ -393,7 +394,9 @@ func (c *PeerRestrict) PseudoToReal(db firewalldb.PrivacyMapDB,
 		return &PeerRestrict{DenyList: restrictList}, nil
 	}
 
-	err := db.View(func(tx firewalldb.PrivacyMapTx) error {
+	err := db.View(ctx, func(_ context.Context,
+		tx firewalldb.PrivacyMapTx) error {
+
 		for i, peerPubKey := range c.DenyList {
 			real, err := firewalldb.RevealString(tx, peerPubKey)
 			if err != nil {
@@ -418,7 +421,8 @@ func (c *PeerRestrict) PseudoToReal(db firewalldb.PrivacyMapDB,
 // find in the given PrivacyMapReader.
 //
 // NOTE: this is part of the Values interface.
-func (c *PeerRestrict) RealToPseudo(db firewalldb.PrivacyMapReader,
+func (c *PeerRestrict) RealToPseudo(_ context.Context,
+	db firewalldb.PrivacyMapReader,
 	flags session.PrivacyFlags) (Values, map[string]string, error) {
 
 	pseudoIDs := make([]string, len(c.DenyList))

--- a/rules/peer_restrictions_test.go
+++ b/rules/peer_restrictions_test.go
@@ -204,6 +204,9 @@ func TestPeerRestrictCheckRequest(t *testing.T) {
 // method correctly determines which real strings to generate pseudo pairs for
 // based on the privacy map db passed to it.
 func TestPeerRestrictRealToPseudo(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
 	tests := []struct {
 		name           string
 		privacyFlags   session.PrivacyFlags
@@ -276,7 +279,7 @@ func TestPeerRestrictRealToPseudo(t *testing.T) {
 			// form along with any new privacy map pairs that should
 			// be added to the DB.
 			v, newPairs, err := pr.RealToPseudo(
-				privMapPairDB, test.privacyFlags,
+				ctx, privMapPairDB, test.privacyFlags,
 			)
 			require.NoError(t, err)
 			require.Len(t, newPairs, len(test.expectNewPairs))

--- a/rules/rate_limit.go
+++ b/rules/rate_limit.go
@@ -267,8 +267,8 @@ func (r *RateLimit) ToProto() *litrpc.RuleValue {
 // find the real values. This is a no-op for the RateLimit rule.
 //
 // NOTE: this is part of the Values interface.
-func (r *RateLimit) PseudoToReal(_ firewalldb.PrivacyMapDB,
-	_ session.PrivacyFlags) (Values, error) {
+func (r *RateLimit) PseudoToReal(_ context.Context,
+	_ firewalldb.PrivacyMapDB, _ session.PrivacyFlags) (Values, error) {
 
 	return r, nil
 }
@@ -278,8 +278,9 @@ func (r *RateLimit) PseudoToReal(_ firewalldb.PrivacyMapDB,
 // that should be persisted. This is a no-op for the RateLimit rule.
 //
 // NOTE: this is part of the Values interface.
-func (r *RateLimit) RealToPseudo(_ firewalldb.PrivacyMapReader,
-	flags session.PrivacyFlags) (Values, map[string]string, error) {
+func (r *RateLimit) RealToPseudo(_ context.Context,
+	_ firewalldb.PrivacyMapReader, flags session.PrivacyFlags) (Values,
+	map[string]string, error) {
 
 	return r, nil, nil
 }

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -901,10 +901,10 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 		linkedGroupSession = groupSess
 
 		privDB := s.cfg.privMap(groupID)
-		err = privDB.View(ctx, func(_ context.Context,
+		err = privDB.View(ctx, func(ctx context.Context,
 			tx firewalldb.PrivacyMapTx) error {
 
-			knownPrivMapPairs, err = tx.FetchAllPairs()
+			knownPrivMapPairs, err = tx.FetchAllPairs(ctx)
 
 			return err
 		})

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -634,7 +634,7 @@ func (s *sessionRpcServer) PrivacyMapConversion(ctx context.Context,
 
 		var err error
 		if req.RealToPseudo {
-			res, err = tx.RealToPseudo(req.Input)
+			res, err = tx.RealToPseudo(ctx, req.Input)
 			return err
 		}
 

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -1226,11 +1226,11 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 
 	// Register all the privacy map pairs for this session ID.
 	privDB := s.cfg.privMap(sess.GroupID)
-	err = privDB.Update(ctx, func(_ context.Context,
+	err = privDB.Update(ctx, func(ctx context.Context,
 		tx firewalldb.PrivacyMapTx) error {
 
 		for r, p := range newPrivMapPairs {
-			err := tx.NewPair(r, p)
+			err := tx.NewPair(ctx, r, p)
 			if err != nil {
 				return err
 			}

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -355,7 +355,7 @@ func (s *sessionRpcServer) AddSession(ctx context.Context,
 		return nil, fmt.Errorf("error fetching session: %v", err)
 	}
 
-	rpcSession, err := s.marshalRPCSession(sess)
+	rpcSession, err := s.marshalRPCSession(ctx, sess)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling session: %v", err)
 	}
@@ -557,7 +557,7 @@ func (s *sessionRpcServer) ListSessions(ctx context.Context,
 		Sessions: make([]*litrpc.Session, len(sessions)),
 	}
 	for idx, sess := range sessions {
-		response.Sessions[idx], err = s.marshalRPCSession(sess)
+		response.Sessions[idx], err = s.marshalRPCSession(ctx, sess)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling session: %v",
 				err)
@@ -629,7 +629,9 @@ func (s *sessionRpcServer) PrivacyMapConversion(ctx context.Context,
 
 	var res string
 	privMap := s.cfg.privMap(groupID)
-	err = privMap.View(func(tx firewalldb.PrivacyMapTx) error {
+	err = privMap.View(ctx, func(_ context.Context,
+		tx firewalldb.PrivacyMapTx) error {
+
 		var err error
 		if req.RealToPseudo {
 			res, err = tx.RealToPseudo(req.Input)
@@ -899,7 +901,9 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 		linkedGroupSession = groupSess
 
 		privDB := s.cfg.privMap(groupID)
-		err = privDB.View(func(tx firewalldb.PrivacyMapTx) error {
+		err = privDB.View(ctx, func(_ context.Context,
+			tx firewalldb.PrivacyMapTx) error {
+
 			knownPrivMapPairs, err = tx.FetchAllPairs()
 
 			return err
@@ -1002,7 +1006,8 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 				if privacy {
 					var privMapPairs map[string]string
 					v, privMapPairs, err = v.RealToPseudo(
-						knownPrivMapPairs, privacyFlags,
+						ctx, knownPrivMapPairs,
+						privacyFlags,
 					)
 					if err != nil {
 						return nil, err
@@ -1221,7 +1226,9 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 
 	// Register all the privacy map pairs for this session ID.
 	privDB := s.cfg.privMap(sess.GroupID)
-	err = privDB.Update(func(tx firewalldb.PrivacyMapTx) error {
+	err = privDB.Update(ctx, func(_ context.Context,
+		tx firewalldb.PrivacyMapTx) error {
+
 		for r, p := range newPrivMapPairs {
 			err := tx.NewPair(r, p)
 			if err != nil {
@@ -1272,7 +1279,7 @@ func (s *sessionRpcServer) AddAutopilotSession(ctx context.Context,
 		return nil, fmt.Errorf("error fetching session: %v", err)
 	}
 
-	rpcSession, err := s.marshalRPCSession(sess)
+	rpcSession, err := s.marshalRPCSession(ctx, sess)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling session: %v", err)
 	}
@@ -1297,7 +1304,7 @@ func (s *sessionRpcServer) ListAutopilotSessions(ctx context.Context,
 		Sessions: make([]*litrpc.Session, len(sessions)),
 	}
 	for idx, sess := range sessions {
-		response.Sessions[idx], err = s.marshalRPCSession(sess)
+		response.Sessions[idx], err = s.marshalRPCSession(ctx, sess)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling session: %v",
 				err)
@@ -1426,8 +1433,8 @@ func marshalPerms(perms map[string][]bakery.Op) []*litrpc.Permissions {
 }
 
 // marshalRPCSession converts a session into its RPC counterpart.
-func (s *sessionRpcServer) marshalRPCSession(sess *session.Session) (
-	*litrpc.Session, error) {
+func (s *sessionRpcServer) marshalRPCSession(ctx context.Context,
+	sess *session.Session) (*litrpc.Session, error) {
 
 	rpcState, err := marshalRPCState(sess.State)
 	if err != nil {
@@ -1484,7 +1491,8 @@ func (s *sessionRpcServer) marshalRPCSession(sess *session.Session) (
 							sess.GroupID,
 						)
 						val, err = val.PseudoToReal(
-							db, sess.PrivacyFlags,
+							ctx, db,
+							sess.PrivacyFlags,
 						)
 						if err != nil {
 							return nil, err

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -629,7 +629,7 @@ func (s *sessionRpcServer) PrivacyMapConversion(ctx context.Context,
 
 	var res string
 	privMap := s.cfg.privMap(groupID)
-	err = privMap.View(ctx, func(_ context.Context,
+	err = privMap.View(ctx, func(ctx context.Context,
 		tx firewalldb.PrivacyMapTx) error {
 
 		var err error
@@ -638,7 +638,7 @@ func (s *sessionRpcServer) PrivacyMapConversion(ctx context.Context,
 			return err
 		}
 
-		res, err = tx.PseudoToReal(req.Input)
+		res, err = tx.PseudoToReal(ctx, req.Input)
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
Here we do a a few things:

1) thread contexts through for privacy mapper interfaces
2) use the new DBExecutor to init the PrivacyMapDB
3) Unify the kv store and privacy map implementations of DBExecutor to a single bbolt backed one. Later on we will add a sql backed one