### PR TITLE
LNC Sessions: Give more granular control to LND Account Macaroons

### DIFF
--- a/cmd/litcli/sessions.go
+++ b/cmd/litcli/sessions.go
@@ -69,7 +69,7 @@ var addSessionCommand = cli.Command{
 			Usage: "The session type to be created which will " +
 				"determine the permissions a user has when " +
 				"connecting with the session; options " +
-				"include readonly|admin|account|custom.",
+				"include readonly|admin|custom.",
 			Value: "readonly",
 		},
 		cli.StringSliceFlag{
@@ -87,10 +87,8 @@ var addSessionCommand = cli.Command{
 		},
 		cli.StringFlag{
 			Name: "account_id",
-			Usage: "The account id that should be used for " +
-				"the account session. Note that this flag " +
-				"will only be used if the 'type' flag is " +
-				"set to 'account'.",
+			Usage: "An optional account ID to restrict the " +
+				"session macaroon to a specific account.",
 		},
 	},
 }
@@ -146,8 +144,6 @@ func parseSessionType(sessionType string) (litrpc.SessionType, error) {
 		return litrpc.SessionType_TYPE_MACAROON_ADMIN, nil
 	case "readonly":
 		return litrpc.SessionType_TYPE_MACAROON_READONLY, nil
-	case "account":
-		return litrpc.SessionType_TYPE_MACAROON_ACCOUNT, nil
 	case "custom":
 		return litrpc.SessionType_TYPE_MACAROON_CUSTOM, nil
 	default:

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -314,16 +314,12 @@ func (s *sessionRpcServer) AddSession(ctx context.Context,
 	// the macaroons are baked correctly when creating the session.
 	case session.TypeMacaroonAdmin, session.TypeMacaroonReadonly:
 
-	// For account based sessions we just add the account ID caveat, the
-	// permissions are added dynamically when creating the session.
+	// For account based sessions we require an account ID to be set.
 	case session.TypeMacaroonAccount:
-		id, err := accounts.ParseAccountID(req.AccountId)
-		if err != nil {
-			return nil, fmt.Errorf("invalid account ID: %v", err)
+		if req.AccountId == "" {
+			return nil, fmt.Errorf("account_id must be set for " +
+				"the account session type")
 		}
-
-		caveats = append(caveats, accounts.CaveatFromID(*id))
-		accountID = fn.Some(*id)
 
 	// For the custom macaroon type, we use the custom permissions specified
 	// in the request. For the time being, the caveats list will be empty
@@ -387,6 +383,18 @@ func (s *sessionRpcServer) AddSession(ctx context.Context,
 			"readonly, custom and account macaroon types " +
 			"supported in LiT. Autopilot sessions must be added " +
 			"using AddAutoPilotSession method")
+	}
+
+	// If an account ID was provided, bind the macaroon to that account
+	// regardless of session type.
+	if req.AccountId != "" {
+		id, err := accounts.ParseAccountID(req.AccountId)
+		if err != nil {
+			return nil, fmt.Errorf("invalid account ID: %v", err)
+		}
+
+		caveats = append(caveats, accounts.CaveatFromID(*id))
+		accountID = fn.Some(*id)
 	}
 
 	// Collect the de-duped permissions.

--- a/session_rpcserver.go
+++ b/session_rpcserver.go
@@ -481,8 +481,9 @@ func (s *sessionRpcServer) resumeSession(ctx context.Context,
 		readOnly    = sess.Type == session.TypeMacaroonReadonly
 	)
 	switch sess.Type {
-	// For the default session types we use empty caveats and permissions,
-	// the macaroons are baked correctly when creating the session.
+	// For the default session types, permissions are baked correctly when
+	// creating the session. Any stored caveats (e.g. account binding) are
+	// applied below after the switch.
 	case session.TypeMacaroonAdmin, session.TypeMacaroonReadonly:
 		permissions = s.cfg.permMgr.ActivePermissions(readOnly)
 
@@ -494,24 +495,25 @@ func (s *sessionRpcServer) resumeSession(ctx context.Context,
 				"recipe to be set")
 		}
 
-		caveats = sess.MacaroonRecipe.Caveats
 		permissions = accounts.MacaroonPermissions
 
 	// For custom session types, we use the caveats and permissions that
 	// were persisted on session creation.
 	case session.TypeMacaroonCustom, session.TypeAutopilot:
-		if sess.MacaroonRecipe == nil {
-			break
+		if sess.MacaroonRecipe != nil {
+			permissions = sess.MacaroonRecipe.Permissions
 		}
-
-		permissions = sess.MacaroonRecipe.Permissions
-		caveats = append(caveats, sess.MacaroonRecipe.Caveats...)
 
 	// No other types are currently supported.
 	default:
 		log.Debugf("Not resuming session %x with type %d", pubKeyBytes,
 			sess.Type)
 		return nil
+	}
+
+	// Apply any stored caveats (e.g. account binding) for all session types.
+	if sess.MacaroonRecipe != nil {
+		caveats = append(caveats, sess.MacaroonRecipe.Caveats...)
 	}
 
 	// Add the session expiry as a macaroon caveat.


### PR DESCRIPTION
Disclaimer: This pull request was entirely made with Claude, but tested manually in great detail

### Introduction
The command `litcli sessions add` allows a user to generate an LNC pairing phrase. This allows a user to permission an external application, for example Zeus on their phone, Alby in the browser, Lnget in the command line or a Wasm like Lightning Terminal. Currently, these sessions can be of `--type readonly|admin|account|custom`

An LND Account is a macaroon with an associated balance. The holder of that macaroon can send and receive, as well as see basic information of the node they are connected to. They cannot open or close channels , and they can only spend funds allocated to their account. Paid invoices created with the Account macaroon are counted towards the Account budget.

### Problem
In the current setup, an admin can only create a full LND Account session that can both receive and spend the funds of an LND Account.

While it is possible to create `readonly` or `custom` macaroons for an LND Account ([see guide here](https://docs.lightning.engineering/lightning-network-tools/lightning-terminal/accounts)), it is not possible to create an LNC session for it. Most commonly, a user might want to generate an invoice macaroon for their account.

### Solution
In this pull request, the flag `--account_id` no longer requires `--type account`. Instead, `--account_id` attenuates any macaroon type defined in `--type` with `lnd-custom account`. This allows the creation of LNC sessions for `readonly` and `custom` macaroons restricted to a single LND Account.

### Testing
I am running this pull request on signet, the created sessions have the expected macaroons with the expected attenuation.

### Future Work
Through this change, users can generate LNC sessions for LND Accounts with arbitrary macaroons. This makes new macaroon types easier to create in the future with LND Accounts, such as invoice-only LNC sessions. In the future, the `litcli sessions add` command could also accept any arbitrary attenuation.

### Considerations
The macaroon created with the existing `--type account --account_id <account id>` differs from that created with `--type admin --account_id <account id`. While it contains all the admin permissions such as `macaroon:generate`, LND doesn't accept these actions because of the `account_id` attenuation.

While it would be possible to adjust the LND Account macaroon to be identical to the status quo, the restrictions of an LND Account macaroon are defined by what `litd` can handle, not what is specified in the macaroon. The main disadvantage is that applications like Terminal will currently use the heuristics of the present permissions, rather than the `lnd-custom account` attenuation.

LND Account Macaroon permissions today:
```
{
    "version": 2,
    "location": "lnd",
    "root_key_id": "18441921394825525203",
    "permissions": [
        "info:read",
        "invoices:read",
        "invoices:write",
        "offchain:read",
        "offchain:write",
        "onchain:read",
        "peers:read"
    ],
    "caveats": [
        "lnd-custom account 0cae57e48e182361",
        "time-before 2026-07-06T05:39:23Z"
    ]
}
```

LND Account "Admin" Macaroon created through the code of this pull request:
```
{
    "version": 2,
    "location": "lnd",
    "root_key_id": "18441921394195493058",
    "permissions": [
        "account:read",
        "account:write",
        "actions:read",
        "address:read",
        "address:write",
        "addresses:read",
        "addresses:write",
        "assets:read",
        "assets:write",
        "auction:read",
        "audit:read",
        "auth:read",
        "auth:write",
        "autopilot:read",
        "autopilot:write",
        "channels:read",
        "channels:write",
        "daemon:read",
        "daemon:write",
        "info:read",
        "info:write",
        "insights:read",
        "invoices:read",
        "invoices:write",
        "loop:admin",
        "loop:in",
        "loop:out",
        "macaroon:generate",
        "macaroon:read",
        "macaroon:write",
        "mailbox:read",
        "mailbox:write",
        "message:read",
        "message:write",
        "mint:read",
        "mint:write",
        "offchain:read",
        "offchain:write",
        "onchain:read",
        "onchain:write",
        "order:read",
        "order:write",
        "peers:read",
        "peers:write",
        "privacymap:read",
        "proofs:read",
        "proofs:write",
        "proxy:read",
        "proxy:write",
        "rates:read",
        "recommendation:read",
        "report:read",
        "rfq:read",
        "rfq:write",
        "sessions:read",
        "sessions:write",
        "signer:generate",
        "signer:read",
        "suggestions:read",
        "suggestions:write",
        "supermacaroon:write",
        "swap:execute",
        "swap:read",
        "terms:read",
        "universe:read",
        "universe:write"
    ],
    "caveats": [
        "lnd-custom account 92d17f9e544e1f97",
        "time-before 2026-07-06T05:37:02Z"
    ]
}
```