### PR TITLE
dev.Dockerfile: allow skipping build of the web UI 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,14 +148,21 @@ go-install-noui:
 	$(GOINSTALL) -tags="litd_no_ui $(LND_RELEASE_TAGS)" -ldflags "$(LDFLAGS)" $(PKG)/cmd/litd
 	$(GOINSTALL) -tags="litd_no_ui $(LND_RELEASE_TAGS)" -ldflags "$(LDFLAGS)" $(PKG)/cmd/litcli
 
-go-install-cli:
+go-install-cli-nolit:
 	@$(call print, "Installing all CLI binaries.")
 	$(GOINSTALL) -trimpath -tags="$(LND_RELEASE_TAGS)" -ldflags "$(LDFLAGS)" github.com/lightningnetwork/lnd/cmd/lncli
 	$(GOINSTALL) -trimpath -ldflags "$(LDFLAGS)" github.com/lightninglabs/loop/cmd/loop
 	$(GOINSTALL) -trimpath github.com/lightninglabs/faraday/cmd/frcli
 	$(GOINSTALL) -trimpath -ldflags "$(LDFLAGS)" github.com/lightninglabs/pool/cmd/pool
 	$(GOINSTALL) -trimpath -ldflags "$(LDFLAGS)" github.com/lightninglabs/taproot-assets/cmd/tapcli
+
+go-install-cli: go-install-cli-nolit
+	@$(call print, "Installing litcli binary.")
 	$(GOINSTALL) -trimpath -tags="$(LND_RELEASE_TAGS)" -ldflags "$(LDFLAGS)" $(PKG)/cmd/litcli
+
+go-install-cli-noui: go-install-cli-nolit
+	@$(call print, "Installing litcli binary without UI.")
+	$(GOINSTALL) -trimpath -tags="litd_no_ui $(LND_RELEASE_TAGS)" -ldflags "$(LDFLAGS)" $(PKG)/cmd/litcli
 
 app-build: yarn-install
 	@$(call print, "Building production app.")


### PR DESCRIPTION
We now run `make go-install-noui` and `make go-install-cli-noui` when
the `NO_UI` build arg is set to 1 to skip building of the web UI when
using the development docker container. If the `NO_UI` build arg is not
set, `make go-install` and `make go-install-cli` are run as before the
`NO_UI` build arg existed.

The Makefile also had to be slightly modified to support this feature.

This feature allows quicker rebuilding when using docker if you aren't doing anything with the web UI.