### PR TITLE
build: add `monitoring` tag for lnd

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -35,7 +35,12 @@ and also added coverage to verify support for channel versioning:
     - https://github.com/lightninglabs/lightning-terminal/pull/1106
     - https://github.com/lightninglabs/lightning-terminal/pull/1097
     - https://github.com/lightninglabs/lightning-terminal/pull/1138
- 
+
+- [LND is now built with the `monitoring` tag enabled](https://github.com/lightninglabs/lightning-terminal/pull/1167)
+  which has been the default
+  in standalone LND release builds since
+  https://github.com/lightningnetwork/lnd/commit/8491d0da433c23051b723f4c018e2f041df548c8
+  .
 
 ### LND
 

--- a/make/compile_flags.mk
+++ b/make/compile_flags.mk
@@ -1,1 +1,1 @@
-COMPILE_TAGS = autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc neutrinorpc peersrpc kvdb_postgres kvdb_etcd kvdb_sqlite
+COMPILE_TAGS = autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc neutrinorpc monitoring peersrpc kvdb_postgres kvdb_etcd kvdb_sqlite


### PR DESCRIPTION
- LND is now built with the `monitoring` tag enabled, which has been the default
  in standalone LND release builds since
  https://github.com/lightningnetwork/lnd/commit/8491d0da433c23051b723f4c018e2f041df548c8