### PR TITLE
make: fix itest case filter

### DIFF
--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -25,7 +25,7 @@ endif
 
 # Define the integration test.run filter if the icase argument was provided.
 ifneq ($(icase),)
-ITEST_FLAGS += -test.run="TestLightningTerminal/$(icase)"
+ITEST_FLAGS += -test.run="TestLightningTerminal/tranche.*/.*-of-.*/$(icase)"
 endif
 
 # Run itests with specified db backend.


### PR DESCRIPTION
The -test.run pattern was missing the tranche prefix, so terminal and custom_channels tests weren't actually running in CI. The fix simply grafts the pattern used in taproot-assets to ensure the tests are run.