### PR TITLE
firewall: add interceptor for non-LND calls

### DIFF
--- a/docs/privacy-mapping-flows.md
+++ b/docs/privacy-mapping-flows.md
@@ -1,0 +1,65 @@
+# Privacy Mapping Call Flows
+
+The privacy mapper translates real network identifiers (pubkeys, channel
+IDs, amounts) into pseudonymous values for LNC sessions, so a session
+operator can interact with node data without learning the host's actual
+topology. LiT applies this mapping at two different layers depending on
+which service the request targets; the diagrams below contrast the two
+flows.
+
+## LND Requests (e.g. `/lnrpc.Lightning/GetInfo`)
+
+LND calls are proxied through to LND, which applies privacy mapping via
+its own middleware chain (`PrivacyMapper.Intercept`). The LNC interceptor
+detects LND URIs and passes them through without mapping.
+
+```mermaid
+sequenceDiagram
+    participant C as LNC Client
+    participant S as Session ID Injector
+    participant P as PrivacyMapper.UnaryInterceptor
+    participant R as rpcProxy (auth/routing)
+    participant L as LND
+    participant MW as LND Middleware
+    participant PM as PrivacyMapper.Intercept
+
+    C->>S: gRPC request
+    S->>P: ctx with server-assigned session ID
+    P->>P: isLndURI() → true, skip
+    P->>R: pass through
+    R->>L: proxy to LND
+    L->>MW: middleware intercept
+    MW->>PM: pseudo → real (request)
+    PM-->>L: mapped request
+    L-->>MW: response
+    MW->>PM: real → pseudo (response)
+    PM-->>R: mapped response
+    R-->>C: pseudonymous response
+```
+
+## Sub-daemon Requests (e.g. `/frdrpc.FaradayServer/RevenueReport`)
+
+Non-LND calls are privacy-mapped at the gRPC interceptor level before
+reaching the sub-daemon. The interceptor checks the session's
+`WithPrivacyMapper` flag and applies request/response mapping inline.
+
+```mermaid
+sequenceDiagram
+    participant C as LNC Client
+    participant S as Session ID Injector
+    participant P as PrivacyMapper.UnaryInterceptor
+    participant R as rpcProxy (auth/routing)
+    participant F as Sub-daemon (Faraday)
+
+    C->>S: gRPC request
+    S->>P: ctx with server-assigned session ID
+    P->>P: isLndURI() → false
+    P->>P: check WithPrivacyMapper
+    P->>P: pseudo → real (request)
+    P->>R: mapped request
+    R->>F: forward to sub-daemon
+    F-->>R: response
+    R-->>P: raw response
+    P->>P: real → pseudo (response)
+    P-->>C: pseudonymous response
+```

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -27,6 +27,10 @@
 * The Faraday subserver [is made an active
   component](https://github.com/lightninglabs/lightning-terminal/pull/1251)
   instead of only incorporating its RPC server.
+* A gRPC interceptor [is
+  added](https://github.com/lightninglabs/lightning-terminal/pull/1271) to be
+  able to apply privacy mapping for non-LND sub-daemon requests (e.g. Faraday)
+  within LNC sessions. Non-mapped subservers calls are blocked.
 
 ## RPC Updates
 

--- a/firewall/privacy_mapper.go
+++ b/firewall/privacy_mapper.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	// privacyMapperName is the name of the RequestLogger interceptor.
+	// privacyMapperName is the name of the PrivacyMapper interceptor.
 	privacyMapperName = "lit-privacy-mapper"
 
 	// amountVariation and DefaultTimeVariation are used to set the
@@ -120,7 +120,7 @@ func (p *PrivacyMapper) Intercept(ctx context.Context,
 		return nil, err
 	}
 
-	log.Tracef("PrivacyMapper: Intercepting %v", ri)
+	log.TraceS(ctx, "PrivacyMapper: Intercepting", "info", ri)
 
 	switch r := req.InterceptType.(type) {
 	case *lnrpc.RPCMiddlewareRequest_StreamAuth:

--- a/firewall/privacy_mapper.go
+++ b/firewall/privacy_mapper.go
@@ -415,6 +415,45 @@ func (p *PrivacyMapper) UnaryInterceptor() grpc.UnaryServerInterceptor {
 	}
 }
 
+// StreamServerInterceptor returns a gRPC stream server interceptor that
+// enforces fail-close privacy for non-LND services. LND streaming RPCs are
+// passed through (they use LND's own middleware chain). Non-LND streams are
+// passed through for sessions without privacy mapping, and blocked for
+// privacy-enabled sessions because the privacy mapper does not yet support
+// stream-level request/response rewriting.
+func (p *PrivacyMapper) StreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler) error {
+
+		ctx := ss.Context()
+
+		log.TraceS(ctx, "LNC privacy stream interceptor called",
+			"method", info.FullMethod)
+
+		sess, passThrough, err := p.resolveLNCSession(
+			ctx, info.FullMethod,
+		)
+		if err != nil {
+			return err
+		}
+		if passThrough {
+			return handler(srv, ss)
+		}
+
+		// Fail-close: non-LND streaming RPCs are not yet supported
+		// by the privacy mapper. Block them to prevent cleartext
+		// leaks to LNC sessions with privacy enabled.
+		log.WarnS(ctx, "Blocking non-LND stream: privacy mapping "+
+			"not supported for streams", nil,
+			"method", info.FullMethod,
+			"session_id", sess.ID)
+
+		return status.Errorf(codes.PermissionDenied,
+			"streaming RPCs for non-LND services are not "+
+				"supported with privacy mapping")
+	}
+}
+
 // isLndURI returns true if the URI belongs to LND (uses permissions manager
 // to identify all LND services: lnrpc, routerrpc, signrpc, walletrpc, etc).
 func (p *PrivacyMapper) isLndURI(uri string) (bool, error) {

--- a/firewall/privacy_mapper.go
+++ b/firewall/privacy_mapper.go
@@ -16,7 +16,12 @@ import (
 	"github.com/lightninglabs/lightning-terminal/firewalldb"
 	mid "github.com/lightninglabs/lightning-terminal/rpcmiddleware"
 	"github.com/lightninglabs/lightning-terminal/session"
+	"github.com/lightninglabs/lightning-terminal/subservers"
 	"github.com/lightningnetwork/lnd/lnrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -67,6 +72,15 @@ type PrivacyMapper struct {
 	randIntn      func(int) (int, error)
 	sessionDB     firewalldb.SessionDB
 	timeVariation time.Duration
+	permsMgr      PermissionsManager
+}
+
+// PermissionsManager defines the interface for checking if a URI belongs to a
+// specific sub-server.
+type PermissionsManager interface {
+	// IsSubServerURI returns true if the given URI belongs to the RPC of
+	// the named sub-server.
+	IsSubServerURI(subServer string, uri string) bool
 }
 
 // NewPrivacyMapper returns a new instance of PrivacyMapper. The time variation
@@ -74,7 +88,7 @@ type PrivacyMapper struct {
 // DefaultTimeVariation is used. The randIntn function is used to draw
 // randomness for request field obfuscation.
 func NewPrivacyMapper(newDB firewalldb.PrivacyMapper, randIntn func(int) (int,
-	error), sessionDB firewalldb.SessionDB,
+	error), sessionDB firewalldb.SessionDB, permsMgr PermissionsManager,
 	timeVariation time.Duration) *PrivacyMapper {
 
 	return &PrivacyMapper{
@@ -82,6 +96,7 @@ func NewPrivacyMapper(newDB firewalldb.PrivacyMapper, randIntn func(int) (int,
 		randIntn:      randIntn,
 		sessionDB:     sessionDB,
 		timeVariation: timeVariation,
+		permsMgr:      permsMgr,
 	}
 }
 
@@ -221,6 +236,209 @@ func (p *PrivacyMapper) Intercept(ctx context.Context,
 	default:
 		return mid.RPCErrString(req, "invalid intercept type: %v", r)
 	}
+}
+
+// resolveLNCSession runs the fail-close prelude shared by the LNC unary and
+// stream privacy interceptors. Exactly one of three states is returned:
+//   - (sess, false, nil): privacy mapping must run; sess is fully populated.
+//   - (nil,  true,  nil): caller must pass the call through unmodified
+//     (LND URI, or the session has WithPrivacyMapper=false).
+//   - (nil,  false, err): err is a gRPC status.Error to return to the client.
+func (p *PrivacyMapper) resolveLNCSession(ctx context.Context, method string) (
+	*session.Session, bool, error) {
+
+	// Fail-close: block if permissions manager isn't ready.
+	isLnd, err := p.isLndURI(method)
+	if err != nil {
+		log.ErrorS(ctx, "Permissions manager not initialized, "+
+			"blocking request", err, "method", method)
+
+		return nil, false, status.Errorf(codes.Unavailable,
+			"permissions manager not ready, please retry")
+	}
+
+	// LND URIs are exempted (they use LND's middleware chain).
+	if isLnd {
+		log.TraceS(ctx, "Skipping LNC privacy for LND URI",
+			"method", method)
+
+		return nil, true, nil
+	}
+
+	// Fail-close: block if dependencies aren't ready during startup.
+	if p.sessionDB == nil {
+		log.ErrorS(ctx, "Session DB not initialized, blocking request",
+			nil, "method", method)
+
+		return nil, false, status.Errorf(codes.Unavailable,
+			"session database not ready, please retry")
+	}
+	if p.db == nil {
+		log.ErrorS(ctx, "Privacy DB not initialized, blocking request",
+			nil, "method", method)
+
+		return nil, false, status.Errorf(codes.Unavailable,
+			"privacy database not ready, please retry")
+	}
+
+	// Fail-close: this interceptor runs on the LNC session server, so
+	// every request must carry a session ID. A missing ID is unexpected
+	// and blocked to prevent bypassing privacy mapping.
+	sessionID, err := extractSessionFromContext(ctx)
+	if err != nil {
+		log.ErrorS(ctx, "No session ID on LNC listener, "+
+			"blocking request", err, "method", method)
+
+		return nil, false, status.Errorf(codes.Unauthenticated,
+			"session ID required")
+	}
+
+	sess, err := p.sessionDB.GetSession(ctx, sessionID)
+	if err != nil {
+		log.ErrorS(ctx, "Failed to get session", err,
+			"session_id", sessionID)
+
+		return nil, false, status.Errorf(codes.Internal,
+			"failed to get session")
+	}
+
+	// Pass through if privacy is explicitly disabled for this session.
+	if !sess.WithPrivacyMapper {
+		log.TraceS(ctx, "Privacy disabled for session, passing through",
+			"session_id", sessionID, "method", method)
+
+		return nil, true, nil
+	}
+
+	return sess, false, nil
+}
+
+// UnaryInterceptor returns a gRPC unary server interceptor that applies privacy
+// mapping to LNC session requests for non-LND services. This interceptor
+// enforces fail-close behavior: blocks requests if dependencies aren't ready,
+// returns errors if no privacy checker exists for the URI.
+func (p *PrivacyMapper) UnaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler) (any, error) {
+
+		log.TraceS(ctx, "LNC privacy interceptor called",
+			"method", info.FullMethod)
+
+		sess, passThrough, err := p.resolveLNCSession(
+			ctx, info.FullMethod,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if passThrough {
+			return handler(ctx, req)
+		}
+
+		log.DebugS(ctx, "Applying privacy mapping",
+			"method", info.FullMethod,
+			"session_id", sess.ID)
+
+		// Apply request mapping (pseudo→real). Fail-close: if no
+		// checker exists for the URI, this returns an error to prevent
+		// unauthorized access.
+		reqMsg, ok := req.(proto.Message)
+		if !ok {
+			return nil, status.Errorf(codes.Internal,
+				"request is not a proto.Message, "+
+					"cannot apply privacy mapping")
+		}
+
+		mappedReq, err := p.checkAndReplaceIncomingRequest(
+			ctx, info.FullMethod, reqMsg, sess,
+		)
+		if err != nil {
+			log.ErrorS(ctx, "Privacy mapping request failed", err,
+				"method", info.FullMethod,
+				"session_id", sess.ID)
+
+			return nil, status.Errorf(
+				codes.PermissionDenied,
+				"privacy mapping failed")
+		}
+
+		// Per the rpcmiddleware round-trip-checker convention, a nil
+		// mapped request means "no rewrite needed, forward the
+		// original". Same semantics on the response side and on the
+		// LND-side Intercept.
+		if mappedReq != nil {
+			req = mappedReq
+			log.DebugS(ctx, "Request privacy applied",
+				"method", info.FullMethod,
+				"session_id", sess.ID)
+		}
+
+		// Call handler with real values.
+		resp, err := handler(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+
+		// Apply response mapping (real→pseudo). Fail-close: if no
+		// checker exists for the URI, this returns an error to avoid
+		// accidental leaks.
+		respMsg, ok := resp.(proto.Message)
+		if !ok {
+			return nil, status.Errorf(codes.Internal,
+				"response is not a proto.Message, "+
+					"cannot apply privacy mapping")
+		}
+
+		mappedResp, err := p.replaceOutgoingResponse(
+			ctx, info.FullMethod, respMsg, sess,
+		)
+		if err != nil {
+			log.ErrorS(ctx, "Privacy mapping response failed", err,
+				"method", info.FullMethod,
+				"session_id", sess.ID)
+
+			return nil, status.Errorf(
+				codes.PermissionDenied,
+				"privacy mapping failed")
+		}
+
+		// Per the rpcmiddleware round-trip-checker convention, a nil
+		// mapped response means "no rewrite needed, forward the
+		// original".
+		if mappedResp != nil {
+			resp = mappedResp
+			log.DebugS(ctx, "Response privacy applied",
+				"method", info.FullMethod,
+				"session_id", sess.ID)
+		}
+
+		return resp, nil
+	}
+}
+
+// isLndURI returns true if the URI belongs to LND (uses permissions manager
+// to identify all LND services: lnrpc, routerrpc, signrpc, walletrpc, etc).
+func (p *PrivacyMapper) isLndURI(uri string) (bool, error) {
+	if p.permsMgr == nil {
+		return false, fmt.Errorf("permissions manager not initialized")
+	}
+	return p.permsMgr.IsSubServerURI(subservers.LND, uri), nil
+}
+
+// extractSessionFromContext extracts the session ID from gRPC metadata.
+func extractSessionFromContext(ctx context.Context) (session.ID, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return session.ID{}, fmt.Errorf("no metadata in context")
+	}
+
+	sessionIDOpt, err := session.FromGRPCMetadata(md)
+	if err != nil {
+		return session.ID{}, err
+	}
+
+	return sessionIDOpt.UnwrapOrErr(
+		fmt.Errorf("no session ID in metadata"),
+	)
 }
 
 // checkAndReplaceIncomingRequest inspects an incoming request and optionally

--- a/firewall/privacy_mapper.go
+++ b/firewall/privacy_mapper.go
@@ -122,6 +122,26 @@ func (p *PrivacyMapper) Intercept(ctx context.Context,
 
 	log.TraceS(ctx, "PrivacyMapper: Intercepting", "info", ri)
 
+	// loadSession fetches the session for the current intercept call. It
+	// is only needed for request/non-error-response branches, so we defer
+	// the DB read until we know we'll use it. Failures are reported as a
+	// per-request rejection (mid.RPCErr) rather than a raw error, so that
+	// a transient DB hiccup does not tear down LND's middleware stream.
+	loadSession := func() (*session.Session, *lnrpc.RPCMiddlewareResponse,
+		error) {
+
+		sess, err := p.sessionDB.GetSession(ctx, sessionID)
+		if err != nil {
+			rejection, rerr := mid.RPCErr(req, fmt.Errorf(
+				"error fetching session %x: %w",
+				sessionID, err,
+			))
+			return nil, rejection, rerr
+		}
+
+		return sess, nil, nil
+	}
+
 	switch r := req.InterceptType.(type) {
 	case *lnrpc.RPCMiddlewareRequest_StreamAuth:
 		return mid.RPCErr(req, fmt.Errorf("streams unsupported"))
@@ -136,8 +156,13 @@ func (p *PrivacyMapper) Intercept(ctx context.Context,
 				err)
 		}
 
+		sess, rejection, rerr := loadSession()
+		if rerr != nil || rejection != nil {
+			return rejection, rerr
+		}
+
 		replacement, err := p.checkAndReplaceIncomingRequest(
-			ctx, r.Request.MethodFullUri, msg, sessionID,
+			ctx, r.Request.MethodFullUri, msg, sess,
 		)
 		if err != nil {
 			return mid.RPCErr(req, err)
@@ -170,8 +195,13 @@ func (p *PrivacyMapper) Intercept(ctx context.Context,
 				err)
 		}
 
+		sess, rejection, rerr := loadSession()
+		if rerr != nil || rejection != nil {
+			return rejection, rerr
+		}
+
 		replacement, err := p.replaceOutgoingResponse(
-			ctx, r.Response.MethodFullUri, msg, sessionID,
+			ctx, r.Response.MethodFullUri, msg, sess,
 		)
 		if err != nil {
 			return mid.RPCErr(req, err)
@@ -196,19 +226,14 @@ func (p *PrivacyMapper) Intercept(ctx context.Context,
 // checkAndReplaceIncomingRequest inspects an incoming request and optionally
 // modifies some of the request parameters.
 func (p *PrivacyMapper) checkAndReplaceIncomingRequest(ctx context.Context,
-	uri string, req proto.Message, sessionID session.ID) (proto.Message,
+	uri string, req proto.Message, sess *session.Session) (proto.Message,
 	error) {
 
-	session, err := p.sessionDB.GetSession(ctx, sessionID)
-	if err != nil {
-		return nil, err
-	}
-
-	db := p.db.PrivacyDB(session.GroupID)
+	db := p.db.PrivacyDB(sess.GroupID)
 
 	// If we don't have a handler for the URI, we don't allow the request
 	// to go through.
-	checker, ok := p.checkers(db, session.PrivacyFlags)[uri]
+	checker, ok := p.checkers(db, sess.PrivacyFlags)[uri]
 	if !ok {
 		return nil, ErrNotSupportedByPrivacyMapper
 	}
@@ -227,18 +252,13 @@ func (p *PrivacyMapper) checkAndReplaceIncomingRequest(ctx context.Context,
 // replaceOutgoingResponse inspects the responses before sending them out to the
 // client and replaces them if needed.
 func (p *PrivacyMapper) replaceOutgoingResponse(ctx context.Context, uri string,
-	resp proto.Message, sessionID session.ID) (proto.Message, error) {
+	resp proto.Message, sess *session.Session) (proto.Message, error) {
 
-	session, err := p.sessionDB.GetSession(ctx, sessionID)
-	if err != nil {
-		return nil, err
-	}
-
-	db := p.db.PrivacyDB(session.GroupID)
+	db := p.db.PrivacyDB(sess.GroupID)
 
 	// If we don't have a handler for the URI, we don't allow the response
 	// to go to avoid accidental leaks.
-	checker, ok := p.checkers(db, session.PrivacyFlags)[uri]
+	checker, ok := p.checkers(db, sess.PrivacyFlags)[uri]
 	if !ok {
 		return nil, ErrNotSupportedByPrivacyMapper
 	}

--- a/firewall/privacy_mapper_test.go
+++ b/firewall/privacy_mapper_test.go
@@ -1812,3 +1812,214 @@ func TestUnaryInterceptor(t *testing.T) {
 		})
 	}
 }
+
+// mockServerStream is a minimal mock of grpc.ServerStream for testing.
+type mockServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (m *mockServerStream) Context() context.Context {
+	return m.ctx
+}
+
+// TestStreamServerInterceptor tests the StreamServerInterceptor method of
+// PrivacyMapper. LND streams pass through, non-LND streams pass through for
+// non-private sessions, and non-LND streams are blocked for private sessions.
+func TestStreamServerInterceptor(t *testing.T) {
+	t.Parallel()
+
+	sessionID := session.ID{1, 2, 3, 4}
+	lndURI := "/lnrpc.Lightning/SubscribeChannelEvents"
+	faradayURI := "/frdrpc.FaradayServer/SomeStream"
+
+	ctxWithSession := func() context.Context {
+		md := make(metadata.MD)
+		session.AddToGRPCMetadata(md, sessionID)
+		return metadata.NewIncomingContext(
+			context.Background(), md,
+		)
+	}
+
+	tests := []struct {
+		name              string
+		setupMapper       func() *PrivacyMapper
+		setupStream       func() grpc.ServerStream
+		uri               string
+		expectError       bool
+		expectErrorCode   string
+		expectPassThrough bool
+	}{
+		{
+			name: "permissions manager not initialized",
+			setupMapper: func() *PrivacyMapper {
+				return &PrivacyMapper{
+					permsMgr: nil,
+				}
+			},
+			setupStream: func() grpc.ServerStream {
+				return &mockServerStream{
+					ctx: context.Background(),
+				}
+			},
+			uri:             faradayURI,
+			expectError:     true,
+			expectErrorCode: "Unavailable",
+		},
+		{
+			name: "LND stream passes through",
+			setupMapper: func() *PrivacyMapper {
+				mock := newMockPermissionsManager()
+				mock.uriToSubServer[lndURI] = subservers.LND
+				return &PrivacyMapper{
+					permsMgr: mock,
+				}
+			},
+			setupStream: func() grpc.ServerStream {
+				return &mockServerStream{
+					ctx: context.Background(),
+				}
+			},
+			uri:               lndURI,
+			expectPassThrough: true,
+		},
+		{
+			name: "session DB not initialized",
+			setupMapper: func() *PrivacyMapper {
+				return &PrivacyMapper{
+					permsMgr:  newMockPermissionsManager(),
+					sessionDB: nil,
+				}
+			},
+			setupStream: func() grpc.ServerStream {
+				return &mockServerStream{
+					ctx: context.Background(),
+				}
+			},
+			uri:             faradayURI,
+			expectError:     true,
+			expectErrorCode: "Unavailable",
+		},
+		{
+			name: "privacy DB not initialized",
+			setupMapper: func() *PrivacyMapper {
+				pd := firewalldb.NewMockSessionDB()
+				return &PrivacyMapper{
+					permsMgr:  newMockPermissionsManager(),
+					sessionDB: pd,
+					db:        nil,
+				}
+			},
+			setupStream: func() grpc.ServerStream {
+				return &mockServerStream{
+					ctx: context.Background(),
+				}
+			},
+			uri:             faradayURI,
+			expectError:     true,
+			expectErrorCode: "Unavailable",
+		},
+		{
+			name: "no session in context blocked",
+			setupMapper: func() *PrivacyMapper {
+				pd := firewalldb.NewMockSessionDB()
+				db := newMockDB(t, nil, sessionID)
+				return &PrivacyMapper{
+					permsMgr:  newMockPermissionsManager(),
+					sessionDB: pd,
+					db:        db,
+				}
+			},
+			setupStream: func() grpc.ServerStream {
+				return &mockServerStream{
+					ctx: context.Background(),
+				}
+			},
+			uri:             faradayURI,
+			expectError:     true,
+			expectErrorCode: "Unauthenticated",
+		},
+		{
+			name: "non-private session passes through",
+			setupMapper: func() *PrivacyMapper {
+				pd := firewalldb.NewMockSessionDB()
+				pd.AddPair(sessionID, sessionID)
+				pd.SetWithPrivacyMapper(sessionID, false)
+				db := newMockDB(t, nil, sessionID)
+				return &PrivacyMapper{
+					permsMgr:  newMockPermissionsManager(),
+					sessionDB: pd,
+					db:        db,
+				}
+			},
+			setupStream: func() grpc.ServerStream {
+				return &mockServerStream{
+					ctx: ctxWithSession(),
+				}
+			},
+			uri:               faradayURI,
+			expectPassThrough: true,
+		},
+		{
+			name: "private session non-LND stream blocked",
+			setupMapper: func() *PrivacyMapper {
+				pd := firewalldb.NewMockSessionDB()
+				pd.AddPair(sessionID, sessionID)
+				err := pd.AddPrivacyFlags(
+					sessionID, session.PrivacyFlags{},
+				)
+				require.NoError(t, err)
+				db := newMockDB(t, nil, sessionID)
+				return &PrivacyMapper{
+					permsMgr:  newMockPermissionsManager(),
+					sessionDB: pd,
+					db:        db,
+				}
+			},
+			setupStream: func() grpc.ServerStream {
+				return &mockServerStream{
+					ctx: ctxWithSession(),
+				}
+			},
+			uri:             faradayURI,
+			expectError:     true,
+			expectErrorCode: "PermissionDenied",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mapper := tt.setupMapper()
+			ss := tt.setupStream()
+
+			handlerCalled := false
+			mockHandler := func(srv any,
+				stream grpc.ServerStream) error {
+
+				handlerCalled = true
+				return nil
+			}
+
+			info := &grpc.StreamServerInfo{
+				FullMethod: tt.uri,
+			}
+
+			interceptor := mapper.StreamServerInterceptor()
+			err := interceptor(nil, ss, info, mockHandler)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(
+					t, err.Error(), tt.expectErrorCode,
+				)
+				require.False(t, handlerCalled)
+			} else if tt.expectPassThrough {
+				require.NoError(t, err)
+				require.True(t, handlerCalled)
+			}
+		})
+	}
+}

--- a/firewall/privacy_mapper_test.go
+++ b/firewall/privacy_mapper_test.go
@@ -8,11 +8,14 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/faraday/frdrpc"
 	"github.com/lightninglabs/lightning-terminal/firewalldb"
 	"github.com/lightninglabs/lightning-terminal/session"
+	"github.com/lightninglabs/lightning-terminal/subservers"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/rpcperms"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 	"gopkg.in/macaroon-bakery.v2/bakery"
@@ -921,7 +924,8 @@ func TestPrivacyMapper(t *testing.T) {
 			// randIntn is used for deterministic testing.
 			randIntn := func(n int) (int, error) { return 100, nil }
 			p := NewPrivacyMapper(
-				db, randIntn, pd, DefaultTimeVariation,
+				db, randIntn, pd, newMockPermissionsManager(),
+				DefaultTimeVariation,
 			)
 
 			rawMsg, err := proto.Marshal(test.msg)
@@ -1003,7 +1007,8 @@ func TestPrivacyMapper(t *testing.T) {
 		require.NoError(t, err)
 
 		p := NewPrivacyMapper(
-			db, CryptoRandIntn, pd, DefaultTimeVariation,
+			db, CryptoRandIntn, pd, newMockPermissionsManager(),
+			DefaultTimeVariation,
 		)
 		require.NoError(t, err)
 
@@ -1608,4 +1613,202 @@ func variance(numbers []uint64) uint64 {
 	}
 
 	return uint64(sum)
+}
+
+// mockPermissionsManager is a mock implementation of PermissionsManager for
+// testing. It allows flexible configuration of which URIs belong to which
+// subservers.
+type mockPermissionsManager struct {
+	// uriToSubServer maps URIs to their subserver name. If a URI is not
+	// in this map, IsSubServerURI will return false.
+	uriToSubServer map[string]string
+}
+
+// newMockPermissionsManager creates a new mock with common test URIs.
+func newMockPermissionsManager() *mockPermissionsManager {
+	return &mockPermissionsManager{
+		//nolint:ll
+		uriToSubServer: map[string]string{
+			"/lnrpc.Lightning/GetInfo":            subservers.LND,
+			"/lnrpc.Lightning/ListChannels":       subservers.LND,
+			"/routerrpc.Router/SendPaymentV2":     subservers.LND,
+			"/frdrpc.FaradayServer/RevenueReport": subservers.FARADAY,
+		},
+	}
+}
+
+func (m *mockPermissionsManager) IsSubServerURI(subServer string,
+	uri string) bool {
+
+	if m.uriToSubServer == nil {
+		return false
+	}
+	return m.uriToSubServer[uri] == subServer
+}
+
+// TestUnaryInterceptor tests the UnaryInterceptor method of PrivacyMapper. This
+// test focuses on the interceptor's routing logic, fail-close behavior, and
+// session handling.
+func TestUnaryInterceptor(t *testing.T) {
+	t.Parallel()
+
+	sessionID := session.ID{1, 2, 3, 4}
+	testURI := "/frdrpc.FaradayServer/RevenueReport"
+	lndURI := "/lnrpc.Lightning/GetInfo"
+
+	tests := []struct {
+		name              string
+		setupMapper       func() *PrivacyMapper
+		setupContext      func() context.Context
+		uri               string
+		expectError       bool
+		expectErrorCode   string
+		expectPassThrough bool
+	}{
+		{
+			name: "permissions manager not initialized",
+			setupMapper: func() *PrivacyMapper {
+				return &PrivacyMapper{
+					permsMgr: nil,
+				}
+			},
+			setupContext: func() context.Context {
+				return context.Background()
+			},
+			uri:             testURI,
+			expectError:     true,
+			expectErrorCode: "Unavailable",
+		},
+		{
+			name: "LND URI passes through",
+			setupMapper: func() *PrivacyMapper {
+				return &PrivacyMapper{
+					permsMgr: newMockPermissionsManager(),
+				}
+			},
+			setupContext: func() context.Context {
+				return context.Background()
+			},
+			uri:               lndURI,
+			expectPassThrough: true,
+		},
+		{
+			name: "session DB not initialized",
+			setupMapper: func() *PrivacyMapper {
+				return &PrivacyMapper{
+					permsMgr:  newMockPermissionsManager(),
+					sessionDB: nil,
+				}
+			},
+			setupContext: func() context.Context {
+				return context.Background()
+			},
+			uri:             testURI,
+			expectError:     true,
+			expectErrorCode: "Unavailable",
+		},
+		{
+			name: "privacy DB not initialized",
+			setupMapper: func() *PrivacyMapper {
+				pd := firewalldb.NewMockSessionDB()
+				return &PrivacyMapper{
+					permsMgr:  newMockPermissionsManager(),
+					sessionDB: pd,
+					db:        nil,
+				}
+			},
+			setupContext: func() context.Context {
+				return context.Background()
+			},
+			uri:             testURI,
+			expectError:     true,
+			expectErrorCode: "Unavailable",
+		},
+		{
+			name: "no session in context blocked",
+			setupMapper: func() *PrivacyMapper {
+				pd := firewalldb.NewMockSessionDB()
+				db := newMockDB(t, nil, sessionID)
+				return &PrivacyMapper{
+					permsMgr:  newMockPermissionsManager(),
+					sessionDB: pd,
+					db:        db,
+				}
+			},
+			setupContext: func() context.Context {
+				return context.Background()
+			},
+			uri:             testURI,
+			expectError:     true,
+			expectErrorCode: "Unauthenticated",
+		},
+		{
+			name: "unsupported URI returns error (fail-close)",
+			setupMapper: func() *PrivacyMapper {
+				pd := firewalldb.NewMockSessionDB()
+				pd.AddPair(sessionID, sessionID)
+				err := pd.AddPrivacyFlags(
+					sessionID, session.PrivacyFlags{},
+				)
+				require.NoError(t, err)
+
+				db := newMockDB(t, nil, sessionID)
+				randIntn := func(n int) (int, error) {
+					return 100, nil
+				}
+				return NewPrivacyMapper(
+					db, randIntn, pd,
+					newMockPermissionsManager(),
+					DefaultTimeVariation,
+				)
+			},
+			setupContext: func() context.Context {
+				md := make(metadata.MD)
+				session.AddToGRPCMetadata(md, sessionID)
+				return metadata.NewIncomingContext(
+					context.Background(), md,
+				)
+			},
+			uri:             testURI,
+			expectError:     true,
+			expectErrorCode: "PermissionDenied",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mapper := tt.setupMapper()
+			ctx := tt.setupContext()
+
+			handlerCalled := false
+			mockHandler := func(ctx context.Context,
+				req any) (any, error) {
+
+				handlerCalled = true
+				return &frdrpc.RevenueReportResponse{}, nil
+			}
+
+			info := &grpc.UnaryServerInfo{FullMethod: tt.uri}
+			req := &frdrpc.RevenueReportRequest{}
+
+			interceptor := mapper.UnaryInterceptor()
+			resp, err := interceptor(
+				ctx, req, info, mockHandler,
+			)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(
+					t, err.Error(), tt.expectErrorCode,
+				)
+				require.False(t, handlerCalled)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				require.True(t, handlerCalled)
+			}
+		})
+	}
 }

--- a/firewalldb/mock.go
+++ b/firewalldb/mock.go
@@ -11,6 +11,7 @@ type mockSessionDB struct {
 	sessionToGroupID  map[session.ID]session.ID
 	groupToSessionIDs map[session.ID][]session.ID
 	privacyFlags      map[session.ID]session.PrivacyFlags
+	withPrivacy       map[session.ID]bool
 }
 
 var _ SessionDB = (*mockSessionDB)(nil)
@@ -21,6 +22,7 @@ func NewMockSessionDB() *mockSessionDB {
 		sessionToGroupID:  make(map[session.ID]session.ID),
 		groupToSessionIDs: make(map[session.ID][]session.ID),
 		privacyFlags:      make(map[session.ID]session.PrivacyFlags),
+		withPrivacy:       make(map[session.ID]bool),
 	}
 }
 
