### PR TITLE
dev.Dockerfile: add `BUILD_TAGS` build argument

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -69,6 +69,11 @@ ARG NO_UI
 # to be more clear of the default value.
 ARG CGO_ENABLED=1
 
+# Allow defining a custom set of build tags that override the defaults used
+# by `make`. If not set, the default empty value here causes the defaults
+# to be used.
+ARG BUILD_TAGS=""
+
 # Install dependencies and install/build lightning-terminal.
 # Note: When using `docker build`, setting the environmental variable
 # `DOCKER_BUILDKIT=1` is required to enable
@@ -119,11 +124,11 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     && go mod tidy; \
   fi \
   && if [ "$NO_UI" -eq "1" ]; then \
-    make go-install-noui \
-    && make go-install-cli-noui; \
+    make go-install-noui tags="$BUILD_TAGS"\
+    && make go-install-cli-noui tags="$BUILD_TAGS"; \
   else \
-    make go-install \
-    && make go-install-cli; \
+    make go-install tags="$BUILD_TAGS" \
+    && make go-install-cli tags="$BUILD_TAGS"; \
   fi
 
 # Start a new, final image to reduce size.

--- a/docs/release-notes/release-notes-0.16.2.md
+++ b/docs/release-notes/release-notes-0.16.2.md
@@ -1,0 +1,47 @@
+# Release Notes
+
+- [Lightning Terminal](#lightning-terminal)
+    - [Bug Fixes](#bug-fixes)
+    - [Functional Changes/Additions](#functional-changesadditions)
+    - [Technical and Architectural Updates](#technical-and-architectural-updates)
+- [Integrated Binary Updates](#integrated-binary-updates)
+    - [LND](#lnd)
+    - [Loop](#loop)
+    - [Pool](#pool)
+    - [Faraday](#faraday)
+    - [Taproot Assets](#taproot-assets)
+- [Contributors](#contributors-alphabetical-order)
+
+## Lightning Terminal
+
+### Bug Fixes
+
+### Functional Changes/Additions
+
+* [`dev.Dockerfile` now has](https://github.com/lightninglabs/lightning-terminal/pull/1244)
+  a `BUILD_TAGS` build argument that allows the `tags` passed to `make` to be
+  customized. If defined, the defaults are completely overriden (not added to). 
+  If not defined, the default values are used.
+
+### Technical and Architectural Updates
+
+## RPC Updates
+
+## Integrated Binary Updates
+
+### LND
+
+### Loop
+
+### Pool
+
+### Faraday
+
+### Taproot Assets
+
+
+# Contributors (Alphabetical Order)
+
+* bitromortac
+* Elle Mouton
+* ViktorT-11


### PR DESCRIPTION
- `dev.Dockerfile` now has  a `BUILD_TAGS` build argument that allows the `tags` passed to `make` to be customized. If defined, the defaults are completely overriden (not added to). If not defined, the default values are used.