### PR TITLE
litcli: align help text style for top-level commands

### DIFF
--- a/cmd/litcli/actions.go
+++ b/cmd/litcli/actions.go
@@ -10,7 +10,7 @@ import (
 
 var listActionsCommand = cli.Command{
 	Name:     "actions",
-	Usage:    "List actions performed on the Litd server",
+	Usage:    "List actions performed on the litd server",
 	Category: "Firewall",
 	Action:   listActions,
 	Flags: []cli.Flag{

--- a/cmd/litcli/autopilot.go
+++ b/cmd/litcli/autopilot.go
@@ -17,7 +17,7 @@ import (
 
 var autopilotCommands = cli.Command{
 	Name:     "autopilot",
-	Usage:    "Manage autopilot sessions",
+	Usage:    "Manage Autopilot sessions",
 	Category: "LNC",
 	Subcommands: []cli.Command{
 		listAutopilotFeaturesCmd,
@@ -25,7 +25,7 @@ var autopilotCommands = cli.Command{
 		revokeAutopilotSessionCmd,
 		listAutopilotSessionsCmd,
 	},
-	Description: "Manage autopilot sessions.",
+	Description: "Manage Autopilot sessions.",
 }
 
 var listAutopilotFeaturesCmd = cli.Command{

--- a/cmd/litcli/privacy_map.go
+++ b/cmd/litcli/privacy_map.go
@@ -13,7 +13,7 @@ var privacyMapCommands = cli.Command{
 	Name:      "privacy",
 	ShortName: "p",
 	Usage: "Access the real-pseudo string pairs of the " +
-		"privacy mapper.",
+		"privacy mapper",
 	Category: "Firewall",
 	Flags: []cli.Flag{
 		cli.StringFlag{


### PR DESCRIPTION
### Description

Tiny `litcli` help text consistency pass per #591.

Three changes, all to top-level commands shown in `litcli -h`:

- `privacy` short usage drops the trailing period to match every other top-level command (none of the others terminate the short usage with a period).
- `actions` uses the lowercase binary name `litd` to match how the daemon is referred to elsewhere in the same file set (e.g. `status`).
- `autopilot` parent command capitalizes `Autopilot` in its usage and description so it matches the casing already used by all Autopilot subcommands and the surrounding documentation.

Before:

```
   actions  List actions performed on the Litd server

   Accounts:
     accounts, a  Manage accounts

   Autopilot:
     autopilot  Manage autopilot sessions

   Firewall:
     privacy, p  Access the real-pseudo string pairs of the privacy mapper.
```

After:

```
   actions  List actions performed on the litd server

   Accounts:
     accounts, a  Manage accounts

   Autopilot:
     autopilot  Manage Autopilot sessions

   Firewall:
     privacy, p  Access the real-pseudo string pairs of the privacy mapper
```

The other items in #591 (the rename of "Terminal Web sessions" to "Lightning Node Connect" landed previously, and adding extended descriptions to every command is a larger change) are out of scope for this PR and can land separately.

Addresses #591.
