### PR TITLE
docs: note that FreeBSD users need gmake to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ our [troubleshooting guide](./docs/troubleshooting.md).
 If you’d prefer to compile from source code please
 follow [these instructions](./docs/compile.md).
 
+**Note for FreeBSD users:** the `Makefile` requires GNU Make. Install it with
+`pkg install gmake` and use `gmake` in place of `make` (for example,
+`gmake install`).
+
 ## Component Compatibility
 
 This section describes version and mode compatibility across Lightning Terminal

--- a/docs/compile.md
+++ b/docs/compile.md
@@ -26,6 +26,11 @@ need to download those binaries from the
 [pool](https://github.com/lightninglabs/pool/releases), and
 [faraday](https://github.com/lightninglabs/faraday/releases) repos manually.
 
+**Note for FreeBSD users:** the `Makefile` requires GNU Make. Install it with
+`pkg install gmake` and substitute `gmake` for `make` in the commands above
+(for example, `gmake install`). The same applies to the other `make` targets
+mentioned later in this document.
+
 ## Building a docker image
 
 There are two flavors of Dockerfiles available:


### PR DESCRIPTION
Closes #859.

The `Makefile` uses GNU Make features, which on FreeBSD requires the `gmake` port rather than the base system `make`. Add a short note to `docs/compile.md` so FreeBSD users know to install `gmake` and substitute it for `make` in the build commands.

Docs-only change — can add a release-notes entry or apply `no-changelog` if preferred.