### PR TITLE
[sql-68] multi: add conf option to remove bbolt tombstone

### DIFF
--- a/accounts/kvdb_deprecation.go
+++ b/accounts/kvdb_deprecation.go
@@ -71,6 +71,34 @@ func DeprecateKVDB(path string) error {
 	})
 }
 
+// RemoveKVDBDeprecation removes the accounts kvdb deprecation marker.
+func RemoveKVDBDeprecation(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
+
+	db, err := bbolt.Open(path, dbFilePermission, &bbolt.Options{
+		Timeout: DefaultAccountDBTimeout,
+	})
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	return db.Update(func(tx *bbolt.Tx) error {
+		accountBucket := tx.Bucket(accountBucketName)
+		if accountBucket == nil {
+			return nil
+		}
+
+		if accountBucket.Bucket(deprecatedBucketKey) == nil {
+			return nil
+		}
+
+		return accountBucket.DeleteBucket(deprecatedBucketKey)
+	})
+}
+
 // CheckKVDBDeprecated returns a clear error if the accounts kvdb file was
 // marked as deprecated.
 func CheckKVDBDeprecated(path string) error {

--- a/accounts/kvdb_deprecation_test.go
+++ b/accounts/kvdb_deprecation_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TestKVDBDeprecation verifies that a deprecated accounts kvdb file refuses to
-// reopen.
+// reopen until the explicit marker is removed again.
 func TestKVDBDeprecation(t *testing.T) {
 	t.Parallel()
 
@@ -33,6 +33,13 @@ func TestKVDBDeprecation(t *testing.T) {
 	require.Contains(t, err.Error(), ErrKVDBDeprecated.Error())
 
 	store, err = NewBoltStoreForMigration(dbDir, DBFilename, clk)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	err = RemoveKVDBDeprecation(dbPath)
+	require.NoError(t, err)
+
+	store, err = NewBoltStore(dbDir, DBFilename, clk)
 	require.NoError(t, err)
 	require.NoError(t, store.Close())
 }

--- a/config_dev.go
+++ b/config_dev.go
@@ -59,6 +59,12 @@ type DevConfig struct {
 
 	// Postgres holds the configuration options for a Postgres database
 	Postgres *db.PostgresConfig `group:"postgres" namespace:"postgres"`
+
+	// UnsafeRemoveDeprecatedKVDBMarkers removes the kvdb deprecation
+	// markers from the legacy bbolt database files before opening them.
+	// This should only be used if the caller fully understands the
+	// consequences of reusing kvdb files that were already migrated to SQL.
+	UnsafeRemoveDeprecatedKVDBMarkers bool `long:"unsafe-remove-kvdb-deprecation" description:"Remove the kvdb deprecation markers if set from accounts.db, session.db and rules.db before opening the bbolt backend. Only set this if you know fully understands the consequences of reusing kvdb files that were already migrated to SQL."`
 }
 
 // Validate checks that all the values set in our DevConfig are valid and uses
@@ -195,6 +201,13 @@ func NewStores(ctx context.Context, cfg *Config,
 		stores.closeFns["postgres"] = sqlStore.BaseDB.Close
 
 	default:
+		err := clearDeprecatedKVDBMarkers(
+			filepath.Dir(cfg.MacaroonPath), networkDir, cfg,
+		)
+		if err != nil {
+			return stores, err
+		}
+
 		accountStore, err := accounts.NewBoltStore(
 			filepath.Dir(cfg.MacaroonPath), accounts.DBFilename,
 			clock,
@@ -230,4 +243,40 @@ func NewStores(ctx context.Context, cfg *Config,
 	}
 
 	return stores, nil
+}
+
+// clearDeprecatedKVDBMarkers removes the kvdb deprecation markers when the
+// explicit unsafe override is set.
+func clearDeprecatedKVDBMarkers(accountsDir, networkDir string,
+	cfg *Config) error {
+
+	if !cfg.UnsafeRemoveDeprecatedKVDBMarkers {
+		return nil
+	}
+
+	err := accounts.RemoveKVDBDeprecation(
+		filepath.Join(accountsDir, accounts.DBFilename),
+	)
+	if err != nil {
+		return fmt.Errorf("error clearing accounts kvdb deprecation "+
+			"marker: %w", err)
+	}
+
+	err = session.RemoveKVDBDeprecation(
+		filepath.Join(networkDir, session.DBFilename),
+	)
+	if err != nil {
+		return fmt.Errorf("error clearing session kvdb deprecation "+
+			"marker: %w", err)
+	}
+
+	err = firewalldb.RemoveKVDBDeprecation(
+		filepath.Join(networkDir, firewalldb.DBFilename),
+	)
+	if err != nil {
+		return fmt.Errorf("error clearing firewall kvdb deprecation "+
+			"marker: %w", err)
+	}
+
+	return nil
 }

--- a/config_dev_test.go
+++ b/config_dev_test.go
@@ -1,0 +1,79 @@
+//go:build dev
+
+package terminal
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/lightninglabs/lightning-terminal/accounts"
+	"github.com/lightninglabs/lightning-terminal/firewalldb"
+	"github.com/lightninglabs/lightning-terminal/session"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewStoresUnsafeRemoveDeprecatedKVDBMarkers verifies that the explicit
+// unsafe flag clears all kvdb deprecation markers before the bbolt backend is
+// reopened. The test also verifies that reopening the bbolt stores fails while
+// the deprecation markers are still present.
+func TestNewStoresUnsafeRemoveDeprecatedKVDBMarkers(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultConfig()
+	cfg.LitDir = t.TempDir()
+	cfg.Network = "regtest"
+	cfg.DatabaseBackend = DatabaseBackendBbolt
+	cfg.MacaroonPath = filepath.Join(
+		cfg.LitDir, cfg.Network, DefaultMacaroonFilename,
+	)
+
+	dbDir := filepath.Dir(cfg.MacaroonPath)
+	err := makeDirectories(dbDir)
+	require.NoError(t, err)
+
+	clk := clock.NewDefaultClock()
+
+	accountStore, err := accounts.NewBoltStore(
+		dbDir, accounts.DBFilename, clk,
+	)
+	require.NoError(t, err)
+
+	sessionStore, err := session.NewDB(
+		dbDir, session.DBFilename, clk, accountStore,
+	)
+	require.NoError(t, err)
+
+	firewallStore, err := firewalldb.NewBoltDB(
+		dbDir, firewalldb.DBFilename, sessionStore, accountStore, clk,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, firewallStore.Close())
+	require.NoError(t, sessionStore.Close())
+	require.NoError(t, accountStore.Close())
+
+	require.NoError(t, accounts.DeprecateKVDB(
+		filepath.Join(dbDir, accounts.DBFilename),
+	))
+	require.NoError(t, session.DeprecateKVDB(
+		filepath.Join(dbDir, session.DBFilename),
+	))
+	require.NoError(t, firewalldb.DeprecateKVDB(
+		filepath.Join(dbDir, firewalldb.DBFilename),
+	))
+
+	_, err = NewStores(context.Background(), cfg, nil, clk)
+	require.ErrorIs(t, err, accounts.ErrKVDBDeprecated)
+	require.ErrorContains(t, err, accounts.DBFilename)
+
+	cfg.UnsafeRemoveDeprecatedKVDBMarkers = true
+
+	stores, err := NewStores(context.Background(), cfg, nil, clk)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, stores.close())
+	})
+}

