### PR TITLE
itest: cleaner distribution of on-chain assets

### DIFF
--- a/itest/litd_custom_channels_test.go
+++ b/itest/litd_custom_channels_test.go
@@ -46,6 +46,10 @@ var (
 		AssetType: taprpc.AssetType_NORMAL,
 		Name:      "itest-asset-cents",
 		AssetMeta: dummyMetaData,
+
+		// Note: Amount must be large enough to satisfy `daveFundingAmount`,
+		// `erinFundingAmount`, and `charlieFundingAmount` defined below in each
+		// test case.
 		Amount:    1_000_000,
 	}
 
@@ -196,15 +200,23 @@ func testCustomChannelsLarge(_ context.Context, net *NetworkHarness,
 	syncUniverses(t.t, charlieTap, dave, erin, fabia, yara)
 	t.Logf("Universes synced between all nodes, distributing assets...")
 
+	// Define the sizes of each channel that is opened.
+	// Note: Dave needs to have the larger channel size.
 	const (
 		daveFundingAmount = uint64(400_000)
 		erinFundingAmount = uint64(200_000)
 	)
-	charlieFundingAmount := cents.Amount - uint64(2*400_000)
+
+	// Give Dave and Erin both the same amount of on chain funds even though
+	// Erin won't use it all.
+	const assetSendAmount = daveFundingAmount
+
+	// Charlie uses the rest of the funds that are minted in his channel
+	charlieFundingAmount := cents.Amount - 2*assetSendAmount
 
 	chanPointCD, _, _ := createTestAssetNetwork(
 		t, net, charlieTap, daveTap, erinTap, fabiaTap, yaraTap,
-		universeTap, cents, 400_000, charlieFundingAmount,
+		universeTap, cents, assetSendAmount, charlieFundingAmount,
 		daveFundingAmount, erinFundingAmount, DefaultPushSat,
 	)
 
@@ -385,15 +397,23 @@ func testCustomChannels(ctx context.Context, net *NetworkHarness,
 	syncUniverses(t.t, charlieTap, dave, erin, fabia, yara)
 	t.Logf("Universes synced between all nodes, distributing assets...")
 
+	// Define the sizes of each channel that is opened.
+	// Note: Dave needs to have the larger channel size.
 	const (
 		daveFundingAmount = uint64(startAmount)
 		erinFundingAmount = uint64(fundingAmount)
 	)
-	charlieFundingAmount := cents.Amount - 2*startAmount
+
+	// Give Dave and Erin both the same amount of on chain funds even though
+	// Erin won't use it all.
+	const assetSendAmount = daveFundingAmount
+
+	// Charlie uses the rest of the funds that are minted in his channel
+	charlieFundingAmount := cents.Amount - 2*assetSendAmount
 
 	chanPointCD, chanPointDY, chanPointEF := createTestAssetNetwork(
 		t, net, charlieTap, daveTap, erinTap, fabiaTap, yaraTap,
-		universeTap, cents, startAmount, charlieFundingAmount,
+		universeTap, cents, assetSendAmount, charlieFundingAmount,
 		daveFundingAmount, erinFundingAmount, DefaultPushSat,
 	)
 
@@ -852,15 +872,23 @@ func testCustomChannelsGroupedAsset(ctx context.Context, net *NetworkHarness,
 	syncUniverses(t.t, charlieTap, dave, erin, fabia, yara)
 	t.Logf("Universes synced between all nodes, distributing assets...")
 
+	// Define the sizes of each channel that is opened.
+	// Note: Dave needs to have the larger channel size.
 	const (
 		daveFundingAmount = uint64(startAmount)
 		erinFundingAmount = uint64(fundingAmount)
 	)
-	charlieFundingAmount := cents.Amount - 2*startAmount
+
+	// Give Dave and Erin both the same amount of on chain funds even though
+	// Erin won't use it all.
+	const assetSendAmount = daveFundingAmount
+
+	// Charlie uses the rest of the funds that are minted in his channel
+	charlieFundingAmount := cents.Amount - 2*assetSendAmount
 
 	chanPointCD, chanPointDY, chanPointEF := createTestAssetNetwork(
 		t, net, charlieTap, daveTap, erinTap, fabiaTap, yaraTap,
-		universeTap, cents, startAmount, charlieFundingAmount,
+		universeTap, cents, assetSendAmount, charlieFundingAmount,
 		daveFundingAmount, erinFundingAmount, DefaultPushSat,
 	)
 
@@ -1818,15 +1846,23 @@ func testCustomChannelsLiquidityEdgeCases(ctx context.Context,
 	syncUniverses(t.t, charlieTap, dave, erin, fabia, yara)
 	t.Logf("Universes synced between all nodes, distributing assets...")
 
+	// Define the sizes of each channel that is opened.
+	// Note: Dave needs to have the larger channel size.
 	const (
 		daveFundingAmount = uint64(400_000)
 		erinFundingAmount = uint64(200_000)
 	)
-	charlieFundingAmount := cents.Amount - uint64(2*400_000)
+
+	// Give Dave and Erin both the same amount of on chain funds even though
+	// Erin won't use it all.
+	const assetSendAmount = daveFundingAmount
+
+	// Charlie uses the rest of the funds that are minted in his channel
+	charlieFundingAmount := cents.Amount - 2*assetSendAmount
 
 	_, _, _ = createTestAssetNetwork(
 		t, net, charlieTap, daveTap, erinTap, fabiaTap, yaraTap,
-		universeTap, cents, 400_000, charlieFundingAmount,
+		universeTap, cents, assetSendAmount, charlieFundingAmount,
 		daveFundingAmount, erinFundingAmount, 0,
 	)
 
@@ -2265,15 +2301,23 @@ func testCustomChannelsStrictForwarding(ctx context.Context,
 	syncUniverses(t.t, charlieTap, dave, erin, fabia, yara)
 	t.Logf("Universes synced between all nodes, distributing assets...")
 
+	// Define the sizes of each channel that is opened.
+	// Note: Dave needs to have the larger channel size.
 	const (
 		daveFundingAmount = uint64(400_000)
 		erinFundingAmount = uint64(200_000)
 	)
-	charlieFundingAmount := cents.Amount - uint64(2*400_000)
+
+	// Give Dave and Erin both the same amount of on chain funds even though
+	// Erin won't use it all.
+	const assetSendAmount = daveFundingAmount
+
+	// Charlie uses the rest of the funds that are minted in his channel
+	charlieFundingAmount := cents.Amount - 2*assetSendAmount
 
 	_, _, _ = createTestAssetNetwork(
 		t, net, charlieTap, daveTap, erinTap, fabiaTap, yaraTap,
-		universeTap, cents, 400_000, charlieFundingAmount,
+		universeTap, cents, assetSendAmount, charlieFundingAmount,
 		daveFundingAmount, erinFundingAmount, 0,
 	)
 
@@ -2850,16 +2894,26 @@ func testCustomChannelsOraclePricing(ctx context.Context, net *NetworkHarness,
 	syncUniverses(t.t, charlieTap, dave, erin, fabia, yara)
 	t.Logf("Universes synced between all nodes, distributing assets...")
 
+
+
+
+	// Define the sizes of each channel that is opened.
+	// Note: Dave needs to have the larger channel size.
 	const (
-		sendAmount        = uint64(400_000_000)
 		daveFundingAmount = uint64(400_000_000)
 		erinFundingAmount = uint64(200_000_000)
 	)
-	charlieFundingAmount := usdAsset.Amount - 2*sendAmount
+
+	// Give Dave and Erin both the same amount of on chain funds even though
+	// Erin won't use it all.
+	const assetSendAmount = daveFundingAmount
+
+	// Charlie uses the rest of the funds that are minted in his channel
+	charlieFundingAmount := usdAsset.Amount - 2*assetSendAmount
 
 	chanPointCD, chanPointDY, chanPointEF := createTestAssetNetwork(
 		t, net, charlieTap, daveTap, erinTap, fabiaTap, yaraTap,
-		universeTap, usdAsset, sendAmount, charlieFundingAmount,
+		universeTap, usdAsset, assetSendAmount, charlieFundingAmount,
 		daveFundingAmount, erinFundingAmount, 0,
 	)
 
@@ -3739,15 +3793,23 @@ func testCustomChannelsForwardBandwidth(ctx context.Context,
 	syncUniverses(t.t, charlieTap, dave, erin, fabia, yara)
 	t.Logf("Universes synced between all nodes, distributing assets...")
 
+	// Define the sizes of each channel that is opened.
+	// Note: Dave needs to have the larger channel size.
 	const (
 		daveFundingAmount = uint64(400_000)
 		erinFundingAmount = uint64(200_000)
 	)
-	charlieFundingAmount := cents.Amount - uint64(2*400_000)
+
+	// Give Dave and Erin both the same amount of on chain funds even though
+	// Erin won't use it all.
+	const assetSendAmount = daveFundingAmount
+
+	// Charlie uses the rest of the funds that are minted in his channel
+	charlieFundingAmount := cents.Amount - 2*assetSendAmount
 
 	_, _, chanPointEF := createTestAssetNetwork(
 		t, net, charlieTap, daveTap, erinTap, fabiaTap, yaraTap,
-		universeTap, cents, 400_000, charlieFundingAmount,
+		universeTap, cents, assetSendAmount, charlieFundingAmount,
 		daveFundingAmount, erinFundingAmount, 0,
 	)
 


### PR DESCRIPTION
This fixes https://github.com/lightninglabs/taproot-assets/issues/1432 by defining the on chain asset amounts sent to each node and the sizes of channels opened by each node relative to each other without hard coding the values. This then allows the channel sizes to be adjusted more easily as needed.