### PR TITLE
build: add build flags for other databases

### DIFF
--- a/make/compile_flags.mk
+++ b/make/compile_flags.mk
@@ -1,1 +1,1 @@
-COMPILE_TAGS = autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc neutrinorpc peersrpc
+COMPILE_TAGS = autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc neutrinorpc peersrpc kvdb_postgres kvdb_etcd kvdb_sqlite


### PR DESCRIPTION
This commit adds support for all other databases
as they are supported in the standalone lnd
builds.