--- a/firewalldb/kvdb_deprecation.go
+++ b/firewalldb/kvdb_deprecation.go
@@ -49,6 +49,30 @@ func DeprecateKVDB(path string) error {
 	})
 }
 
+// RemoveKVDBDeprecation removes the rules kvdb deprecation marker.
+func RemoveKVDBDeprecation(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
+
+	db, err := bbolt.Open(path, dbFilePermission, &bbolt.Options{
+		Timeout: DefaultRulesDBTimeout,
+	})
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	return db.Update(func(tx *bbolt.Tx) error {
+		metadataBucket := tx.Bucket(metadataBucketKey)
+		if metadataBucket == nil {
+			return nil
+		}
+
+		return setDBVersion(metadataBucket, latestDBVersion)
+	})
+}
+
 // CheckKVDBDeprecated returns a clear error if the rules kvdb file was marked
 // as deprecated.
 func CheckKVDBDeprecated(path string) error {

--- a/firewalldb/kvdb_deprecation_test.go
+++ b/firewalldb/kvdb_deprecation_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // TestKVDBDeprecation verifies that a deprecated rules kvdb file refuses to
-// reopen.
+// reopen until the explicit marker is removed again.
 func TestKVDBDeprecation(t *testing.T) {
 	t.Parallel()
 
@@ -49,6 +49,15 @@ func TestKVDBDeprecation(t *testing.T) {
 	require.Contains(t, err.Error(), ErrKVDBDeprecated.Error())
 
 	store, err = NewBoltDBForMigration(
+		dbDir, DBFilename, sessionStore, accountStore, clk,
+	)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	err = RemoveKVDBDeprecation(dbPath)
+	require.NoError(t, err)
+
+	store, err = NewBoltDB(
 		dbDir, DBFilename, sessionStore, accountStore, clk,
 	)
 	require.NoError(t, err)

--- a/itest/litd_migration_test.go
+++ b/itest/litd_migration_test.go
@@ -54,9 +54,12 @@ import (
 //  9. Delete the SQL database and show that SQL startup reruns the migration.
 //  10. If available, show that downgrading to an old LiT binary still fails to
 //     start against the deprecated kvdb files.
-//  11. Delete `accounts.db` and verify that bbolt startup is still blocked by
+//  11. Show that starting with the unsafe unmark flag removes the deprecation
+//     markers so bbolt can be started again, then rerun the SQL migration so
+//     the tombstones exist again for the remaining startup-order checks.
+//  12. Delete `accounts.db` and verify that bbolt startup is still blocked by
 //     the next deprecated kvdb file, `session.db`.
-//  12. Delete `session.db` and verify that bbolt startup is still blocked by
+//  13. Delete `session.db` and verify that bbolt startup is still blocked by
 //     the next deprecated kvdb file, `rules.db`.
 func testKvdbSQLMigration(ctx context.Context, net *NetworkHarness,
 	t *harnessTest) {
@@ -204,7 +207,59 @@ func testKvdbSQLMigration(ctx context.Context, net *NetworkHarness,
 		delete(net.backwardCompat, migNode.Name())
 	}
 
-	// Step 11: Delete the first-startup kvdb file and verify that bbolt
+	// Step 11: Verify that the unsafe flag removes the kvdb tombstones and
+	// allows bbolt startup again.
+	err = migNode.Start(
+		net.litdBinary, net.backwardCompat, net.lndErrorChan, true,
+		WithLitArg("databasebackend", terminal.DatabaseBackendBbolt),
+		WithLitArg("unsafe-remove-kvdb-deprecation", ""),
+		WithLitArg("firewall.request-logger.level", "all"),
+	)
+	require.NoError(t.t, err)
+
+	ctxt, cancel = newStepCtx()
+	rawConn, err = connectRPC(
+		ctxt, migNode.Cfg.LitAddr(), migNode.Cfg.LitTLSCertPath,
+	)
+	require.NoError(t.t, err)
+	cancel()
+
+	accountsClient = litrpc.NewAccountsClient(rawConn)
+	sessionsClient = litrpc.NewSessionsClient(rawConn)
+	firewallClient = litrpc.NewFirewallClient(rawConn)
+
+	ctxm, cancel = newAdminCtx()
+	afterUnsafeUnmark := queryMigrationData(
+		ctxm, t, accountsClient, sessionsClient, firewallClient,
+		migrationRefs.actionMethod,
+	)
+	cancel()
+	assertMigrationSnapshotsEqual(t, beforeMigration, afterUnsafeUnmark)
+
+	// The unsafe flag should persistently remove the tombstones, so a
+	// subsequent plain bbolt restart must succeed as well.
+	require.NoError(t.t, rawConn.Close())
+	require.NoError(t.t, migNode.Stop())
+
+	err = migNode.Start(
+		net.litdBinary, net.backwardCompat, net.lndErrorChan, true,
+		WithLitArg("databasebackend", terminal.DatabaseBackendBbolt),
+		WithLitArg("firewall.request-logger.level", "all"),
+	)
+	require.NoError(t.t, err)
+
+	require.NoError(t.t, migNode.Stop())
+
+	// Recreate the kvdb tombstones so startup still exercises the
+	// deprecated-file checks after the unsafe unmark path above.
+	rerunSQLMigrationAndAssert(
+		t, net, migNode, newStepCtx, newAdminCtx, beforeMigration,
+		migrationRefs,
+	)
+
+	require.NoError(t.t, migNode.Stop())
+
+	// Step 12: Delete the first-startup kvdb file and verify that bbolt
 	// startup is still blocked by the next deprecated file in the open
 	// order.
 	removeMigrationKVDBFile(t, kvdbFiles[0])
@@ -222,7 +277,7 @@ func testKvdbSQLMigration(ctx context.Context, net *NetworkHarness,
 		),
 	)
 
-	// Step 12: Delete the second-startup kvdb file and verify that bbolt
+	// Step 13: Delete the second-startup kvdb file and verify that bbolt
 	// startup is still blocked by the third deprecated file.
 	removeMigrationKVDBFile(t, kvdbFiles[1])
 	assertNodeStartFails(

--- a/session/kvdb_deprecation.go
+++ b/session/kvdb_deprecation.go
@@ -49,6 +49,30 @@ func DeprecateKVDB(path string) error {
 	})
 }
 
+// RemoveKVDBDeprecation removes the session kvdb deprecation marker.
+func RemoveKVDBDeprecation(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
+
+	db, err := bbolt.Open(path, dbFilePermission, &bbolt.Options{
+		Timeout: DefaultSessionDBTimeout,
+	})
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	return db.Update(func(tx *bbolt.Tx) error {
+		metadataBucket := tx.Bucket(metadataBucketKey)
+		if metadataBucket == nil {
+			return nil
+		}
+
+		return setDBVersion(metadataBucket, latestDBVersion)
+	})
+}
+
 // CheckKVDBDeprecated returns a clear error if the session kvdb file was
 // marked as deprecated.
 func CheckKVDBDeprecated(path string) error {

--- a/session/kvdb_deprecation_test.go
+++ b/session/kvdb_deprecation_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TestKVDBDeprecation verifies that a deprecated session kvdb file refuses to
-// reopen.
+// reopen until the explicit marker is removed again.
 func TestKVDBDeprecation(t *testing.T) {
 	t.Parallel()
 
@@ -40,6 +40,13 @@ func TestKVDBDeprecation(t *testing.T) {
 	require.Contains(t, err.Error(), ErrKVDBDeprecated.Error())
 
 	store, err = NewDBForMigration(dbDir, DBFilename, clk, accountStore)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	err = RemoveKVDBDeprecation(dbPath)
+	require.NoError(t, err)
+
+	store, err = NewDB(dbDir, DBFilename, clk, accountStore)
 	require.NoError(t, err)
 	require.NoError(t, store.Close())
 }


### PR DESCRIPTION
Based on #1272

This PR adds a config option `unsafe-remove-kvdb-deprecation` that removes the bbolt tombstone on the next startup the tombstone is added after a kvdb-> SQL migration.

Pushing this in draft for now, so that we can decide if we actually want to go ahead with this PR or not.