### PR TITLE
[sql-55] firewalldb: actions mig handle empty RPCParamsJson

### DIFF
--- a/firewalldb/test_kvdb.go
+++ b/firewalldb/test_kvdb.go
@@ -12,6 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// isSqlite is true if the test_db_sqlite build flag is set.
+var isSqlite = false
+
 // NewTestDB is a helper function that creates an BBolt database for testing.
 func NewTestDB(t *testing.T, clock clock.Clock) FirewallDBs {
 	return NewTestDBFromPath(t, t.TempDir(), clock)

--- a/firewalldb/test_postgres.go
+++ b/firewalldb/test_postgres.go
@@ -9,6 +9,9 @@ import (
 	"github.com/lightningnetwork/lnd/clock"
 )
 
+// isSqlite is true if the test_db_sqlite build flag is set.
+var isSqlite = false
+
 // NewTestDB is a helper function that creates an BBolt database for testing.
 func NewTestDB(t *testing.T, clock clock.Clock) FirewallDBs {
 	return createStore(t, db.NewTestPostgresDB(t).BaseDB, clock)

--- a/firewalldb/test_sqlite.go
+++ b/firewalldb/test_sqlite.go
@@ -9,6 +9,9 @@ import (
 	"github.com/lightningnetwork/lnd/clock"
 )
 
+// isSqlite is true if the test_db_sqlite build flag is set.
+var isSqlite = true
+
 // NewTestDB is a helper function that creates an BBolt database for testing.
 func NewTestDB(t *testing.T, clock clock.Clock) FirewallDBs {
 	return createStore(t, db.NewTestSqliteDB(t).BaseDB, clock)


### PR DESCRIPTION
If there are no RPCParamsJson set for an action, the value is represented differently in KVDB vs SQL.
In the SQL DB, empty RPCParamsJson are represented as `nil`, while they are represented as an empty array in the KVDB version. This PR addresses that issue, by overriding the RPCParamsJson in that scenario, so that they are set to the same representation when a KVDB and an SQL action is compared.