### PR TITLE
build: add removal of ./vendor to `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,7 @@ clean: clean-itest
 	$(RM) ./litcli-debug
 	$(RM) ./litd-debug
 	$(RM) coverage.txt
+	$(RM) -r ./vendor
 
 sqlc:
 	@$(call print, "Generating sql models and queries in Go")


### PR DESCRIPTION
If we error during the making of a `release`, during the `packaging vendor` step, we'll leave the `./vendor` directory in the repo root. That'll mess up the next `release` build, and therefore we should add it to the `make clean` command, similar to how `lnd` does it. 