### PR TITLE
[sql-36] actions: prepare ActionsDB interface

### DIFF
--- a/firewall/request_logger.go
+++ b/firewall/request_logger.go
@@ -53,7 +53,7 @@ type RequestLogger struct {
 	// be used to find the corresponding action. This is used so that
 	// requests and responses can be easily linked. The mu mutex must be
 	// used when accessing this map.
-	reqIDToAction map[uint64]*firewalldb.ActionLocator
+	reqIDToAction map[uint64]firewalldb.ActionLocator
 	mu            sync.Mutex
 }
 
@@ -105,7 +105,7 @@ func NewRequestLogger(cfg *RequestLoggerConfig,
 	return &RequestLogger{
 		shouldLogAction: shouldLogAction,
 		actionsDB:       actionsDB,
-		reqIDToAction:   make(map[uint64]*firewalldb.ActionLocator),
+		reqIDToAction:   make(map[uint64]firewalldb.ActionLocator),
 	}, nil
 }
 
@@ -223,16 +223,13 @@ func (r *RequestLogger) addNewAction(ctx context.Context, ri *RequestInfo,
 		}
 	}
 
-	id, err := r.actionsDB.AddAction(ctx, action)
+	locator, err := r.actionsDB.AddAction(ctx, action)
 	if err != nil {
 		return err
 	}
 
 	r.mu.Lock()
-	r.reqIDToAction[ri.RequestID] = &firewalldb.ActionLocator{
-		SessionID: sessionID,
-		ActionID:  id,
-	}
+	r.reqIDToAction[ri.RequestID] = locator
 	r.mu.Unlock()
 
 	return nil

