### PR TITLE
GitHub: make Docker build more reliable

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,9 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
+      - name: cleanup space
+        run: rm -rf /opt/hostedtoolcache
+  
       - name: Set up QEMU
         uses: lightninglabs/gh-actions/setup-qemu-action@2021.01.25.00
 
@@ -62,8 +65,11 @@ jobs:
           tags: "${{ env.DOCKER_ORG }}/${{ env.DOCKER_REPO }}:${{ env.IMAGE_TAG }}"
           build-args: checkout=${{ env.RELEASE_VERSION }}
       
-      - name: Clear the build cache
+      - name: Clear the Docker build cache
         run: docker builder prune -a -f
+        
+      - name: Clear the Docker image cache
+        run: docker image prune -a -f
 
       - name: Build and push image with /lit path
         id: docker_build2


### PR DESCRIPTION
Currently the Docker image build regularly fails with "no space left on disk". We try to delete additional files and docker images to try to avoid that error.

Example failure run: https://github.com/lightninglabs/lightning-terminal/actions/runs/15668989025/job/44136975088