### PR TITLE
workflows/claude: fix PR checkout for fork PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,18 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Checkout PR branch (handles fork PRs)
+        if: github.event.issue.pull_request || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            PR_NUMBER=${{ github.event.issue.number }}
+          else
+            PR_NUMBER=${{ github.event.pull_request.number }}
+          fi
+          gh pr checkout "$PR_NUMBER"
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
When a PR originates from a fork, the PR branch doesn't exist in the origin remote. This adds a step that uses `gh pr checkout` before running the Claude action, which properly handles fork PRs by adding the fork as a remote and fetching the branch from there.

This issue can be seen in:
https://github.com/lightninglabs/lightning-terminal/pull/1215#issuecomment-3840255488