### PR TITLE
Add new custom channels itest liquidity edge case for safe HTLC failure

### DIFF
--- a/itest/litd_accounts_test.go
+++ b/itest/litd_accounts_test.go
@@ -416,12 +416,12 @@ func payNode(invoiceCtx, paymentCtx context.Context, t *harnessTest,
 	stream, err := from.SendPaymentV2(paymentCtx, sendReq)
 	require.NoError(t.t, err)
 
-	result, err := getPaymentResult(stream)
+	result, err := getFinalPaymentResult(stream)
 	require.NoError(t.t, err)
 	require.Equal(t.t, result.Status, lnrpc.Payment_SUCCEEDED)
 }
 
-func getPaymentResult(stream routerrpc.Router_SendPaymentV2Client) (
+func getFinalPaymentResult(stream routerrpc.Router_SendPaymentV2Client) (
 	*lnrpc.Payment, error) {
 
 	for {


### PR DESCRIPTION
## Description

This new custom channels liquidity edge case tests that an asset HTLC with more units than the local balance may not get added to the channel.

 Based on 
https://github.com/lightninglabs/taproot-assets/pull/1462
https://github.com/lightningnetwork/lnd/pull/9687