### PR TITLE
build: bump go to v1.24.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ env:
   # If you change this value, please change it in the following files as well:
   # /Dockerfile
   # /dev.Dockerfile
-  GO_VERSION: 1.24.6
+  GO_VERSION: 1.24.9
 
 jobs:
   ########################

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apk add --no-cache --update alpine-sdk \
 
 # The first stage is already done and all static assets should now be generated
 # in the app/build sub directory.
-FROM golang:1.24.6-alpine3.22@sha256:c8c5f95d64aa79b6547f3b626eb84b16a7ce18a139e3e9ca19a8c078b85ba80d as golangbuilder
+FROM golang:1.24.9-alpine3.22@sha256:8f8959f38530d159bf71d0b3eb0c547dc61e7959d8225d1599cf762477384923 as golangbuilder
 
 # Instead of checking out from git again, we just copy the whole working
 # directory of the previous stage that includes the generated static assets.

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ PUBLIC_URL :=
 # GO_VERSION is the Go version used for the release build, docker files, and
 # GitHub Actions. This is the reference version for the project. All other Go
 # versions are checked against this version.
-GO_VERSION = 1.24.6
+GO_VERSION = 1.24.9
 
 # LITD_COMPAT_VERSIONS is a space-separated list of litd versions that are
 # installed before running the integration tests which include backward

--- a/autopilotserverrpc/go.mod
+++ b/autopilotserverrpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/autopilotserverrpc
 
-go 1.24.6
+go 1.24.9
 
 require (
 	google.golang.org/grpc v1.56.3

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -20,7 +20,7 @@ RUN cd /go/src/github.com/lightninglabs/lightning-terminal/app \
 
 # The first stage is already done and all static assets should now be generated
 # in the app/build sub directory.
-FROM golang:1.24.6-alpine3.22@sha256:c8c5f95d64aa79b6547f3b626eb84b16a7ce18a139e3e9ca19a8c078b85ba80d as golangbuilder
+FROM golang:1.24.9-alpine3.22@sha256:8f8959f38530d159bf71d0b3eb0c547dc61e7959d8225d1599cf762477384923 as golangbuilder
 
 # Instead of checking out from git again, we just copy the whole working
 # directory of the previous stage that includes the generated static assets.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal
 
-go 1.24.6
+go 1.24.9
 
 require (
 	github.com/btcsuite/btcd v0.24.3-0.20250318170759-4f4ea81776d6

--- a/litrpc/Dockerfile
+++ b/litrpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.6-bookworm@sha256:ab1d1823abb55a9504d2e3e003b75b36dbeb1cbcc4c92593d85a84ee46becc6c
+FROM golang:1.24.9-bookworm@sha256:e400aebe4e96e1d52b510fb7a82c417d9377f595f0160eb1bd979d441711d20c
 
 RUN apt-get update && apt-get install -y \
   git \

--- a/litrpc/go.mod
+++ b/litrpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/litrpc
 
-go 1.24.6
+go 1.24.9
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.6-bookworm@sha256:ab1d1823abb55a9504d2e3e003b75b36dbeb1cbcc4c92593d85a84ee46becc6c
+FROM golang:1.24.9-bookworm@sha256:e400aebe4e96e1d52b510fb7a82c417d9377f595f0160eb1bd979d441711d20c
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>
 

--- a/perms/go.mod
+++ b/perms/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/perms
 
-go 1.24.6
+go 1.24.9
 
 require (
 	github.com/btcsuite/btcd v0.24.3-0.20250318170759-4f4ea81776d6

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.6-bookworm@sha256:ab1d1823abb55a9504d2e3e003b75b36dbeb1cbcc4c92593d85a84ee46becc6c
+FROM golang:1.24.9-bookworm@sha256:e400aebe4e96e1d52b510fb7a82c417d9377f595f0160eb1bd979d441711d20c
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/tools
 
-go 1.24.6
+go 1.24.9
 
 require (
 	github.com/btcsuite/btcd v0.24.2


### PR DESCRIPTION
As of lnd commit https://github.com/lightningnetwork/lnd/commit/4fc8d8dda31c941a2431cfc3b37d402ef70e4d4c, golang version `1.24.9` is required.

I'm not sure if https://github.com/lightninglabs/lightning-terminal/pull/1159 should be closed in favor of this one or if we should merge https://github.com/lightninglabs/lightning-terminal/pull/1159 first and them make a litd RC with lnd version `v0.20.0-beta.rc2` with golang `1.24.8`? Not sure of the differences between these golang versions so someone else with more expertise should weigh in on which PR to use, but both are available to look review and merge at this time.