@@ -67,18 +69,27 @@ func (m *mockSessionDB) GetSession(_ context.Context,
 		return nil, fmt.Errorf("no session found for session ID")
 	}
 
-	f, ok := m.privacyFlags[id]
-	if !ok {
-		return nil, fmt.Errorf("no privacy flags found for session ID")
+	f := m.privacyFlags[id]
+
+	// Default to true for backward compatibility with existing
+	// tests that don't explicitly set this.
+	privacy := true
+	if v, ok := m.withPrivacy[id]; ok {
+		privacy = v
 	}
 
 	return &session.Session{
-		GroupID:      s,
-		PrivacyFlags: f,
-		// We always set this to true to make sure the privacy mapper is
-		// on in tests.
-		WithPrivacyMapper: true,
+		GroupID:           s,
+		PrivacyFlags:      f,
+		WithPrivacyMapper: privacy,
 	}, nil
+}
+
+// SetWithPrivacyMapper sets the WithPrivacyMapper flag for a session.
+func (m *mockSessionDB) SetWithPrivacyMapper(sessionID session.ID,
+	enabled bool) {
+
+	m.withPrivacy[sessionID] = enabled
 }
 
 // AddPrivacyFlags is a helper that adds privacy flags to the mock session db.

--- a/firewalldb/mock.go
+++ b/firewalldb/mock.go
@@ -72,7 +72,13 @@ func (m *mockSessionDB) GetSession(_ context.Context,
 		return nil, fmt.Errorf("no privacy flags found for session ID")
 	}
 
