### PR TITLE
terminal: add signet autopilot server address

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -75,6 +75,7 @@ import (
 const (
 	MainnetServer = "autopilot.lightning.finance:12010"
 	TestnetServer = "test.autopilot.lightning.finance:12010"
+	SignetServer  = "signet.autopilot.lightning.finance:12010"
 
 	// lndWalletReadyStatus is a custom status that will be used with the
 	// LND subserver. If the subserver is in this state then it will allow
@@ -465,9 +466,12 @@ func (g *LightningTerminal) start(ctx context.Context) error {
 				g.cfg.Autopilot.Address = MainnetServer
 			case "testnet":
 				g.cfg.Autopilot.Address = TestnetServer
+			case "signet":
+				g.cfg.Autopilot.Address = SignetServer
 			default:
-				return errors.New("no autopilot server " +
-					"address specified")
+				return fmt.Errorf("no autopilot server "+
+					"address specified for network %s",
+					g.cfg.Network)
 			}
 		}
 


### PR DESCRIPTION
Adds the default autopilot server address for signet. Also includes the network name in the fallback error so misconfigurations are easier to diagnose.