### PR TITLE
dev.Dockerfile: use cache mounts to speed up rebuilding

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -70,7 +70,13 @@ ARG NO_UI
 ARG CGO_ENABLED=1
 
 # Install dependencies and install/build lightning-terminal.
-RUN apk add --no-cache --update alpine-sdk make \
+# Note: When using `docker build`, setting the environmental variable
+# `DOCKER_BUILDKIT=1` is required to enable
+# [BuildKit](https://docs.docker.com/build/buildkit)
+# so that the cache mounts can be used.
+RUN --mount=type=cache,target=/go/pkg/mod \
+  --mount=type=cache,target=/root/.cache/go-build \
+  apk add --no-cache --update alpine-sdk make \
   && cd /go/src/github.com/lightninglabs/lightning-terminal \
   # If a custom lnd version is supplied, force it now.
   && if [ -n "$LND_VERSION" ]; then \

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -17,6 +17,18 @@
 
 ### Functional Changes/Additions
 
+* [`dev.Dockerfile` now uses](https://github.com/lightninglabs/lightning-terminal/pull/1168)
+  [cache mounts](https://docs.docker.com/build/cache/optimize/#use-cache-mounts)
+  to cache the `GOMODCACHE` and `GOCACHE` directories so that dependencies don't
+  need to be re-downloaded and re-built every time the image is re-created.
+  As a result of this change, `dev.Dockerfile` now requires
+  [BuildKit](https://docs.docker.com/build/buildkit) to build. When using
+  `docker build`, this can be enabled by setting the environmental variable
+  `DOCKER_BUILDKIT=1`. BuildKit also does not unnecessarily rebuild images when
+  the build context is a remote git repository because COPY layers are more
+  smartly compared to cache.
+
+
 ### Technical and Architectural Updates
 
 ## RPC Updates


### PR DESCRIPTION
The branch in https://github.com/lightninglabs/lightning-terminal/pull/1161 was accidentally deleted and the PR automatically closed, so this PR re-opens it with a new copy of the branch.


* `dev.Dockerfile` now uses 
  [cache mounts](https://docs.docker.com/build/cache/optimize/#use-cache-mounts)
  to cache the `GOMODCACHE` and `GOCACHE` directories so that dependencies don't
  need to be re-downloaded and re-built every time the image is re-created.
  As a result of this change, `dev.Dockerfile` now requires
  [BuildKit](https://docs.docker.com/build/buildkit) to build. When using
  `docker build`, this can be enabled by setting the environmental variable
  `DOCKER_BUILDKIT=1`. BuildKit also does not unnecessarily rebuild images when
  the build context is a remote git repository because COPY layers are more
  smartly compared to cache.


Would like some feedback on this change. Not sure if it might have some unintended consequences that I have not thought of, but it really speeds things up a lot.

