### PR TITLE
account: add option to rename account

### DIFF
--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -242,11 +242,11 @@ type Store interface {
 	// Accounts retrieves all accounts from the store and un-marshals them.
 	Accounts(ctx context.Context) ([]*OffChainBalanceAccount, error)
 
-	// UpdateAccountBalanceAndExpiry updates the balance and/or expiry of an
-	// account.
-	UpdateAccountBalanceAndExpiry(ctx context.Context, id AccountID,
+	// UpdateAccount updates the balance, expiry and/or label of an account.
+	UpdateAccount(ctx context.Context, id AccountID,
 		newBalance fn.Option[int64],
-		newExpiry fn.Option[time.Time]) error
+		newExpiry fn.Option[time.Time],
+		newLabel fn.Option[string]) error
 
 	// AddAccountInvoice adds an invoice hash to an account.
 	AddAccountInvoice(ctx context.Context, id AccountID,

--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -442,3 +442,18 @@ func WithErrIfUnknown() UpsertPaymentOption {
 		o.errIfUnknown = true
 	}
 }
+
+// First, ensure that if a label is set, it can't be
+// mistaken for a hex encoded account ID.
+func checkLabel(label string) error {
+	if len(label) == hex.EncodedLen(AccountIDLen) {
+		_, err := hex.DecodeString(label)
+		if err == nil {
+			return fmt.Errorf("the label '%s'"+
+				" is not allowed as it "+
+				"can be mistaken for an account ID", label)
+		}
+	}
+
+	return nil
+}

--- a/accounts/interface.go
+++ b/accounts/interface.go
@@ -449,8 +449,8 @@ func checkLabel(label string) error {
 	if len(label) == hex.EncodedLen(AccountIDLen) {
 		_, err := hex.DecodeString(label)
 		if err == nil {
-			return fmt.Errorf("the label '%s'"+
-				" is not allowed as it "+
+			return fmt.Errorf("the label '%s' "+
+				"is not allowed as it "+
 				"can be mistaken for an account ID", label)
 		}
 	}

--- a/accounts/rpcserver.go
+++ b/accounts/rpcserver.go
@@ -122,8 +122,9 @@ func (s *RPCServer) CreateAccount(ctx context.Context,
 func (s *RPCServer) UpdateAccount(ctx context.Context,
 	req *litrpc.UpdateAccountRequest) (*litrpc.Account, error) {
 
-	log.Infof("[updateaccount] id=%s, label=%v, balance=%d, expiration=%d",
-		req.Id, req.Label, req.AccountBalance, req.ExpirationDate)
+	log.Infof("[updateaccount] id=%s, label=%v, balance=%d, "+
+		"expiration=%d, new_label=%v", req.Id, req.Label,
+		req.AccountBalance, req.ExpirationDate, req.NewLabel)
 
 	accountID, err := s.findAccount(ctx, req.Id, req.Label)
 	if err != nil {
@@ -133,7 +134,7 @@ func (s *RPCServer) UpdateAccount(ctx context.Context,
 	// Ask the service to update the account.
 	account, err := s.service.UpdateAccount(
 		ctx, accountID, btcutil.Amount(req.AccountBalance),
-		req.ExpirationDate,
+		req.ExpirationDate, req.NewLabel,
 	)
 	if err != nil {
 		return nil, err

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -301,7 +301,8 @@ func (s *InterceptorService) NewAccount(ctx context.Context,
 // if it exists.
 func (s *InterceptorService) UpdateAccount(ctx context.Context,
 	accountID AccountID, accountBalance btcutil.Amount,
-	expirationDate int64) (*OffChainBalanceAccount, error) {
+	expirationDate int64, newLabel string) (*OffChainBalanceAccount,
+	error) {
 
 	s.Lock()
 	defer s.Unlock()
@@ -334,9 +335,17 @@ func (s *InterceptorService) UpdateAccount(ctx context.Context,
 		balance = fn.Some(int64(accountBalance) * 1000)
 	}
 
+	// If a new label was provided, wrap it in an option. An empty
+	// string is treated as "no update requested" because protobuf
+	// cannot distinguish an absent field from the zero value "".
+	var label fn.Option[string]
+	if newLabel != "" {
+		label = fn.Some(newLabel)
+	}
+
 	// Create the actual account in the macaroon account store.
-	err := s.store.UpdateAccountBalanceAndExpiry(
-		ctx, accountID, balance, expiry,
+	err := s.store.UpdateAccount(
+		ctx, accountID, balance, expiry, label,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to update account: %w", err)

--- a/accounts/sql_migration_test.go
+++ b/accounts/sql_migration_test.go
@@ -134,9 +134,10 @@ func TestAccountStoreMigration(t *testing.T) {
 				require.NoError(t, err)
 				require.False(t, acct1.HasExpired())
 
-				err = kvStore.UpdateAccountBalanceAndExpiry(
+				err = kvStore.UpdateAccount(
 					ctx, acct1.ID, fn.None[int64](),
 					fn.Some(time.Now().Add(time.Minute)),
+					fn.None[string](),
 				)
 				require.NoError(t, err)
 			},

--- a/accounts/store_kvdb.go
+++ b/accounts/store_kvdb.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"math"
 	"os"
@@ -123,16 +122,12 @@ func (s *BoltStore) NewAccount(ctx context.Context, balance lnwire.MilliSatoshi,
 
 	// If a label is set, it must be unique, as we use it to identify the
 	// account in some of the RPCs. It also can't be mistaken for a hex
-	// encoded account ID to avoid confusion and make it easier for the CLI
-	// to distinguish between the two.
-	if len(label) > 0 {
-		if _, err := hex.DecodeString(label); err == nil &&
-			len(label) == hex.EncodedLen(AccountIDLen) {
+	// encoded account ID.
+	if err := checkLabel(label); err != nil {
+		return nil, err
+	}
 
-			return nil, fmt.Errorf("the label '%s' is not allowed "+
-				"as it can be mistaken for an account ID",
-				label)
-		}
+	if len(label) > 0 {
 
 		accounts, err := s.Accounts(ctx)
 		if err != nil {

--- a/accounts/store_kvdb.go
+++ b/accounts/store_kvdb.go
@@ -128,7 +128,6 @@ func (s *BoltStore) NewAccount(ctx context.Context, balance lnwire.MilliSatoshi,
 	}
 
 	if len(label) > 0 {
-
 		accounts, err := s.Accounts(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error checking label "+
@@ -181,13 +180,54 @@ func (s *BoltStore) NewAccount(ctx context.Context, balance lnwire.MilliSatoshi,
 	return account, nil
 }
 
-// UpdateAccountBalanceAndExpiry updates the balance and/or expiry of an
-// account.
+// UpdateAccount updates the balance and/or expiration date of an existing
+// off-chain account.
 //
 // NOTE: This is part of the Store interface.
-func (s *BoltStore) UpdateAccountBalanceAndExpiry(_ context.Context,
+func (s *BoltStore) UpdateAccount(ctx context.Context,
 	id AccountID, newBalance fn.Option[int64],
-	newExpiry fn.Option[time.Time]) error {
+	newExpiry fn.Option[time.Time],
+	newLabel fn.Option[string]) error {
+
+	// If a new label is set, we need to check for its uniqueness. Since the
+	// check requires a read transaction, we must do it before we start the
+	// update transaction.
+	var labelErr error
+	newLabel.WhenSome(func(label string) {
+		if err := checkLabel(label); err != nil {
+			labelErr = err
+			return
+		}
+
+		if len(label) > 0 {
+			accounts, err := s.Accounts(ctx)
+			if err != nil {
+				labelErr = fmt.Errorf("error checking label "+
+					"uniqueness: %w", err)
+				return
+			}
+
+			for _, other := range accounts {
+				if other.ID == id {
+					continue
+				}
+
+				if other.Label == label {
+					labelErr = fmt.Errorf(
+						"an account with the "+
+							"label '%s' "+
+							"already "+
+							"exists: %w",
+						label,
+						ErrLabelAlreadyExists)
+					return
+				}
+			}
+		}
+	})
+	if labelErr != nil {
+		return labelErr
+	}
 
 	update := func(account *OffChainBalanceAccount) error {
 		newBalance.WhenSome(func(balance int64) {
@@ -195,6 +235,9 @@ func (s *BoltStore) UpdateAccountBalanceAndExpiry(_ context.Context,
 		})
 		newExpiry.WhenSome(func(expiry time.Time) {
 			account.ExpirationDate = expiry
+		})
+		newLabel.WhenSome(func(label string) {
+			account.Label = label
 		})
 
 		return nil

--- a/accounts/store_sql.go
+++ b/accounts/store_sql.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"database/sql"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"time"
@@ -102,17 +101,13 @@ func (s *SQLStore) NewAccount(ctx context.Context, balance lnwire.MilliSatoshi,
 	error) {
 
 	// Ensure that if a label is set, it can't be mistaken for a hex
-	// encoded account ID to avoid confusion and make it easier for the CLI
-	// to distinguish between the two.
+	// encoded account ID.
+	if err := checkLabel(label); err != nil {
+		return nil, err
+	}
+
 	var labelVal sql.NullString
 	if len(label) > 0 {
-		if _, err := hex.DecodeString(label); err == nil &&
-			len(label) == hex.EncodedLen(AccountIDLen) {
-
-			return nil, fmt.Errorf("the label '%s' is not allowed "+
-				"as it can be mistaken for an account ID",
-				label)
-		}
 
 		labelVal = sql.NullString{
 			String: label,

--- a/accounts/store_sql.go
+++ b/accounts/store_sql.go
@@ -51,6 +51,7 @@ type SQLQueries interface {
 	// UpdateAccountAliasForTests is a query intended only for testing
 	// purposes, to change the account alias.
 	UpdateAccountAliasForTests(ctx context.Context, arg sqlc.UpdateAccountAliasForTestsParams) (int64, error)
+	UpdateAccountLabel(ctx context.Context, arg sqlc.UpdateAccountLabelParams) (int64, error)
 	UpsertAccountPayment(ctx context.Context, arg sqlc.UpsertAccountPaymentParams) error
 	GetAccountInvoice(ctx context.Context, arg sqlc.GetAccountInvoiceParams) (sqlc.AccountInvoice, error)
 }
@@ -108,7 +109,6 @@ func (s *SQLStore) NewAccount(ctx context.Context, balance lnwire.MilliSatoshi,
 
 	var labelVal sql.NullString
 	if len(label) > 0 {
-
 		labelVal = sql.NullString{
 			String: label,
 			Valid:  true,
@@ -335,13 +335,14 @@ func (s *SQLStore) markAccountUpdated(ctx context.Context,
 	return err
 }
 
-// UpdateAccountBalanceAndExpiry updates the balance and/or expiry of an
-// account.
+// UpdateAccount updates the balance and/or expiration date of an existing
+// off-chain account.
 //
 // NOTE: This is part of the Store interface.
-func (s *SQLStore) UpdateAccountBalanceAndExpiry(ctx context.Context,
+func (s *SQLStore) UpdateAccount(ctx context.Context,
 	alias AccountID, newBalance fn.Option[int64],
-	newExpiry fn.Option[time.Time]) error {
+	newExpiry fn.Option[time.Time],
+	newLabel fn.Option[string]) error {
 
 	var writeTxOpts db.QueriesTxOptions
 	return s.db.ExecTx(ctx, &writeTxOpts, func(db SQLQueries) error {
@@ -367,6 +368,52 @@ func (s *SQLStore) UpdateAccountBalanceAndExpiry(ctx context.Context,
 				ctx, sqlc.UpdateAccountExpiryParams{
 					ID:         id,
 					Expiration: t.UTC(),
+				},
+			)
+		})
+		if err != nil {
+			return err
+		}
+
+		newLabel.WhenSome(func(label string) {
+			// First, ensure that if a label is set, it can't be
+			// mistaken for a hex encoded account ID.
+			if err = checkLabel(label); err != nil {
+				return
+			}
+
+			var labelVal sql.NullString
+			if len(label) > 0 {
+				labelVal = sql.NullString{
+					String: label,
+					Valid:  true,
+				}
+
+				// Check label uniqueness.
+				dbAcct, getErr := db.GetAccountByLabel(
+					ctx, labelVal,
+				)
+				if getErr == nil {
+					// If the label
+					// is already set for another
+					// account, then we return an error.
+					if dbAcct.ID != id {
+						err = ErrLabelAlreadyExists
+						return
+					}
+				} else if !errors.Is(getErr, sql.ErrNoRows) {
+					err = getErr
+					return
+				}
+			}
+
+			_, err = db.UpdateAccountLabel(
+				ctx, sqlc.UpdateAccountLabelParams{
+					ID: id,
+					Label: sql.NullString{
+						String: label,
+						Valid:  label != "",
+					},
 				},
 			)
 		})

--- a/accounts/store_test.go
+++ b/accounts/store_test.go
@@ -2,9 +2,10 @@ package accounts
 
 import (
 	"context"
-	"github.com/lightningnetwork/lnd/lnwire"
 	"testing"
 	"time"
+
+	"github.com/lightningnetwork/lnd/lnwire"
 
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/fn"
@@ -39,13 +40,19 @@ func TestAccountStore(t *testing.T) {
 	_, err = store.NewAccount(ctx, 123, time.Time{}, "0011223344556677")
 	require.ErrorContains(t, err, "is not allowed as it can be mistaken")
 
+	// Make sure we can create an account with an empty label.
+	acctEmpty, err := store.NewAccount(ctx, 0, time.Time{}, "")
+	require.NoError(t, err)
+	require.Empty(t, acctEmpty.Label)
+
 	now := clock.Now()
 
 	// Update all values of the account that we can modify.
 	//
 	// Update the balance and expiry.
-	err = store.UpdateAccountBalanceAndExpiry(
+	err = store.UpdateAccount(
 		ctx, acct1.ID, fn.Some(int64(-500)), fn.Some(now),
+		fn.None[string](),
 	)
 	require.NoError(t, err)
 
@@ -128,14 +135,14 @@ func TestAccountStore(t *testing.T) {
 	// Test listing and deleting accounts.
 	accounts, err := store.Accounts(ctx)
 	require.NoError(t, err)
-	require.Len(t, accounts, 1)
+	require.Len(t, accounts, 2)
 
 	err = store.RemoveAccount(ctx, acct1.ID)
 	require.NoError(t, err)
 
 	accounts, err = store.Accounts(ctx)
 	require.NoError(t, err)
-	require.Len(t, accounts, 0)
+	require.Len(t, accounts, 1)
 
 	_, err = store.Account(ctx, acct1.ID)
 	require.ErrorIs(t, err, ErrAccNotFound)
@@ -174,15 +181,15 @@ func TestAccountUpdateMethods(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	t.Run("UpdateAccountBalanceAndExpiry", func(t *testing.T) {
+	t.Run("UpdateAccount", func(t *testing.T) {
 		clock := clock.NewTestClock(time.Now())
 		store := NewTestDB(t, clock)
 
 		// Ensure that the function errors out if we try update an
 		// account that does not exist.
-		err := store.UpdateAccountBalanceAndExpiry(
+		err := store.UpdateAccount(
 			ctx, AccountID{}, fn.None[int64](),
-			fn.None[time.Time](),
+			fn.None[time.Time](), fn.None[string](),
 		)
 		require.ErrorIs(t, err, ErrAccNotFound)
 
@@ -206,16 +213,18 @@ func TestAccountUpdateMethods(t *testing.T) {
 
 		// Now, update just the balance of the account.
 		newBalance := int64(123)
-		err = store.UpdateAccountBalanceAndExpiry(
+		err = store.UpdateAccount(
 			ctx, acct.ID, fn.Some(newBalance), fn.None[time.Time](),
+			fn.None[string](),
 		)
 		require.NoError(t, err)
 		assertBalanceAndExpiry(newBalance, time.Time{})
 
 		// Now update just the expiry of the account.
 		newExpiry := clock.Now().Add(time.Hour)
-		err = store.UpdateAccountBalanceAndExpiry(
+		err = store.UpdateAccount(
 			ctx, acct.ID, fn.None[int64](), fn.Some(newExpiry),
+			fn.None[string](),
 		)
 		require.NoError(t, err)
 		assertBalanceAndExpiry(newBalance, newExpiry)
@@ -223,19 +232,107 @@ func TestAccountUpdateMethods(t *testing.T) {
 		// Update both the balance and expiry of the account.
 		newBalance = 456
 		newExpiry = clock.Now().Add(2 * time.Hour)
-		err = store.UpdateAccountBalanceAndExpiry(
+		err = store.UpdateAccount(
 			ctx, acct.ID, fn.Some(newBalance), fn.Some(newExpiry),
+			fn.None[string](),
 		)
 		require.NoError(t, err)
 		assertBalanceAndExpiry(newBalance, newExpiry)
 
 		// Finally, test an update that has no net changes to the
 		// balance or expiry.
-		err = store.UpdateAccountBalanceAndExpiry(
+		err = store.UpdateAccount(
 			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.None[string](),
 		)
 		require.NoError(t, err)
 		assertBalanceAndExpiry(newBalance, newExpiry)
+
+		// Test renaming the account.
+		newLabel := "bar"
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some(newLabel),
+		)
+		require.NoError(t, err)
+
+		dbAcct, err := store.Account(ctx, acct.ID)
+		require.NoError(t, err)
+		require.Equal(t, newLabel, dbAcct.Label)
+
+		// Test updating an account with its existing label doesn't fail
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some(newLabel),
+		)
+		require.NoError(t, err)
+		require.Equal(t, newLabel, dbAcct.Label)
+
+		// Try to rename to an existing label.
+		_, err = store.NewAccount(ctx, 0, time.Time{}, "existing")
+		require.NoError(t, err)
+
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some("existing"),
+		)
+		require.ErrorIs(t, err, ErrLabelAlreadyExists)
+
+		// Test that passing an empty Some("") label works and clears
+		// the label.
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some(""),
+		)
+		require.NoError(t, err)
+		dbAcct, err = store.Account(ctx, acct.ID)
+		require.NoError(t, err)
+		require.Empty(t, dbAcct.Label)
+
+		// Test that passing a None label doesn't change anything.
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some("new-label"),
+		)
+		require.NoError(t, err)
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.None[string](),
+		)
+		require.NoError(t, err)
+		dbAcct, err = store.Account(ctx, acct.ID)
+		require.NoError(t, err)
+		require.Equal(t, "new-label", dbAcct.Label)
+
+		// Test that we cannot update to a label that looks like an
+		// account ID.
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some("0011223344556677"),
+		)
+		require.ErrorContains(t, err, "is not allowed"+
+			" as it can be mistaken")
+
+		// Test that a hex string with a different length is allowed.
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some("00112233445566"),
+		)
+		require.NoError(t, err)
+
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some("001122334455667788"),
+		)
+		require.NoError(t, err)
+
+		// Test that a non-hex string with the same length as an account
+		// ID is allowed.
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some("G011223344556677"),
+		)
+		require.NoError(t, err)
 	})
 
 	t.Run("AddAccountInvoice", func(t *testing.T) {

--- a/accounts/store_test.go
+++ b/accounts/store_test.go
@@ -40,13 +40,19 @@ func TestAccountStore(t *testing.T) {
 	_, err = store.NewAccount(ctx, 123, time.Time{}, "0011223344556677")
 	require.ErrorContains(t, err, "is not allowed as it can be mistaken")
 
+	// Make sure we can create an account with an empty label.
+	acctEmpty, err := store.NewAccount(ctx, 0, time.Time{}, "")
+	require.NoError(t, err)
+	require.Empty(t, acctEmpty.Label)
+
 	now := clock.Now()
 
 	// Update all values of the account that we can modify.
 	//
 	// Update the balance and expiry.
-	err = store.UpdateAccountBalanceAndExpiry(
+	err = store.UpdateAccount(
 		ctx, acct1.ID, fn.Some(int64(-500)), fn.Some(now),
+		fn.None[string](),
 	)
 	require.NoError(t, err)
 
@@ -129,14 +135,14 @@ func TestAccountStore(t *testing.T) {
 	// Test listing and deleting accounts.
 	accounts, err := store.Accounts(ctx)
 	require.NoError(t, err)
-	require.Len(t, accounts, 1)
+	require.Len(t, accounts, 2)
 
 	err = store.RemoveAccount(ctx, acct1.ID)
 	require.NoError(t, err)
 
 	accounts, err = store.Accounts(ctx)
 	require.NoError(t, err)
-	require.Len(t, accounts, 0)
+	require.Len(t, accounts, 1)
 
 	_, err = store.Account(ctx, acct1.ID)
 	require.ErrorIs(t, err, ErrAccNotFound)
@@ -277,15 +283,15 @@ func TestAccountUpdateMethods(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	t.Run("UpdateAccountBalanceAndExpiry", func(t *testing.T) {
+	t.Run("UpdateAccount", func(t *testing.T) {
 		clock := clock.NewTestClock(time.Now())
 		store := NewTestDB(t, clock)
 
 		// Ensure that the function errors out if we try update an
 		// account that does not exist.
-		err := store.UpdateAccountBalanceAndExpiry(
+		err := store.UpdateAccount(
 			ctx, AccountID{}, fn.None[int64](),
-			fn.None[time.Time](),
+			fn.None[time.Time](), fn.None[string](),
 		)
 		require.ErrorIs(t, err, ErrAccNotFound)
 
@@ -309,16 +315,18 @@ func TestAccountUpdateMethods(t *testing.T) {
 
 		// Now, update just the balance of the account.
 		newBalance := int64(123)
-		err = store.UpdateAccountBalanceAndExpiry(
+		err = store.UpdateAccount(
 			ctx, acct.ID, fn.Some(newBalance), fn.None[time.Time](),
+			fn.None[string](),
 		)
 		require.NoError(t, err)
 		assertBalanceAndExpiry(newBalance, time.Time{})
 
 		// Now update just the expiry of the account.
 		newExpiry := clock.Now().Add(time.Hour)
-		err = store.UpdateAccountBalanceAndExpiry(
+		err = store.UpdateAccount(
 			ctx, acct.ID, fn.None[int64](), fn.Some(newExpiry),
+			fn.None[string](),
 		)
 		require.NoError(t, err)
 		assertBalanceAndExpiry(newBalance, newExpiry)
@@ -326,19 +334,107 @@ func TestAccountUpdateMethods(t *testing.T) {
 		// Update both the balance and expiry of the account.
 		newBalance = 456
 		newExpiry = clock.Now().Add(2 * time.Hour)
-		err = store.UpdateAccountBalanceAndExpiry(
+		err = store.UpdateAccount(
 			ctx, acct.ID, fn.Some(newBalance), fn.Some(newExpiry),
+			fn.None[string](),
 		)
 		require.NoError(t, err)
 		assertBalanceAndExpiry(newBalance, newExpiry)
 
 		// Finally, test an update that has no net changes to the
 		// balance or expiry.
-		err = store.UpdateAccountBalanceAndExpiry(
+		err = store.UpdateAccount(
 			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.None[string](),
 		)
 		require.NoError(t, err)
 		assertBalanceAndExpiry(newBalance, newExpiry)
+
+		// Test renaming the account.
+		newLabel := "bar"
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some(newLabel),
+		)
+		require.NoError(t, err)
+
+		dbAcct, err := store.Account(ctx, acct.ID)
+		require.NoError(t, err)
+		require.Equal(t, newLabel, dbAcct.Label)
+
+		// Test updating an account with its existing label doesn't fail
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some(newLabel),
+		)
+		require.NoError(t, err)
+		require.Equal(t, newLabel, dbAcct.Label)
+
+		// Try to rename to an existing label.
+		_, err = store.NewAccount(ctx, 0, time.Time{}, "existing")
+		require.NoError(t, err)
+
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some("existing"),
+		)
+		require.ErrorIs(t, err, ErrLabelAlreadyExists)
+
+		// Test that passing an empty Some("") label works and clears
+		// the label.
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some(""),
+		)
+		require.NoError(t, err)
+		dbAcct, err = store.Account(ctx, acct.ID)
+		require.NoError(t, err)
+		require.Empty(t, dbAcct.Label)
+
+		// Test that passing a None label doesn't change anything.
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some("new-label"),
+		)
+		require.NoError(t, err)
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.None[string](),
+		)
+		require.NoError(t, err)
+		dbAcct, err = store.Account(ctx, acct.ID)
+		require.NoError(t, err)
+		require.Equal(t, "new-label", dbAcct.Label)
+
+		// Test that we cannot update to a label that looks like an
+		// account ID.
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some("0011223344556677"),
+		)
+		require.ErrorContains(t, err, "is not allowed"+
+			" as it can be mistaken")
+
+		// Test that a hex string with a different length is allowed.
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some("00112233445566"),
+		)
+		require.NoError(t, err)
+
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some("001122334455667788"),
+		)
+		require.NoError(t, err)
+
+		// Test that a non-hex string with the same length as an account
+		// ID is allowed.
+		err = store.UpdateAccount(
+			ctx, acct.ID, fn.None[int64](), fn.None[time.Time](),
+			fn.Some("G011223344556677"),
+		)
+		require.NoError(t, err)
 	})
 
 	t.Run("AddAccountInvoice", func(t *testing.T) {

--- a/app/src/types/generated/lit-accounts_pb.d.ts
+++ b/app/src/types/generated/lit-accounts_pb.d.ts
@@ -176,6 +176,9 @@ export class UpdateAccountRequest extends jspb.Message {
   getLabel(): string;
   setLabel(value: string): void;
 
+  getNewLabel(): string;
+  setNewLabel(value: string): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): UpdateAccountRequest.AsObject;
   static toObject(includeInstance: boolean, msg: UpdateAccountRequest): UpdateAccountRequest.AsObject;
@@ -192,6 +195,7 @@ export namespace UpdateAccountRequest {
     accountBalance: string,
     expirationDate: string,
     label: string,
+    newLabel: string,
   }
 }
 

--- a/app/src/types/generated/lit-accounts_pb.js
+++ b/app/src/types/generated/lit-accounts_pb.js
@@ -1568,7 +1568,8 @@ proto.litrpc.UpdateAccountRequest.toObject = function(includeInstance, msg) {
     id: jspb.Message.getFieldWithDefault(msg, 1, ""),
     accountBalance: jspb.Message.getFieldWithDefault(msg, 2, "0"),
     expirationDate: jspb.Message.getFieldWithDefault(msg, 3, "0"),
-    label: jspb.Message.getFieldWithDefault(msg, 4, "")
+    label: jspb.Message.getFieldWithDefault(msg, 4, ""),
+    newLabel: jspb.Message.getFieldWithDefault(msg, 5, "")
   };
 
   if (includeInstance) {
@@ -1620,6 +1621,10 @@ proto.litrpc.UpdateAccountRequest.deserializeBinaryFromReader = function(msg, re
     case 4:
       var value = /** @type {string} */ (reader.readString());
       msg.setLabel(value);
+      break;
+    case 5:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setNewLabel(value);
       break;
     default:
       reader.skipField();
@@ -1675,6 +1680,13 @@ proto.litrpc.UpdateAccountRequest.serializeBinaryToWriter = function(message, wr
   if (f.length > 0) {
     writer.writeString(
       4,
+      f
+    );
+  }
+  f = message.getNewLabel();
+  if (f.length > 0) {
+    writer.writeString(
+      5,
       f
     );
   }
@@ -1750,6 +1762,24 @@ proto.litrpc.UpdateAccountRequest.prototype.getLabel = function() {
  */
 proto.litrpc.UpdateAccountRequest.prototype.setLabel = function(value) {
   return jspb.Message.setProto3StringField(this, 4, value);
+};
+
+
+/**
+ * optional string new_label = 5;
+ * @return {string}
+ */
+proto.litrpc.UpdateAccountRequest.prototype.getNewLabel = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 5, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.litrpc.UpdateAccountRequest} returns this
+ */
+proto.litrpc.UpdateAccountRequest.prototype.setNewLabel = function(value) {
+  return jspb.Message.setProto3StringField(this, 5, value);
 };
 
 

--- a/cmd/litcli/accounts.go
+++ b/cmd/litcli/accounts.go
@@ -146,18 +146,25 @@ var updateAccountCommand = cli.Command{
 	Name:      "update",
 	ShortName: "u",
 	Usage:     "Update an existing off-chain account.",
-	ArgsUsage: "[id | label] new_balance [new_expiration_date] " +
-		"[--save_to=]",
+	ArgsUsage: "[id | label] [new_balance] [new_expiration_date] " +
+		"[--new_label=]",
 	Description: "Updates an existing off-chain account and sets " +
-		"either a new balance or new expiration date or both.",
+		"a new balance, new expiration date or a new label.",
 	Flags: []cli.Flag{
 		cli.StringFlag{
-			Name:  idName,
-			Usage: "The ID of the account to update.",
+			Name: idName,
+			Usage: "The ID of the account to update. Either the " +
+				"ID or the label must be set.",
 		},
 		cli.StringFlag{
-			Name:  labelName,
-			Usage: "(optional) The unique label of the account.",
+			Name: labelName,
+			Usage: "(optional) The unique label of the account " +
+				"to identify it; if an account has no label, " +
+				"the ID must be used instead.",
+		},
+		cli.StringFlag{
+			Name:  "new_label",
+			Usage: "(optional) The new label of the account.",
 		},
 		cli.Int64Flag{
 			Name: "new_balance",
@@ -229,6 +236,7 @@ func updateAccount(cli *cli.Context) error {
 		Label:          label,
 		AccountBalance: newBalance,
 		ExpirationDate: expirationDate,
+		NewLabel:       cli.String("new_label"),
 	}
 	resp, err := client.UpdateAccount(ctx, req)
 	if err != nil {

--- a/cmd/litcli/accounts.go
+++ b/cmd/litcli/accounts.go
@@ -146,10 +146,10 @@ var updateAccountCommand = cli.Command{
 	Name:      "update",
 	ShortName: "u",
 	Usage:     "Update an existing off-chain account.",
-	ArgsUsage: "[id | label] [new_balance] [new_expiration_date] " +
-		"[--new_label=]",
+	ArgsUsage: "[id | label] new_balance new_expiration_date",
 	Description: "Updates an existing off-chain account and sets " +
-		"a new balance, new expiration date or a new label.",
+		"a new balance, new expiration date and " +
+		"optionally a new label.",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: idName,

--- a/db/sqlc/accounts.sql.go
+++ b/db/sqlc/accounts.sql.go
@@ -371,6 +371,25 @@ func (q *Queries) UpdateAccountExpiry(ctx context.Context, arg UpdateAccountExpi
 	return id, err
 }
 
+const updateAccountLabel = `-- name: UpdateAccountLabel :one
+UPDATE accounts
+SET label = $1
+WHERE id = $2
+RETURNING id
+`
+
+type UpdateAccountLabelParams struct {
+	Label sql.NullString
+	ID    int64
+}
+
+func (q *Queries) UpdateAccountLabel(ctx context.Context, arg UpdateAccountLabelParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, updateAccountLabel, arg.Label, arg.ID)
+	var id int64
+	err := row.Scan(&id)
+	return id, err
+}
+
 const updateAccountLastUpdate = `-- name: UpdateAccountLastUpdate :one
 UPDATE accounts
 SET last_updated = $1

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -72,6 +72,7 @@ type Querier interface {
 	UpdateAccountAliasForTests(ctx context.Context, arg UpdateAccountAliasForTestsParams) (int64, error)
 	UpdateAccountBalance(ctx context.Context, arg UpdateAccountBalanceParams) (int64, error)
 	UpdateAccountExpiry(ctx context.Context, arg UpdateAccountExpiryParams) (int64, error)
+	UpdateAccountLabel(ctx context.Context, arg UpdateAccountLabelParams) (int64, error)
 	UpdateAccountLastUpdate(ctx context.Context, arg UpdateAccountLastUpdateParams) (int64, error)
 	UpdateFeatureKVStoreRecord(ctx context.Context, arg UpdateFeatureKVStoreRecordParams) error
 	UpdateGlobalKVStoreRecord(ctx context.Context, arg UpdateGlobalKVStoreRecordParams) error

--- a/db/sqlc/queries/accounts.sql
+++ b/db/sqlc/queries/accounts.sql
@@ -21,6 +21,12 @@ SET last_updated = $1
 WHERE id = $2
 RETURNING id;
 
+-- name: UpdateAccountLabel :one
+UPDATE accounts
+SET label = $1
+WHERE id = $2
+RETURNING id;
+
 -- name: AddAccountInvoice :exec
 INSERT INTO account_invoices (account_id, hash)
 VALUES ($1, $2);

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -29,6 +29,10 @@
   The `litcli ln payinvoice` command now displays an asset-aware confirmation
   prompt before sending a payment.
 
+* [Renaming off-chain accounts](https://github.com/lightninglabs/lightning-terminal/pull/1274):
+  Added the ability to rename off-chain accounts using the `litcli accounts
+  update` command with a new `--new_label` flag.
+
 ### Technical and Architectural Updates
 
 ## RPC Updates

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -23,6 +23,10 @@
   The `litcli ln payinvoice` command now displays an asset-aware confirmation
   prompt before sending a payment.
 
+* [Renaming off-chain accounts](https://github.com/lightninglabs/lightning-terminal/pull/1274):
+  Added the ability to rename off-chain accounts using the `litcli accounts
+  update` command with a new `--new_label` flag.
+
 ### Technical and Architectural Updates
 
 ## RPC Updates

--- a/litrpc/lit-accounts.pb.go
+++ b/litrpc/lit-accounts.pb.go
@@ -375,8 +375,10 @@ type UpdateAccountRequest struct {
 	// to never expire.
 	ExpirationDate int64 `protobuf:"varint,3,opt,name=expiration_date,json=expirationDate,proto3" json:"expiration_date,omitempty"`
 	// The label of the account to update. If an account has no label, then the ID
-	// must be used instead.
-	Label         string `protobuf:"bytes,4,opt,name=label,proto3" json:"label,omitempty"`
+	// must be used instead. This field is only used to identify the account.
+	Label string `protobuf:"bytes,4,opt,name=label,proto3" json:"label,omitempty"`
+	// The new label to set for the account.
+	NewLabel      string `protobuf:"bytes,5,opt,name=new_label,json=newLabel,proto3" json:"new_label,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -436,6 +438,13 @@ func (x *UpdateAccountRequest) GetExpirationDate() int64 {
 func (x *UpdateAccountRequest) GetLabel() string {
 	if x != nil {
 		return x.Label
+	}
+	return ""
+}
+
+func (x *UpdateAccountRequest) GetNewLabel() string {
+	if x != nil {
+		return x.NewLabel
 	}
 	return ""
 }
@@ -979,12 +988,13 @@ const file_lit_accounts_proto_rawDesc = "" +
 	"\x04hash\x18\x01 \x01(\fR\x04hash\x12\x14\n" +
 	"\x05state\x18\x02 \x01(\tR\x05state\x12\x1f\n" +
 	"\vfull_amount\x18\x03 \x01(\x03R\n" +
-	"fullAmount\"\x92\x01\n" +
+	"fullAmount\"\xaf\x01\n" +
 	"\x14UpdateAccountRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12+\n" +
 	"\x0faccount_balance\x18\x02 \x01(\x03B\x02\x18\x01R\x0eaccountBalance\x12'\n" +
 	"\x0fexpiration_date\x18\x03 \x01(\x03R\x0eexpirationDate\x12\x14\n" +
-	"\x05label\x18\x04 \x01(\tR\x05label\"c\n" +
+	"\x05label\x18\x04 \x01(\tR\x05label\x12\x1b\n" +
+	"\tnew_label\x18\x05 \x01(\tR\bnewLabel\"c\n" +
 	"\x14CreditAccountRequest\x123\n" +
 	"\aaccount\x18\x01 \x01(\v2\x19.litrpc.AccountIdentifierR\aaccount\x12\x16\n" +
 	"\x06amount\x18\x02 \x01(\x04R\x06amount\"B\n" +

--- a/litrpc/lit-accounts.proto
+++ b/litrpc/lit-accounts.proto
@@ -159,9 +159,12 @@ message UpdateAccountRequest {
 
     /*
     The label of the account to update. If an account has no label, then the ID
-    must be used instead.
+    must be used instead. This field is only used to identify the account.
     */
     string label = 4;
+
+    // The new label to set for the account.
+    string new_label = 5;
 }
 
 message CreditAccountRequest {

--- a/litrpc/lit-accounts.swagger.json
+++ b/litrpc/lit-accounts.swagger.json
@@ -287,7 +287,11 @@
         },
         "label": {
           "type": "string",
-          "description": "The label of the account to update. If an account has no label, then the ID\nmust be used instead."
+          "description": "The label of the account to update. If an account has no label, then the ID\nmust be used instead. This field is only used to identify the account."
+        },
+        "new_label": {
+          "type": "string",
+          "description": "The new label to set for the account."
         }
       }
     },

--- a/proto/lit-accounts.proto
+++ b/proto/lit-accounts.proto
@@ -159,9 +159,12 @@ message UpdateAccountRequest {
 
     /*
     The label of the account to update. If an account has no label, then the ID
-    must be used instead.
+    must be used instead. This field is only used to identify the account.
     */
     string label = 4;
+
+    // The new label to set for the account.
+    string new_label = 5;
 }
 
 message CreditAccountRequest {


### PR DESCRIPTION
This PR introduces support for renaming existing off-chain accounts in lightning-terminal. The functionality is exposed via the litcli accounts update command and backed by a new RPC implementation.

This enables users to modify account names without recreating accounts, improving usability and account management.

Closes #1110.