-	return &session.Session{GroupID: s, PrivacyFlags: f}, nil
+	return &session.Session{
+		GroupID:      s,
+		PrivacyFlags: f,
+		// We always set this to true to make sure the privacy mapper is
+		// on in tests.
+		WithPrivacyMapper: true,
+	}, nil
 }
 
 // AddPrivacyFlags is a helper that adds privacy flags to the mock session db.

--- a/terminal.go
+++ b/terminal.go
@@ -1089,6 +1089,11 @@ func (g *LightningTerminal) startInternalSubServers(ctx context.Context,
 		g.rpcProxy.UnaryServerInterceptor,
 	}
 
+	lncStreamInterceptors := []grpc.StreamServerInterceptor{
+		privacyMapper.StreamServerInterceptor(),
+		g.rpcProxy.StreamServerInterceptor,
+	}
+
 	sessionCfg := &sessionRpcServerConfig{
 		db:        g.stores.sessions,
 		basicAuth: g.rpcProxy.basicAuth,
@@ -1096,7 +1101,7 @@ func (g *LightningTerminal) startInternalSubServers(ctx context.Context,
 			// nolint:staticcheck,
 			grpc.CustomCodec(grpcProxy.Codec()),
 			grpc.ChainStreamInterceptor(
-				g.rpcProxy.StreamServerInterceptor,
+				lncStreamInterceptors...,
 			),
 			grpc.ChainUnaryInterceptor(lncUnaryInterceptors...),
 			grpc.UnknownServiceHandler(

--- a/terminal.go
+++ b/terminal.go
@@ -1071,6 +1071,24 @@ func (g *LightningTerminal) startInternalSubServers(ctx context.Context,
 
 	log.Infof("Starting LiT session server")
 
+	// Privacy mapper for LNC sessions. The unary interceptor translates
+	// pseudonymous identifiers to real values for calls to non-LND
+	// sub-daemons (Faraday, Loop, Pool, Taproot Assets); LND calls are
+	// handled separately via LND's own middleware chain
+	// (PrivacyMapper.Intercept). The stream interceptor passes through
+	// LND streams and blocks non-LND streams (fail-close until stream
+	// privacy mapping is implemented). Both run before auth/routing.
+	privacyMapper := firewall.NewPrivacyMapper(
+		g.stores.firewall, firewall.CryptoRandIntn,
+		g.stores.sessions, g.permsMgr,
+		g.cfg.PrivacyTimestampVariation,
+	)
+
+	lncUnaryInterceptors := []grpc.UnaryServerInterceptor{
+		privacyMapper.UnaryInterceptor(),
+		g.rpcProxy.UnaryServerInterceptor,
+	}
+
 	sessionCfg := &sessionRpcServerConfig{
 		db:        g.stores.sessions,
 		basicAuth: g.rpcProxy.basicAuth,
@@ -1080,9 +1098,7 @@ func (g *LightningTerminal) startInternalSubServers(ctx context.Context,
 			grpc.ChainStreamInterceptor(
 				g.rpcProxy.StreamServerInterceptor,
 			),
-			grpc.ChainUnaryInterceptor(
-				g.rpcProxy.UnaryServerInterceptor,
-			),
+			grpc.ChainUnaryInterceptor(lncUnaryInterceptors...),
 			grpc.UnknownServiceHandler(
 				grpcProxy.TransparentHandler(
 					// Don't allow calls to litrpc.
@@ -1150,11 +1166,6 @@ func (g *LightningTerminal) startInternalSubServers(ctx context.Context,
 	} else {
 		closeAccountService()
 	}
-
-	privacyMapper := firewall.NewPrivacyMapper(
-		g.stores.firewall, firewall.CryptoRandIntn,
-		g.stores.sessions, g.cfg.PrivacyTimestampVariation,
-	)
 
 	mw := []mid.RequestInterceptor{
 		privacyMapper,


### PR DESCRIPTION
Adds a gRPC unary interceptor to LNC sessions that applies privacy mapping to non-LND sub-daemon calls (e.g. Faraday). LND URIs are skipped since they're already handled by LND's middleware chain.

I added a diagram to see how the two flows work for lnd/subdaemon calls:
https://github.com/bitromortac/lightning-terminal/blob/eee3d033fff0f808ec5aa3119721fb5d3fd95c9c/docs/privacy-mapping-flows.md

If the design is ok, I can also use a streaming interceptor.