### PR TITLE
[sql-38] multi: couple sessions and accounts to actions

### DIFF
--- a/config_dev.go
+++ b/config_dev.go
@@ -154,7 +154,8 @@ func NewStores(cfg *Config, clock clock.Clock) (*stores, error) {
 	}
 
 	firewallBoltDB, err := firewalldb.NewBoltDB(
-		networkDir, firewalldb.DBFilename, stores.sessions, clock,
+		networkDir, firewalldb.DBFilename, stores.sessions,
+		stores.accounts, clock,
 	)
 	if err != nil {
 		return stores, fmt.Errorf("error creating firewall BoltDB: %v",

--- a/config_prod.go
+++ b/config_prod.go
@@ -56,7 +56,8 @@ func NewStores(cfg *Config, clock clock.Clock) (*stores, error) {
 	stores.closeFns["sessions"] = sessStore.Close
 
 	firewallDB, err := firewalldb.NewBoltDB(
-		networkDir, firewalldb.DBFilename, sessStore, clock,
+		networkDir, firewalldb.DBFilename, stores.sessions,
+		stores.accounts, clock,
 	)
 	if err != nil {
 		return stores, fmt.Errorf("error creating firewall DB: %v", err)

--- a/firewall/request_info.go
+++ b/firewall/request_info.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/lightninglabs/lightning-terminal/accounts"
 	"github.com/lightninglabs/lightning-terminal/session"
 	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -29,6 +30,7 @@ const (
 // request.
 type RequestInfo struct {
 	SessionID       fn.Option[session.ID]
+	AccountID       fn.Option[accounts.AccountID]
 	MsgID           uint64
 	RequestID       uint64
 	MWRequestType   string
@@ -138,6 +140,12 @@ func NewInfoFromRequest(req *lnrpc.RPCMiddlewareRequest) (*RequestInfo, error) {
 		if IsPrivacyCaveat(ri.Caveats[idx]) {
 			ri.WithPrivacy = true
 		}
+	}
+
+	ri.AccountID, err = accounts.IDFromCaveats(ri.Macaroon.Caveats())
+	if err != nil {
+		return nil, fmt.Errorf("error extracting account ID "+
+			"from macaroon: %v", err)
 	}
 
 	return ri, nil

--- a/firewall/request_logger.go
+++ b/firewall/request_logger.go
@@ -195,6 +195,7 @@ func (r *RequestLogger) addNewAction(ctx context.Context, ri *RequestInfo,
 
 	actionReq := &firewalldb.AddActionReq{
 		SessionID:          ri.SessionID,
+		AccountID:          ri.AccountID,
 		MacaroonIdentifier: macaroonID,
 		RPCMethod:          ri.URI,
 	}

--- a/firewalldb/actions.go
+++ b/firewalldb/actions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/lightninglabs/lightning-terminal/accounts"
 	"github.com/lightninglabs/lightning-terminal/session"
 	"github.com/lightningnetwork/lnd/fn"
 )
@@ -44,6 +45,13 @@ type AddActionReq struct {
 	// populate it by casting the macaroon ID to a session.ID and so is not
 	// guaranteed to be linked to an existing session.
 	SessionID fn.Option[session.ID]
+
+	// AccountID holds the optional account ID of the account that this
+	// action was performed on.
+	//
+	// NOTE: for our BoltDB impl, this is not persisted in any way, and we
+	// do not populate it on reading from disk.
+	AccountID fn.Option[accounts.AccountID]
 
 	// ActorName is the name of the entity who performed the Action.
 	ActorName string

--- a/firewalldb/actions_kvdb.go
+++ b/firewalldb/actions_kvdb.go
@@ -54,8 +54,20 @@ var (
 )
 
 // AddAction serialises and adds an Action to the DB under the given sessionID.
-func (db *BoltDB) AddAction(_ context.Context,
+func (db *BoltDB) AddAction(ctx context.Context,
 	req *AddActionReq) (ActionLocator, error) {
+
+	// If the new action links to a session, the session must exist.
+	// For the bbolt impl of the store, this is our best effort attempt
+	// at ensuring each action links to a session. If the session is
+	// deleted later on, however, then the action will still exist.
+	var err error
+	req.SessionID.WhenSome(func(id session.ID) {
+		_, err = db.sessionIDIndex.GetSession(ctx, id)
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	action := &Action{
 		AddActionReq: *req,
@@ -69,7 +81,7 @@ func (db *BoltDB) AddAction(_ context.Context,
 	}
 
 	var locator kvdbActionLocator
-	err := db.DB.Update(func(tx *bbolt.Tx) error {
+	err = db.DB.Update(func(tx *bbolt.Tx) error {
 		mainActionsBucket, err := getBucket(tx, actionsBucketKey)
 		if err != nil {
 			return err

--- a/firewalldb/interface.go
+++ b/firewalldb/interface.go
@@ -3,6 +3,7 @@ package firewalldb
 import (
 	"context"
 
+	"github.com/lightninglabs/lightning-terminal/accounts"
 	"github.com/lightninglabs/lightning-terminal/session"
 )
 
@@ -13,6 +14,15 @@ type SessionDB interface {
 
 	// GetSession returns the session for a specific id.
 	GetSession(context.Context, session.ID) (*session.Session, error)
+}
+
+// AccountsDB is an interface that abstracts the database operations needed
+// firewalldb to be able to query the accounts database.
+type AccountsDB interface {
+	// Account fetches the Account with the given id from the accounts
+	// database.
+	Account(ctx context.Context,
+		id accounts.AccountID) (*accounts.OffChainBalanceAccount, error)
 }
 
 // DBExecutor provides an Update and View method that will allow the caller

--- a/firewalldb/kvdb_store.go
+++ b/firewalldb/kvdb_store.go
@@ -41,12 +41,13 @@ type BoltDB struct {
 	clock clock.Clock
 
 	sessionIDIndex SessionDB
+	accountsDB     AccountsDB
 }
 
 // NewBoltDB creates a new bolt database that can be found at the given
 // directory.
 func NewBoltDB(dir, fileName string, sessionIDIndex SessionDB,
-	clock clock.Clock) (*BoltDB, error) {
+	accountsDB AccountsDB, clock clock.Clock) (*BoltDB, error) {
 
 	firstInit := false
 	path := filepath.Join(dir, fileName)
@@ -73,6 +74,7 @@ func NewBoltDB(dir, fileName string, sessionIDIndex SessionDB,
 	return &BoltDB{
 		DB:             db,
 		sessionIDIndex: sessionIDIndex,
+		accountsDB:     accountsDB,
 		clock:          clock,
 	}, nil
 }

--- a/firewalldb/kvstores_test.go
+++ b/firewalldb/kvstores_test.go
@@ -469,10 +469,3 @@ func TestKVStoreSessionCoupling(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
-
-func intToSessionID(i uint32) session.ID {
-	var id session.ID
-	byteOrder.PutUint32(id[:], i)
-
-	return id
-}

--- a/firewalldb/test_kvdb.go
+++ b/firewalldb/test_kvdb.go
@@ -5,7 +5,6 @@ package firewalldb
 import (
 	"testing"
 
-	"github.com/lightninglabs/lightning-terminal/session"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/stretchr/testify/require"
 )
@@ -18,21 +17,21 @@ func NewTestDB(t *testing.T, clock clock.Clock) *BoltDB {
 // NewTestDBFromPath is a helper function that creates a new BoltStore with a
 // connection to an existing BBolt database for testing.
 func NewTestDBFromPath(t *testing.T, dbPath string, clock clock.Clock) *BoltDB {
-	return newDBFromPathWithSessions(t, dbPath, nil, clock)
+	return newDBFromPathWithSessions(t, dbPath, nil, nil, clock)
 }
 
 // NewTestDBWithSessions creates a new test BoltDB Store with access to an
 // existing sessions DB.
-func NewTestDBWithSessions(t *testing.T, sessStore session.Store,
+func NewTestDBWithSessions(t *testing.T, sessStore SessionDB,
 	clock clock.Clock) *BoltDB {
 
-	return newDBFromPathWithSessions(t, t.TempDir(), sessStore, clock)
+	return newDBFromPathWithSessions(t, t.TempDir(), sessStore, nil, clock)
 }
 
 func newDBFromPathWithSessions(t *testing.T, dbPath string,
-	sessStore session.Store, clock clock.Clock) *BoltDB {
+	sessStore SessionDB, acctStore AccountsDB, clock clock.Clock) *BoltDB {
 
-	store, err := NewBoltDB(dbPath, DBFilename, sessStore, clock)
+	store, err := NewBoltDB(dbPath, DBFilename, sessStore, acctStore, clock)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
In this PR, we add best effort logic to ensure tight coupling between actions and sessions&accounts at the
time of action creation. This forces us to update our tests to expect certain errors if linked sessions/accounts
do not yet exist at the time of action creation. This sets us up nicely for the SQL impl of the actions DB which will
enforce strict coupling.

Part of #917 
