### PR TITLE
Use sat/msat arguments of `ln addinvoice`

### DIFF
--- a/cmd/litcli/ln.go
+++ b/cmd/litcli/ln.go
@@ -679,12 +679,23 @@ func addInvoice(cli *cli.Context) error {
 
 	var (
 		assetAmount = cli.Uint64("asset_amount")
+		msatAmount  = cli.Int64("amt_msat")
+		satAmount   = cli.Int64("amt")
 		preimage    []byte
 		descHash    []byte
 		err         error
 	)
-	if assetAmount == 0 {
-		return fmt.Errorf("asset_amount argument missing")
+	if assetAmount == 0 && msatAmount == 0 && satAmount == 0 {
+		return fmt.Errorf("must set asset amount or sat/msat amount")
+	}
+
+	if assetAmount != 0 && (msatAmount != 0 || satAmount != 0) {
+		return fmt.Errorf("must only set one of asset amount or " +
+			"sat/msat amount")
+	}
+
+	if msatAmount != 0 && satAmount != 0 {
+		return fmt.Errorf("must only set one of amt or amt_msat")
 	}
 
 	if cli.IsSet("preimage") {
@@ -731,6 +742,8 @@ func addInvoice(cli *cli.Context) error {
 			Memo:            cli.String("memo"),
 			RPreimage:       preimage,
 			DescriptionHash: descHash,
+			Value:           satAmount,
+			ValueMsat:       msatAmount,
 			FallbackAddr:    cli.String("fallback_addr"),
 			Expiry:          expirySeconds,
 			Private:         cli.Bool("private"),

--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -93,6 +93,8 @@
 * All Taproot Asset Channel related commands (`litcli ln ...`) can now [use
   a new `--group_key` flag to interact with grouped asset
   channels](https://github.com/lightninglabs/lightning-terminal/pull/1052).
+* The `litcli ln addinvoice` command now supports adding an invoice with a fixed
+  sat/msat amount.
 
 # Contributors (Alphabetical Order)
 


### PR DESCRIPTION
## Description

Uses the existing LND arguments for sat/msat amount for the `litcli ln addinvoice` command. This new argument exposes the behavior introduced in https://github.com/lightninglabs/taproot-assets/pull/1448

Closes https://github.com/lightninglabs/lightning-terminal/issues/1073