### PR TITLE
itest: fix nil error deref

### DIFF
--- a/itest/litd_node.go
+++ b/itest/litd_node.go
@@ -1514,12 +1514,14 @@ func (hn *HarnessNode) Stop() error {
 	// Close any attempts at further grpc connections.
 	if hn.conn != nil {
 		err := hn.conn.Close()
-		isConnClosingErr := strings.Contains(
-			err.Error(), "connection is closing",
-		)
-		if err != nil && !isConnClosingErr {
-			return fmt.Errorf("error attempting to stop grpc "+
-				"client: %v", err)
+		if err != nil {
+			if !strings.Contains(
+				err.Error(), "connection is closing",
+			) {
+
+				return fmt.Errorf("error attempting to "+
+					"stop grpc client: %v", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Here we fix a nil pointer panic that is caused by an 'err' var being deferenced before first checking that it is not nil. This was caused by an oversite in a refactor commit that was attempting to improve line length.

Panic introduced in: https://github.com/lightninglabs/lightning-terminal/pull/1189/files#diff-62c19b273dec93f7183dca48128ca4e3022a0c9736ffa5cfa47ad9bdfdd59508