### PR TITLE
.github: correctly name log zip file to be namespaced

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -312,7 +312,7 @@ jobs:
       - name: Zip log files on failure
         if: ${{ failure() }}
         timeout-minutes: 5
-        run: 7z a logs-itest.zip itest/**/*.log
+        run: 7z a logs-itest-${{ matrix.name }}.zip itest/**/*.log
 
       - name: Upload log files on failure
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Our failed logs have not been uploading since [this](https://github.com/lightninglabs/lightning-terminal/pull/1006/commits/6dbb68b4e52c0379fe5915b947cf0081292c5890) commit in which we started to namespace itest CI artefacts. I forgot to add the namespace tag to the zip directory. 