### PR TITLE
mod+itest: make custom channel itest flakes less annoying

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -279,11 +279,14 @@ jobs:
       matrix:
         include:
           - name: bbolt
-            args: dbbackend=bbolt
+            args: itest icase=terminal dbbackend=bbolt
           - name: sqlite
-            args: dbbackend=sqlite
+            args: itest icase=terminal dbbackend=sqlite
           - name: postgres
-            args: dbbackend=postgres
+            args: itest icase=terminal dbbackend=postgres
+          - name: custom-channels
+            args: itest-only icase=custom_channels
+            
     steps:
       - name: git checkout
         uses: actions/checkout@v4
@@ -305,7 +308,7 @@ jobs:
         run: yarn
 
       - name: run itest ${{ matrix.name }}
-        run: make itest ${{ matrix.args }}
+        run: make ${{ matrix.args }}
 
       - name: Zip log files on failure
         if: ${{ failure() }}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/lightninglabs/pool v0.6.5-beta.0.20250305125211-4e860ec4e77f
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.3-0.20250305125211-4e860ec4e77f
 	github.com/lightninglabs/pool/poolrpc v1.0.1-0.20250305125211-4e860ec4e77f
-	github.com/lightninglabs/taproot-assets v0.5.2-0.20250502070549-52257227c8f8
+	github.com/lightninglabs/taproot-assets v0.5.2-0.20250506181734-e63f1a4f4597
 	github.com/lightninglabs/taproot-assets/taprpc v1.0.1
 	github.com/lightningnetwork/lnd v0.19.0-beta.rc3
 	github.com/lightningnetwork/lnd/cert v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -506,8 +506,8 @@ github.com/lightninglabs/pool/poolrpc v1.0.1-0.20250305125211-4e860ec4e77f h1:5p
 github.com/lightninglabs/pool/poolrpc v1.0.1-0.20250305125211-4e860ec4e77f/go.mod h1:lGs2hSVZ+GFpdv3btaIl9icG5/gz7BBRfvmD2iqqNl0=
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display h1:w7FM5LH9Z6CpKxl13mS48idsu6F+cEZf0lkyiV+Dq9g=
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
-github.com/lightninglabs/taproot-assets v0.5.2-0.20250502070549-52257227c8f8 h1:kYAHGZTfIXgH9wQHml5B916GlS0pe6tcNsroqzabSxI=
-github.com/lightninglabs/taproot-assets v0.5.2-0.20250502070549-52257227c8f8/go.mod h1:OdeFcj2bnJf6aaYjBB5c8KdNI3aDaEMQpsSu2EqvMlw=
+github.com/lightninglabs/taproot-assets v0.5.2-0.20250506181734-e63f1a4f4597 h1:2gdwdH9HAPWnHk/1gnU7g1imofiw56KAEuLVBmMeoyQ=
+github.com/lightninglabs/taproot-assets v0.5.2-0.20250506181734-e63f1a4f4597/go.mod h1:OdeFcj2bnJf6aaYjBB5c8KdNI3aDaEMQpsSu2EqvMlw=
 github.com/lightninglabs/taproot-assets/taprpc v1.0.1 h1:aSlCWdJkagx9xa8DqK/pzHYCtY7PokU6wASse3dWayc=
 github.com/lightninglabs/taproot-assets/taprpc v1.0.1/go.mod h1:Ccq0t2GsXzOtC8qF0U1ux/yTF5HcBbVrhCb0tb/jObM=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb h1:yfM05S8DXKhuCBp5qSMZdtSwvJ+GFzl94KbXMNB1JDY=

--- a/itest/litd_test_list_on_test.go
+++ b/itest/litd_test_list_on_test.go
@@ -5,23 +5,23 @@ package itest
 
 var allTestCases = []*testCase{
 	{
-		name: "integrated mode",
+		name: "terminal integrated mode",
 		test: testModeIntegrated,
 	},
 	{
-		name: "remote mode",
+		name: "terminal remote mode",
 		test: testModeRemote,
 	},
 	{
-		name: "stateless init mode",
+		name: "terminal stateless init mode",
 		test: testStatelessInitMode,
 	},
 	{
-		name: "firewall rules",
+		name: "terminal firewall rules",
 		test: testFirewallRules,
 	},
 	{
-		name: "large http header",
+		name: "terminal large http header",
 		test: testLargeHttpHeader,
 	},
 	{


### PR DESCRIPTION
Runs the litd/terminal only itests separately from the custom channel itests, so flakes can be seen more clearly and ignored if not relevant.