### PR TITLE
[sql-35]: firewalldb+rpcserver: refactor ListActions

### DIFF
--- a/firewalldb/action_paginator.go
+++ b/firewalldb/action_paginator.go
@@ -16,7 +16,7 @@ type actionPaginator struct {
 
 	// filterFn is the filter function which we are using to determine which
 	// actions should be included in the return list.
-	filterFn ListActionsFilterFn
+	filterFn listActionsFilterFn
 
 	// readAction is a closure which we use to read an action from the db
 	// given a key value pair.
@@ -32,7 +32,7 @@ type actionPaginator struct {
 // cfg.CountAll is set).
 func paginateActions(cfg *ListActionsQuery, c kvdb.RCursor,
 	readAction func(k, v []byte) (*Action, error),
-	filterFn ListActionsFilterFn) ([]*Action, uint64, uint64, error) {
+	filterFn listActionsFilterFn) ([]*Action, uint64, uint64, error) {
 
 	if cfg == nil {
 		cfg = &ListActionsQuery{}

--- a/session/interface.go
+++ b/session/interface.go
@@ -14,6 +14,9 @@ import (
 	"gopkg.in/macaroon.v2"
 )
 
+// EmptyID is an empty session ID.
+var EmptyID ID
+
 // Type represents the type of session.
 type Type uint8
 


### PR DESCRIPTION
Here we move the filter logic behind the method so that our sql implementation of ListActions can make use of indexes later on instead of how it is done in the bbolt  where the filters are applied in memory. 

This is quite a big diff in a single commit - so I'm just dedicating this PR to the single commit to help with review load. 