--- a/firewalldb/actions.go
+++ b/firewalldb/actions.go
@@ -230,7 +230,7 @@ func (db *BoltDB) GetActionsReadDB(groupID session.ID,
 
 // allActionsReadDb is an implementation of the ActionsReadDB.
 type allActionsReadDB struct {
-	db          *BoltDB
+	db          ActionDB
 	groupID     session.ID
 	featureName string
 }

--- a/firewalldb/actions.go
+++ b/firewalldb/actions.go
@@ -181,9 +181,9 @@ func WithActionState(state ActionState) ListActionOption {
 // ActionsWriteDB is an abstraction over the Actions DB that will allow a
 // caller to add new actions as well as change the values of an existing action.
 type ActionsWriteDB interface {
-	AddAction(action *Action) (uint64, error)
-	SetActionState(al *ActionLocator, state ActionState,
-		errReason string) error
+	AddAction(ctx context.Context, action *Action) (uint64, error)
+	SetActionState(ctx context.Context, al *ActionLocator,
+		state ActionState, errReason string) error
 }
 
 // RuleAction represents a method call that was performed at a certain time at

--- a/firewalldb/actions.go
+++ b/firewalldb/actions.go
@@ -181,8 +181,8 @@ func WithActionState(state ActionState) ListActionOption {
 // ActionsWriteDB is an abstraction over the Actions DB that will allow a
 // caller to add new actions as well as change the values of an existing action.
 type ActionsWriteDB interface {
-	AddAction(ctx context.Context, action *Action) (uint64, error)
-	SetActionState(ctx context.Context, al *ActionLocator,
+	AddAction(ctx context.Context, action *Action) (ActionLocator, error)
+	SetActionState(ctx context.Context, al ActionLocator,
 		state ActionState, errReason string) error
 }
 
@@ -318,7 +318,6 @@ func actionToRulesAction(a *Action) *RuleAction {
 }
 
 // ActionLocator helps us find an action in the database.
-type ActionLocator struct {
-	SessionID session.ID
-	ActionID  uint64
+type ActionLocator interface {
+	isActionLocator()
 }

--- a/firewalldb/actions_kvdb.go
+++ b/firewalldb/actions_kvdb.go
@@ -53,7 +53,7 @@ var (
 )
 
 // AddAction serialises and adds an Action to the DB under the given sessionID.
-func (db *BoltDB) AddAction(action *Action) (uint64, error) {
+func (db *BoltDB) AddAction(_ context.Context, action *Action) (uint64, error) {
 	var buf bytes.Buffer
 	if err := SerializeAction(&buf, action); err != nil {
 		return 0, err
@@ -167,8 +167,8 @@ func getAction(actionsBkt *bbolt.Bucket, al *ActionLocator) (*Action, error) {
 
 // SetActionState finds the action specified by the ActionLocator and sets its
 // state to the given state.
-func (db *BoltDB) SetActionState(al *ActionLocator, state ActionState,
-	errorReason string) error {
+func (db *BoltDB) SetActionState(_ context.Context, al *ActionLocator,
+	state ActionState, errorReason string) error {
 
 	if errorReason != "" && state != ActionStateError {
 		return fmt.Errorf("error reason should only be set for " +

--- a/firewalldb/actions_test.go
+++ b/firewalldb/actions_test.go
@@ -66,13 +66,11 @@ func TestActionStorage(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, actions, 0)
 
-	id, err := db.AddAction(ctx, action1)
+	_, err = db.AddAction(ctx, action1)
 	require.NoError(t, err)
-	require.Equal(t, uint64(1), id)
 
-	id, err = db.AddAction(ctx, action2)
+	locator2, err := db.AddAction(ctx, action2)
 	require.NoError(t, err)
-	require.Equal(t, uint64(1), id)
 
 	actions, _, _, err = db.ListActions(
 		ctx, nil,
@@ -91,12 +89,7 @@ func TestActionStorage(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, actions, 0)
 
-	err = db.SetActionState(
-		ctx, &ActionLocator{
-			SessionID: sessionID2,
-			ActionID:  uint64(1),
-		}, ActionStateDone, "",
-	)
+	err = db.SetActionState(ctx, locator2, ActionStateDone, "")
 	require.NoError(t, err)
 
 	actions, _, _, err = db.ListActions(
@@ -109,9 +102,8 @@ func TestActionStorage(t *testing.T) {
 	action2.State = ActionStateDone
 	require.Equal(t, action2, actions[0])
 
-	id, err = db.AddAction(ctx, action1)
+	_, err = db.AddAction(ctx, action1)
 	require.NoError(t, err)
-	require.Equal(t, uint64(2), id)
 
 	// Check that providing no session id and no filter function returns
 	// all the actions.
@@ -124,21 +116,11 @@ func TestActionStorage(t *testing.T) {
 	require.Len(t, actions, 3)
 
 	// Try set an error reason for a non Errored state.
-	err = db.SetActionState(
-		ctx, &ActionLocator{
-			SessionID: sessionID2,
-			ActionID:  uint64(1),
-		}, ActionStateDone, "hello",
-	)
+	err = db.SetActionState(ctx, locator2, ActionStateDone, "hello")
 	require.Error(t, err)
 
 	// Now try move the action to errored with a reason.
-	err = db.SetActionState(
-		ctx, &ActionLocator{
-			SessionID: sessionID2,
-			ActionID:  uint64(1),
-		}, ActionStateError, "fail whale",
-	)
+	err = db.SetActionState(ctx, locator2, ActionStateError, "fail whale")
 	require.NoError(t, err)
 
 	actions, _, _, err = db.ListActions(

--- a/firewalldb/actions_test.go
+++ b/firewalldb/actions_test.go
@@ -66,11 +66,11 @@ func TestActionStorage(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, actions, 0)
 
-	id, err := db.AddAction(action1)
+	id, err := db.AddAction(ctx, action1)
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), id)
 
-	id, err = db.AddAction(action2)
+	id, err = db.AddAction(ctx, action2)
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), id)
 
@@ -92,7 +92,7 @@ func TestActionStorage(t *testing.T) {
 	require.Len(t, actions, 0)
 
 	err = db.SetActionState(
-		&ActionLocator{
+		ctx, &ActionLocator{
 			SessionID: sessionID2,
 			ActionID:  uint64(1),
 		}, ActionStateDone, "",
@@ -109,7 +109,7 @@ func TestActionStorage(t *testing.T) {
 	action2.State = ActionStateDone
 	require.Equal(t, action2, actions[0])
 
-	id, err = db.AddAction(action1)
+	id, err = db.AddAction(ctx, action1)
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), id)
 
@@ -125,7 +125,7 @@ func TestActionStorage(t *testing.T) {
 
 	// Try set an error reason for a non Errored state.
 	err = db.SetActionState(
-		&ActionLocator{
+		ctx, &ActionLocator{
 			SessionID: sessionID2,
 			ActionID:  uint64(1),
 		}, ActionStateDone, "hello",
@@ -134,7 +134,7 @@ func TestActionStorage(t *testing.T) {
 
 	// Now try move the action to errored with a reason.
 	err = db.SetActionState(
-		&ActionLocator{
+		ctx, &ActionLocator{
 			SessionID: sessionID2,
 			ActionID:  uint64(1),
 		}, ActionStateError, "fail whale",
@@ -184,7 +184,7 @@ func TestListActions(t *testing.T) {
 			State:              ActionStateDone,
 		}
 
-		_, err := db.AddAction(action)
+		_, err := db.AddAction(ctx, action)
 		require.NoError(t, err)
 	}
 
@@ -373,7 +373,7 @@ func TestListGroupActions(t *testing.T) {
 	require.Empty(t, al)
 
 	// Add an action under session 1.
-	_, err = db.AddAction(action1)
+	_, err = db.AddAction(ctx, action1)
 	require.NoError(t, err)
 
 	// There should now be one action in the group.
@@ -383,7 +383,7 @@ func TestListGroupActions(t *testing.T) {
 	require.Equal(t, sessionID1, al[0].SessionID)
 
 	// Add an action under session 2.
-	_, err = db.AddAction(action2)
+	_, err = db.AddAction(ctx, action2)
 	require.NoError(t, err)
 
 	// There should now be actions in the group.

--- a/firewalldb/actions_test.go
+++ b/firewalldb/actions_test.go
@@ -79,7 +79,7 @@ func TestActionStorage(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, actions, 1)
-	require.Equal(t, action1, actions[0])
+	assertEqualActions(t, action1, actions[0])
 
 	actions, _, _, err = db.ListActions(
 		ctx, nil,
@@ -100,7 +100,7 @@ func TestActionStorage(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, actions, 1)
 	action2.State = ActionStateDone
-	require.Equal(t, action2, actions[0])
+	assertEqualActions(t, action2, actions[0])
 
 	_, err = db.AddAction(ctx, action1)
 	require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestActionStorage(t *testing.T) {
 	require.Len(t, actions, 1)
 	action2.State = ActionStateError
 	action2.ErrorReason = "fail whale"
-	require.Equal(t, action2, actions[0])
+	assertEqualActions(t, action2, actions[0])
 }
 
 // TestListActions tests some ListAction options.
@@ -374,4 +374,18 @@ func TestListGroupActions(t *testing.T) {
 	require.Len(t, al, 2)
 	require.Equal(t, sessionID1, al[0].SessionID)
 	require.Equal(t, sessionID2, al[1].SessionID)
+}
+
+func assertEqualActions(t *testing.T, expected, got *Action) {
+	expectedAttemptedAt := expected.AttemptedAt
+	actualAttemptedAt := got.AttemptedAt
+
+	expected.AttemptedAt = time.Time{}
+	got.AttemptedAt = time.Time{}
+
+	require.Equal(t, expected, got)
+	require.Equal(t, expectedAttemptedAt.Unix(), actualAttemptedAt.Unix())
+
+	expected.AttemptedAt = expectedAttemptedAt
+	got.AttemptedAt = actualAttemptedAt
 }

--- a/firewalldb/interface.go
+++ b/firewalldb/interface.go
@@ -100,3 +100,27 @@ type PrivacyMapper interface {
 	// given group ID key.
 	PrivacyDB(groupID session.ID) PrivacyMapDB
 }
+
+// ActionDB is an interface that abstracts the database operations needed for
+// the Action persistence and querying.
+type ActionDB interface {
+	// AddAction persists the given action to the database.
+	AddAction(action *Action) (uint64, error)
+
+	// SetActionState finds the action specified by the ActionLocator and
+	// sets its state to the given state.
+	SetActionState(al *ActionLocator, state ActionState,
+		errReason string) error
+
+	// ListActions returns a list of Actions that pass the filterFn
+	// requirements. The query IndexOffset and MaxNum params can be used to
+	// control the number of actions returned. The return values are the
+	// list of actions, the last index and the total count (iff
+	// query.CountTotal is set).
+	ListActions(ctx context.Context, query *ListActionsQuery,
+		options ...ListActionOption) ([]*Action, uint64, uint64, error)
+
+	// GetActionsReadDB produces an ActionReadDB using the given group ID
+	// and feature name.
+	GetActionsReadDB(groupID session.ID, featureName string) ActionsReadDB
+}

--- a/firewalldb/interface.go
+++ b/firewalldb/interface.go
@@ -105,11 +105,11 @@ type PrivacyMapper interface {
 // the Action persistence and querying.
 type ActionDB interface {
 	// AddAction persists the given action to the database.
-	AddAction(ctx context.Context, action *Action) (uint64, error)
+	AddAction(ctx context.Context, action *Action) (ActionLocator, error)
 
 	// SetActionState finds the action specified by the ActionLocator and
 	// sets its state to the given state.
-	SetActionState(ctx context.Context, al *ActionLocator,
+	SetActionState(ctx context.Context, al ActionLocator,
 		state ActionState, errReason string) error
 
 	// ListActions returns a list of Actions that pass the filterFn

--- a/firewalldb/interface.go
+++ b/firewalldb/interface.go
@@ -105,12 +105,12 @@ type PrivacyMapper interface {
 // the Action persistence and querying.
 type ActionDB interface {
 	// AddAction persists the given action to the database.
-	AddAction(action *Action) (uint64, error)
+	AddAction(ctx context.Context, action *Action) (uint64, error)
 
 	// SetActionState finds the action specified by the ActionLocator and
 	// sets its state to the given state.
-	SetActionState(al *ActionLocator, state ActionState,
-		errReason string) error
+	SetActionState(ctx context.Context, al *ActionLocator,
+		state ActionState, errReason string) error
 
 	// ListActions returns a list of Actions that pass the filterFn
 	// requirements. The query IndexOffset and MaxNum params can be used to

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -63,7 +63,7 @@ type sessionRpcServerConfig struct {
 	superMacBaker           litmac.Baker
 	firstConnectionDeadline time.Duration
 	permMgr                 *perms.Manager
-	actionsDB               *firewalldb.BoltDB
+	actionsDB               firewalldb.ActionDB
 	autopilot               autopilotserver.Autopilot
 	ruleMgrs                rules.ManagerSet
 	privMap                 firewalldb.PrivacyMapper

--- a/terminal.go
+++ b/terminal.go
@@ -1118,9 +1118,11 @@ func (g *LightningTerminal) startInternalSubServers(ctx context.Context,
 			g.permsMgr, g.lndClient.NodePubkey,
 			g.lndClient.Router,
 			g.lndClient.Client, g.lndConnID, g.ruleMgrs,
-			func(reqID uint64, reason string) error {
+			func(ctx context.Context, reqID uint64,
+				reason string) error {
+
 				return requestLogger.MarkAction(
-					reqID, firewalldb.ActionStateError,
+					ctx, reqID, firewalldb.ActionStateError,
 					reason,
 				)
 			}, g.stores.firewall,


### PR DESCRIPTION
Here, we add an abstract `ActionsDB` interface that we will later add a SQL implementation for. 

Part of #917 