### PR TITLE
github: ensure logs are uploaded correctly on error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -313,7 +313,13 @@ jobs:
       - name: Zip log files on failure
         if: ${{ failure() }}
         timeout-minutes: 5
-        run: 7z a logs-itest-${{ matrix.name }}.zip itest/**/*.log
+        # Note that we move the itest logs into a "logs" folder not prefixed by
+        # a dot character (.) to ensure that they dir doesn't appear as a
+        # hidden folder when being downloaded.
+        run: |
+          mkdir -p itest/logs
+          cp -R itest/.logs/. itest/logs/
+          7z a logs-itest-${{ matrix.name }}.zip itest/logs itest/*.log
 
       - name: Upload log files on failure
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Prior to this commit, logs were not correctly uploaded on failure as the logs were being written under itest/.logs, but the workflow zipped only itest/ **/*.log. Because .logs is a hidden directory, the glob doesn’t match it, so 7z creates an empty archive.

We also move the logs to a non-hidden directory when being uploaded to avoid that the logs are downloaded as a hidden directory.

The incorrect behaviour can be seen in:
https://github.com/lightninglabs/lightning-terminal/actions/runs/21231016128?pr=1208

This run includes the fix in this PR, and therefore works as expected:
https://github.com/lightninglabs/lightning-terminal/actions/runs/21358426539?pr=1085