### PR TITLE
build: bump go to v1.24.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ env:
   # If you change this value, please change it in the following files as well:
   # /Dockerfile
   # /dev.Dockerfile
-  GO_VERSION: 1.24.6
+  GO_VERSION: 1.24.8
 
 jobs:
   ########################

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apk add --no-cache --update alpine-sdk \
 
 # The first stage is already done and all static assets should now be generated
 # in the app/build sub directory.
-FROM golang:1.24.6-alpine3.22@sha256:c8c5f95d64aa79b6547f3b626eb84b16a7ce18a139e3e9ca19a8c078b85ba80d as golangbuilder
+FROM golang:1.24.8-alpine3.22@sha256:3d78beb141d98f42337f1252ecf2a5f20374109929a4c3f6817f9e4179cc0ae5 as golangbuilder
 
 # Instead of checking out from git again, we just copy the whole working
 # directory of the previous stage that includes the generated static assets.

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ PUBLIC_URL :=
 # GO_VERSION is the Go version used for the release build, docker files, and
 # GitHub Actions. This is the reference version for the project. All other Go
 # versions are checked against this version.
-GO_VERSION = 1.24.6
+GO_VERSION = 1.24.8
 
 # LITD_COMPAT_VERSIONS is a space-separated list of litd versions that are
 # installed before running the integration tests which include backward

--- a/autopilotserverrpc/go.mod
+++ b/autopilotserverrpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/autopilotserverrpc
 
-go 1.24.6
+go 1.24.8
 
 require (
 	google.golang.org/grpc v1.56.3

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -20,7 +20,7 @@ RUN cd /go/src/github.com/lightninglabs/lightning-terminal/app \
 
 # The first stage is already done and all static assets should now be generated
 # in the app/build sub directory.
-FROM golang:1.24.6-alpine3.22@sha256:c8c5f95d64aa79b6547f3b626eb84b16a7ce18a139e3e9ca19a8c078b85ba80d as golangbuilder
+FROM golang:1.24.8-alpine3.22@sha256:3d78beb141d98f42337f1252ecf2a5f20374109929a4c3f6817f9e4179cc0ae5 as golangbuilder
 
 # Instead of checking out from git again, we just copy the whole working
 # directory of the previous stage that includes the generated static assets.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal
 
-go 1.24.6
+go 1.24.8
 
 require (
 	github.com/btcsuite/btcd v0.24.3-0.20250318170759-4f4ea81776d6

--- a/litrpc/Dockerfile
+++ b/litrpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.6-bookworm@sha256:ab1d1823abb55a9504d2e3e003b75b36dbeb1cbcc4c92593d85a84ee46becc6c
+FROM golang:1.24.8-bookworm@sha256:4ed690d6649d63c312b99a6120025ec79ce3b542968a37da53d6236c7c61a848
 
 RUN apt-get update && apt-get install -y \
   git \

--- a/litrpc/go.mod
+++ b/litrpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/litrpc
 
-go 1.24.6
+go 1.24.8
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.6-bookworm@sha256:ab1d1823abb55a9504d2e3e003b75b36dbeb1cbcc4c92593d85a84ee46becc6c
+FROM golang:1.24.8-bookworm@sha256:4ed690d6649d63c312b99a6120025ec79ce3b542968a37da53d6236c7c61a848
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>
 

--- a/perms/go.mod
+++ b/perms/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/perms
 
-go 1.24.6
+go 1.24.8
 
 require (
 	github.com/btcsuite/btcd v0.24.3-0.20250318170759-4f4ea81776d6

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.6-bookworm@sha256:ab1d1823abb55a9504d2e3e003b75b36dbeb1cbcc4c92593d85a84ee46becc6c
+FROM golang:1.24.8-bookworm@sha256:4ed690d6649d63c312b99a6120025ec79ce3b542968a37da53d6236c7c61a848
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/tools
 
-go 1.24.6
+go 1.24.8
 
 require (
 	github.com/btcsuite/btcd v0.24.2


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/lightning-terminal/issues/1158

I'm not sure if there are any other code changes that should be made to accommodate golang version 1.24.8 and why litd has not yet upgraded but it looks like what I've done is similar to https://github.com/lightninglabs/lightning-terminal/pull/1144/commits/69ca6587b72a6324cf9b9660ebec6804b56936c2 .