### PR TITLE
multi: extract session ID from context

### DIFF
--- a/firewall/privacy_mapper.go
+++ b/firewall/privacy_mapper.go
@@ -106,9 +106,11 @@ func (p *PrivacyMapper) Intercept(ctx context.Context,
 			"interception request: %v", err)
 	}
 
-	sessionID, err := session.IDFromMacaroon(ri.Macaroon)
+	sessionID, err := ri.SessionID.UnwrapOrErr(
+		fmt.Errorf("no session ID found in request info"),
+	)
 	if err != nil {
-		return nil, fmt.Errorf("could not extract ID from macaroon")
+		return nil, err
 	}
 
 	log.Tracef("PrivacyMapper: Intercepting %v", ri)

--- a/firewall/privacy_mapper_test.go
+++ b/firewall/privacy_mapper_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/rpcperms"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon.v2"
@@ -907,6 +908,9 @@ func TestPrivacyMapper(t *testing.T) {
 			rawMsg, err := proto.Marshal(test.msg)
 			require.NoError(t, err)
 
+			md := make(metadata.MD)
+			session.AddToGRPCMetadata(md, sessionID)
+
 			interceptReq := &rpcperms.InterceptionRequest{
 				Type:            test.msgType,
 				Macaroon:        mac,
@@ -916,6 +920,7 @@ func TestPrivacyMapper(t *testing.T) {
 				ProtoTypeName: string(
 					proto.MessageName(test.msg),
 				),
+				CtxMetadataPairs: md,
 			}
 
 			mwReq, err := interceptReq.ToRPC(1, 2)
@@ -1006,6 +1011,9 @@ func TestPrivacyMapper(t *testing.T) {
 		amounts := make([]uint64, numSamples)
 		timestamps := make([]uint64, numSamples)
 
+		md := make(metadata.MD)
+		session.AddToGRPCMetadata(md, sessionID)
+
 		for i := 0; i < numSamples; i++ {
 			interceptReq := &rpcperms.InterceptionRequest{
 				Type:            rpcperms.TypeResponse,
@@ -1016,6 +1024,7 @@ func TestPrivacyMapper(t *testing.T) {
 				ProtoTypeName: string(
 					proto.MessageName(msg),
 				),
+				CtxMetadataPairs: md,
 			}
 
 			mwReq, err := interceptReq.ToRPC(1, 2)

--- a/firewall/request_logger.go
+++ b/firewall/request_logger.go
@@ -194,6 +194,7 @@ func (r *RequestLogger) addNewAction(ctx context.Context, ri *RequestInfo,
 	}
 
 	actionReq := &firewalldb.AddActionReq{
+		SessionID:          ri.SessionID,
 		MacaroonIdentifier: macaroonID,
 		RPCMethod:          ri.URI,
 	}

--- a/firewall/rule_enforcer.go
+++ b/firewall/rule_enforcer.go
@@ -237,9 +237,11 @@ func (r *RuleEnforcer) Intercept(ctx context.Context,
 func (r *RuleEnforcer) handleRequest(ctx context.Context,
 	ri *RequestInfo) (proto.Message, error) {
 
-	sessionID, err := session.IDFromMacaroon(ri.Macaroon)
+	sessionID, err := ri.SessionID.UnwrapOrErr(
+		fmt.Errorf("no session ID found in request info"),
+	)
 	if err != nil {
-		return nil, fmt.Errorf("could not extract ID from macaroon")
+		return nil, err
 	}
 
 	rules, err := r.collectEnforcers(ctx, ri, sessionID)

--- a/session/context.go
+++ b/session/context.go
@@ -1,0 +1,57 @@
+package session
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/fn"
+	"google.golang.org/grpc/metadata"
+)
+
+// contextKey is a struct that is used as a key for storing session IDs
+// in a context. Using this unexported type prevents collisions with other
+// context keys that may be used in the same context. However, this only
+// applies if the context is passed around in the same binary and not if the
+// value is converted to grpc metadata and sent over the wire. In that case,
+// we need to use a string key to avoid collisions with other metadata keys.
+type contextKey struct {
+	name string
+}
+
+// sessionIDCtxKey is the context key used to store the session ID in
+// a context. The key is a string to avoid collisions with other context values
+// that may also be included in grpc metadata which is why we add the 'lit'
+// prefix.
+var sessionIDCtxKey = contextKey{"lit_session_id"}
+
+// FromGRPCMetadata extracts the session ID from the given gRPC metadata kv
+// pairs if one is found.
+func FromGRPCMetadata(md metadata.MD) (fn.Option[ID], error) {
+	val := md.Get(sessionIDCtxKey.name)
+	if len(val) == 0 {
+		return fn.None[ID](), nil
+	}
+
+	if len(val) != 1 {
+		return fn.None[ID](), fmt.Errorf("more than one session ID "+
+			"found in gRPC metadata: %v", val)
+	}
+
+	b, err := hex.DecodeString(val[0])
+	if err != nil {
+		return fn.None[ID](), err
+	}
+
+	sessID, err := IDFromBytes(b)
+	if err != nil {
+		return fn.None[ID](), err
+	}
+
+	return fn.Some(sessID), nil
+}
+
+// AddToGRPCMetadata adds the session ID to the given gRPC metadata kv pairs.
+// The session ID is encoded as a hex string.
+func AddToGRPCMetadata(md metadata.MD, id ID) {
+	md.Set(sessionIDCtxKey.name, hex.EncodeToString(id[:]))
+}

--- a/session/server.go
+++ b/session/server.go
@@ -18,7 +18,8 @@ import (
 
 type sessionID [33]byte
 
-type GRPCServerCreator func(opts ...grpc.ServerOption) *grpc.Server
+type GRPCServerCreator func(sessionID ID,
+	opts ...grpc.ServerOption) *grpc.Server
 
 type mailboxSession struct {
 	server *grpc.Server
@@ -70,7 +71,7 @@ func (m *mailboxSession) start(session *Session,
 	}
 
 	noiseConn := mailbox.NewNoiseGrpcConn(keys)
-	m.server = serverCreator(grpc.Creds(noiseConn))
+	m.server = serverCreator(session.ID, grpc.Creds(noiseConn))
 
 	m.wg.Add(1)
 	go m.run(mailboxServer)


### PR DESCRIPTION
Currently, in our RPC interceptors, we use the macaroon data in the request to extract the session ID. This is not ideal since we are using the root key ID of the macaroon and this can cause issues because sometimes we also store the first 4 bytes of an account ID in there. Or it could just be a totally unrelated macaroon that happens to have root key ID that matches with one of our session IDs. 

We should instead use a much more reliable way of passing along session ID info: we can do this because any request that comes in via a session, we can intercept and add the session ID to the grpc metadata for the call via the context. This will then be included in the ctx info that LND gets when which interceptors to send the request too. So LND can then send this metadata info _back_ to lit via the `lnrpc.RPCMiddlewareRequest` message (see PR [here](https://github.com/lightningnetwork/lnd/pull/9739)), LiT can then extract the session ID in a much more reliable way during request interception. 

NOTE: with this change, it _must_ be the case that in remote mode LND is >=v0.19.0 for this change to work properly (since only in 19 will LND send back the metadata we use here) . So in our next release, we need to bump our minimum required LND version to 19 (we might do it anyways for taproot-asset reasons).

Depends on:
- #1070 