### PR TITLE
itest: have tapd skip cert verification

### DIFF
--- a/itest/litd_custom_channels_test.go
+++ b/itest/litd_custom_channels_test.go
@@ -90,6 +90,7 @@ var (
 		"--taproot-assets.custodianproofretrievaldelay=500ms",
 	}
 	litdArgsTemplate = append(litdArgsTemplateNoOracle, []string{
+		"--taproot-assets.experimental.rfq.priceoracletlsinsecure",
 		"--taproot-assets.experimental.rfq.priceoracleaddress=" +
 			"use_mock_price_oracle_service_promise_to_" +
 			"not_use_on_mainnet",
@@ -99,6 +100,7 @@ var (
 	}...)
 
 	litdArgsTemplateDiffOracle = append(litdArgsTemplateNoOracle, []string{
+		"--taproot-assets.experimental.rfq.priceoracletlsinsecure",
 		"--taproot-assets.experimental.rfq.priceoracleaddress=" +
 			"use_mock_price_oracle_service_promise_to_" +
 			"not_use_on_mainnet",
@@ -4123,10 +4125,12 @@ func testCustomChannelsOraclePricing(ctx context.Context, net *NetworkHarness,
 
 	lndArgs := slices.Clone(lndArgsTemplate)
 	litdArgs := slices.Clone(litdArgsTemplateNoOracle)
-	litdArgs = append(litdArgs, fmt.Sprintf(
-		"--taproot-assets.experimental.rfq.priceoracleaddress="+
-			"rfqrpc://%s", oracleAddr,
-	))
+	litdArgs = append(litdArgs,
+		"--taproot-assets.experimental.rfq.priceoracletlsinsecure",
+		fmt.Sprintf(
+			"--taproot-assets.experimental.rfq.priceoracleaddress="+
+				"rfqrpc://%s", oracleAddr,
+		))
 
 	// We use Charlie as the proof courier. But in order for Charlie to also
 	// use itself, we need to define its port upfront.
@@ -4970,10 +4974,12 @@ func testCustomChannelsDecodeAssetInvoice(ctx context.Context,
 
 	lndArgs := slices.Clone(lndArgsTemplate)
 	litdArgs := slices.Clone(litdArgsTemplateNoOracle)
-	litdArgs = append(litdArgs, fmt.Sprintf(
-		"--taproot-assets.experimental.rfq.priceoracleaddress="+
-			"rfqrpc://%s", oracleAddr,
-	))
+	litdArgs = append(litdArgs,
+		"--taproot-assets.experimental.rfq.priceoracletlsinsecure",
+		fmt.Sprintf(
+			"--taproot-assets.experimental.rfq.priceoracleaddress="+
+				"rfqrpc://%s", oracleAddr,
+		))
 
 	// We'll just make a single node here, as this doesn't actually rely on
 	// a set of active channels.


### PR DESCRIPTION
(Depends on lightninglabs/taproot-assets#1775.)

The mock oracle uses a self-signed certificate for TLS, but we're not concerned with having tapd verify it in the itest environment. This commit adds the 'experimental.rfq.priceoracletlsinsecure' flag to the litd args list, instructing tapd not to verify certificates.