### PR TITLE
multi: bump to latest lnd/tapd, assert close chan data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,8 +28,8 @@ require (
 	github.com/lightninglabs/pool v0.6.5-beta.0.20250305125211-4e860ec4e77f
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.3-0.20250305125211-4e860ec4e77f
 	github.com/lightninglabs/pool/poolrpc v1.0.1-0.20250305125211-4e860ec4e77f
-	github.com/lightninglabs/taproot-assets v0.5.2-0.20250326140136-a724d385e7ae
-	github.com/lightningnetwork/lnd v0.19.0-beta.rc1
+	github.com/lightninglabs/taproot-assets v0.5.2-0.20250401150538-a9ea76a9ed3c
+	github.com/lightningnetwork/lnd v0.19.0-beta.rc1.0.20250327183348-eb822a5e117f
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -1181,12 +1181,12 @@ github.com/lightninglabs/pool/poolrpc v1.0.1-0.20250305125211-4e860ec4e77f h1:5p
 github.com/lightninglabs/pool/poolrpc v1.0.1-0.20250305125211-4e860ec4e77f/go.mod h1:lGs2hSVZ+GFpdv3btaIl9icG5/gz7BBRfvmD2iqqNl0=
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display h1:w7FM5LH9Z6CpKxl13mS48idsu6F+cEZf0lkyiV+Dq9g=
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
-github.com/lightninglabs/taproot-assets v0.5.2-0.20250326140136-a724d385e7ae h1:t2GDmnV/ab+dsaTDjCDTGbCVSMCE13pxc6zu4zQFsJs=
-github.com/lightninglabs/taproot-assets v0.5.2-0.20250326140136-a724d385e7ae/go.mod h1:hLK/spdccubmDZjufTqGJrj9mn0hQpOxaJBQ767Idxw=
+github.com/lightninglabs/taproot-assets v0.5.2-0.20250401150538-a9ea76a9ed3c h1:Rebx5DVZx3u327vKRrueFjZNlei1RzdGzFmOZmenkiQ=
+github.com/lightninglabs/taproot-assets v0.5.2-0.20250401150538-a9ea76a9ed3c/go.mod h1:e3SjXbbi4xKhOzq54c672Z/j9UTRq5DLJGx/URgVTJo=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb h1:yfM05S8DXKhuCBp5qSMZdtSwvJ+GFzl94KbXMNB1JDY=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
-github.com/lightningnetwork/lnd v0.19.0-beta.rc1 h1:FJvsdw4PZ41ykrHi7vNGit9IIohE+IlKpVwL5/1+L+0=
-github.com/lightningnetwork/lnd v0.19.0-beta.rc1/go.mod h1:BP+neeFpmeAA7o5hu3zp3FwOEl26idSyPV9zBOavp6E=
+github.com/lightningnetwork/lnd v0.19.0-beta.rc1.0.20250327183348-eb822a5e117f h1:+Bejv2Ij/ryUjLacBd5au0acMH0AYs0lhb7ki5rx9ms=
+github.com/lightningnetwork/lnd v0.19.0-beta.rc1.0.20250327183348-eb822a5e117f/go.mod h1:BP+neeFpmeAA7o5hu3zp3FwOEl26idSyPV9zBOavp6E=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=

--- a/itest/litd_custom_channels_test.go
+++ b/itest/litd_custom_channels_test.go
@@ -3,6 +3,7 @@ package itest
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"math/big"
@@ -12,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/itest"
 	"github.com/lightninglabs/taproot-assets/proof"
@@ -3261,8 +3263,8 @@ func runCustomChannelsHtlcForceClose(ctx context.Context, t *harnessTest,
 	// At this point, both sides should have 4 (or +4 with MPP) HTLCs
 	// active.
 	numHtlcs := 4
+	numAdditionalShards := assetInvoiceAmt / assetsPerMPPShard
 	if mpp {
-		numAdditionalShards := assetInvoiceAmt / assetsPerMPPShard
 		numHtlcs += numAdditionalShards * 2
 	}
 	t.Logf("Asserting both Alice and Bob have %d HTLCs...", numHtlcs)
@@ -3521,6 +3523,10 @@ func runCustomChannelsHtlcForceClose(ctx context.Context, t *harnessTest,
 
 	// We'll wait for both Alice and Bob to present their respective sweeps
 	// to the sweeper.
+	numTimeoutHTLCs := 1
+	if mpp {
+		numTimeoutHTLCs += numAdditionalShards
+	}
 	assertSweepExists(
 		t.t, alice,
 		walletrpc.WitnessType_TAPROOT_HTLC_LOCAL_OFFERED_TIMEOUT,
@@ -3541,6 +3547,58 @@ func runCustomChannelsHtlcForceClose(ctx context.Context, t *harnessTest,
 
 	// Finally, we'll mine a single block to confirm them.
 	mineBlocks(t, net, 1, 2)
+
+	// Make sure Bob swept all his HTLCs.
+	bobSweeps, err := bob.WalletKitClient.ListSweeps(
+		ctx, &walletrpc.ListSweepsRequest{
+			Verbose: true,
+		},
+	)
+	require.NoError(t.t, err)
+
+	var bobSweepTx *wire.MsgTx
+	for _, sweep := range bobSweeps.GetTransactionDetails().Transactions {
+		for _, tx := range timeoutSweeps {
+			if sweep.TxHash == tx.String() {
+				txBytes, err := hex.DecodeString(sweep.RawTxHex)
+				require.NoError(t.t, err)
+
+				bobSweepTx = &wire.MsgTx{}
+				err = bobSweepTx.Deserialize(
+					bytes.NewReader(txBytes),
+				)
+				require.NoError(t.t, err)
+			}
+		}
+	}
+	require.NotNil(t.t, bobSweepTx, "Bob's sweep transaction not found")
+
+	// There's always an extra input that pays for the fees. So we can only
+	// count the remainder as HTLC inputs.
+	numSweptHTLCs := len(bobSweepTx.TxIn) - 1
+
+	// If we didn't yet sweep all HTLCs, then we need to wait for another
+	// sweep.
+	if numSweptHTLCs < numTimeoutHTLCs {
+		assertSweepExists(
+			t.t, bob,
+			// nolint: lll
+			walletrpc.WitnessType_TAPROOT_HTLC_OFFERED_REMOTE_TIMEOUT,
+		)
+
+		t.Logf("Confirming additional HTLC timeout sweep txns")
+
+		additionalTimeoutSweeps, err := waitForNTxsInMempool(
+			net.Miner.Client, 1, shortTimeout,
+		)
+		require.NoError(t.t, err)
+
+		t.Logf("Asserting balance on additional timeout sweeps: %v",
+			additionalTimeoutSweeps)
+
+		// Finally, we'll mine a single block to confirm them.
+		mineBlocks(t, net, 1, 1)
+	}
 
 	// At this point, Bob's balance should be incremented by an additional
 	// HTLC value.

--- a/itest/litd_custom_channels_test.go
+++ b/itest/litd_custom_channels_test.go
@@ -3278,6 +3278,9 @@ func runCustomChannelsHtlcForceClose(ctx context.Context, t *harnessTest,
 
 	t.Logf("Channel closed! Mining blocks, close_txid=%v", closeTxid)
 
+	// The channel should first be in "waiting close" until it confirms.
+	assertWaitingCloseChannelAssetData(t.t, alice, aliceChanPoint)
+
 	// Next, we'll mine a block which should start the clock ticking on the
 	// relative timeout for the Alice, and Bob.
 	//
@@ -3296,6 +3299,9 @@ func runCustomChannelsHtlcForceClose(ctx context.Context, t *harnessTest,
 	locateAssetTransfers(t.t, bobTap, *closeTxid)
 
 	t.Logf("Settling Bob's hodl invoice")
+
+	// It should then go to "pending force closed".
+	assertPendingForceCloseChannelAssetData(t.t, alice, aliceChanPoint)
 
 	// At this point, the commitment transaction has been mined, and we have
 	// 4 total HTLCs on Alice's commitment transaction:

--- a/itest/litd_test_list_on_test.go
+++ b/itest/litd_test_list_on_test.go
@@ -53,6 +53,10 @@ var allTestCases = []*testCase{
 		test: testCustomChannelsHtlcForceClose,
 	},
 	{
+		name: "test custom channels htlc force close MPP",
+		test: testCustomChannelsHtlcForceCloseMpp,
+	},
+	{
 		name: "test custom channels balance consistency",
 		test: testCustomChannelsBalanceConsistency,
 	},


### PR DESCRIPTION
~Depends on https://github.com/lightningnetwork/lnd/pull/9504.~
~Depends on https://github.com/lightninglabs/taproot-assets/pull/1441.~

Serves as validation code for the changes in https://github.com/lightningnetwork/lnd/pull/9504.

Also fixes https://github.com/lightninglabs/lightning-terminal/issues/940.