### PR TITLE
multi: expose `Proxy` service over LNC

### DIFF
--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -42,6 +42,15 @@
   instead, to update an account's balance. The flag will no longer be
   supported in Lightning Terminal `v0.16.0-alpha`.
 
+* [The `litrpc.Proxy` endpoints are now exposed over
+  LNC](https://github.com/lightninglabs/lightning-terminal/pull/1033).  
+  Note that this also exposes the `stop` and `bakesupermacaroon` endpoints over
+  LNC. If this is not desired, it is recommended to fine-tune the macaroon
+  created for the LNC session. Specifically, remove the `proxy:write`
+  permission to disable access to the `stop` endpoint, and the
+  `supermacaroon:write` permission to disable access to the
+  `bakesupermacaroon` endpoint.
+
 ## Integrated Binary Updates
 
 ### LND

--- a/itest/litd_mode_integrated_test.go
+++ b/itest/litd_mode_integrated_test.go
@@ -358,7 +358,7 @@ var (
 		macaroonFn:        litMacaroonFn,
 		requestFn:         proxyRequestFn,
 		successPattern:    "\"version\":",
-		allowedThroughLNC: false,
+		allowedThroughLNC: true,
 		grpcWebURI:        "/litrpc.Proxy/GetInfo",
 		restWebURI:        "/v1/proxy/info",
 		litOnly:           true,

--- a/terminal.go
+++ b/terminal.go
@@ -1176,6 +1176,7 @@ func (g *LightningTerminal) registerSubDaemonGrpcServers(server *grpc.Server,
 
 	if forLNCSession {
 		litrpc.RegisterStatusServer(server, g.statusMgr)
+		litrpc.RegisterProxyServer(server, g.rpcProxy)
 	} else {
 		litrpc.RegisterSessionsServer(server, g.sessionRpcServer)
 


### PR DESCRIPTION
Fixes issue #1027 

Previously, the `Proxy` service was not accessible over LNC, as we did not want to expose the `stop` and `bakesupermacaroon` endpoints over LNC. This also meant that the `getinfo` endpoint was not accessible over LNC. As we now have demand to expose the `getinfo` endpoint over LNC, we have decided to expose the `Proxy` service over LNC, and let the user fine-tune the access to the `stop` and `bakesupermacaroon` endpoints via the macaroon for the LNC session instead.