### PR TITLE
itest: fix wording "over" -> "for"

### DIFF
--- a/itest/assets_test.go
+++ b/itest/assets_test.go
@@ -1144,7 +1144,7 @@ func createAssetInvoice(t *testing.T, dstRfqPeer, dst *HarnessNode,
 		AssetAmount: assetAmount,
 		PeerPubkey:  dstRfqPeer.PubKey[:],
 		InvoiceRequest: &lnrpc.Invoice{
-			Memo: fmt.Sprintf("this is an asset invoice over "+
+			Memo: fmt.Sprintf("this is an asset invoice for "+
 				"%d units", assetAmount),
 			Expiry: timeoutSeconds,
 		},
@@ -1291,7 +1291,7 @@ func createAssetHodlInvoice(t *testing.T, dstRfqPeer, dst *HarnessNode,
 	timeoutSeconds := int64(rfq.DefaultInvoiceExpiry.Seconds())
 
 	t.Logf("Asking peer %x for quote to buy assets to receive for "+
-		"invoice over %d units; waiting up to %ds",
+		"invoice for %d units; waiting up to %ds",
 		dstRfqPeer.PubKey[:], assetAmount, timeoutSeconds)
 
 	dstTapd := newTapClient(t, dst)
@@ -1309,7 +1309,7 @@ func createAssetHodlInvoice(t *testing.T, dstRfqPeer, dst *HarnessNode,
 		AssetAmount: assetAmount,
 		PeerPubkey:  dstRfqPeer.PubKey[:],
 		InvoiceRequest: &lnrpc.Invoice{
-			Memo: fmt.Sprintf("this is an asset invoice over "+
+			Memo: fmt.Sprintf("this is an asset invoice for "+
 				"%d units", assetAmount),
 			Expiry: timeoutSeconds,
 		},

--- a/itest/litd_custom_channels_test.go
+++ b/itest/litd_custom_channels_test.go
@@ -1977,8 +1977,7 @@ func testCustomChannelsLiquidityEdgeCases(ctx context.Context,
 	// channels, where the total asset value is less than the default anchor
 	// amount of 354 sats.
 	createAssetInvoice(t.t, dave, charlie, 1, assetID, withInvoiceErrSubStr(
-		"cannot create invoice over 1 asset units, as the minimal "+
-			"transportable amount",
+		"1 asset units, as the minimal transportable amount",
 	))
 
 	logBalance(t.t, nodes, assetID, "after small payment (asset "+


### PR DESCRIPTION
This is a German phrasing that made it into English... Since we will change the error message (and fix it) in tapd, we want to make sure that our itest doesn't fail on that.

Will fix the CI on https://github.com/lightninglabs/taproot-assets/pull/1448.