### PR TITLE
Asset Invoice with sats value itest

### DIFF
--- a/itest/litd_custom_channels_test.go
+++ b/itest/litd_custom_channels_test.go
@@ -2679,10 +2679,13 @@ func testCustomChannelsLiquidityEdgeCasesCore(ctx context.Context,
 	assertNumHtlcs(t.t, erin, 0)
 	assertNumHtlcs(t.t, fabia, 0)
 
-	// Now Fabia creates the normal invoice.
+	// Now Fabia creates another invoice. We also use a fixed msat value for
+	// the invoice. Since our itest oracle evaluates every asset to about
+	// 17.1 sats, this invoice should be a bit below 10k assets, so roughly
+	// the same volume as the previous invoice we just cancelled.
 	invoiceResp = createAssetInvoice(
-		t.t, erin, fabia, 10_000, assetID,
-		withInvGroupKey(groupID),
+		t.t, erin, fabia, 0, assetID, withInvGroupKey(groupID),
+		withMsatAmount(170_000_000),
 	)
 
 	// Now Charlie pays the invoice, again by using the manually specified


### PR DESCRIPTION
## Description

This itest tests the behavior exposed in https://github.com/lightninglabs/taproot-assets/pull/1448

It is very minimal, and currently only to be used as a proof-of-concept sanity check for the above feature.