### PR TITLE
dev.Dockerfile: allow forcing faraday repo and version

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -30,22 +30,23 @@ COPY --from=nodejsbuilder /go/src/github.com/lightninglabs/lightning-terminal /g
 # queries required to connect to linked containers succeed.
 ENV GODEBUG netdns=cgo
 
-# Allow forcing a specific lnd, taproot-assets, taprpc, loop, and/or faraday
-# repo so that commits referenced by LND_VERSION, TAPROOT_ASSETS_VERSION,
-# TAPRPC_VERSION, LOOP_VERSION, and FARADAY_VERSION don't have to exist in the
-# default repository. If any of these build arguments are not defined, the
-# build continues using the default repository for that module. NOTE: If these
-# arguments ARE defined then the corresponding `_VERSION` argument MUST also be
-# defined, otherwise the build continues using the default repository defined
-# for that module.
+# Allow forcing a specific lnd, taproot-assets, taprpc, loop, faraday, and/or
+# frdrpc repo so that commits referenced by LND_VERSION,
+# TAPROOT_ASSETS_VERSION, TAPRPC_VERSION, LOOP_VERSION, FARADAY_VERSION, and
+# FRDRPC_VERSION don't have to exist in the default repository. If any of these
+# build arguments are not defined, the build continues using the default
+# repository for that module. NOTE: If these arguments ARE defined then the
+# corresponding `_VERSION` argument MUST also be defined, otherwise the build
+# continues using the default repository defined for that module.
 ARG LND_REPO
 ARG TAPROOT_ASSETS_REPO
 ARG TAPRPC_REPO
 ARG LOOP_REPO
 ARG FARADAY_REPO
+ARG FRDRPC_REPO
 
-# Allow forcing a specific lnd, taproot-assets, taprpc, loop, and/or faraday
-# version through a build argument.
+# Allow forcing a specific lnd, taproot-assets, taprpc, loop, faraday, and/or
+# frdrpc version through a build argument.
 # Please see https://go.dev/ref/mod#version-queries for the types of
 # queries that can be used to define a version.
 # If any of these build arguments are not defined then build uses the version
@@ -62,6 +63,7 @@ ARG TAPROOT_ASSETS_VERSION
 ARG TAPRPC_VERSION
 ARG LOOP_VERSION
 ARG FARADAY_VERSION
+ARG FRDRPC_VERSION
 
 # Need to restate this since running in a new container from above.
 ARG NO_UI
@@ -128,6 +130,16 @@ RUN --mount=type=cache,target=/go/pkg/mod \
       go mod edit -replace=github.com/lightninglabs/faraday=$FARADAY_REPO@$FARADAY_VERSION; \
     else \
       go get -v github.com/lightninglabs/faraday@$FARADAY_VERSION; \
+    fi \
+    && go mod tidy; \
+  fi \
+  # If a custom frdrpc version is supplied, force it now.
+  && if [ -n "$FRDRPC_VERSION" ]; then \
+    # If a custom frdrpc repo is supplied, force it now.
+    if [ -n "$FRDRPC_REPO" ]; then \
+      go mod edit -replace=github.com/lightninglabs/faraday/frdrpc=$FRDRPC_REPO@$FRDRPC_VERSION; \
+    else \
+      go get -v github.com/lightninglabs/faraday/frdrpc@$FRDRPC_VERSION; \
     fi \
     && go mod tidy; \
   fi \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -30,20 +30,22 @@ COPY --from=nodejsbuilder /go/src/github.com/lightninglabs/lightning-terminal /g
 # queries required to connect to linked containers succeed.
 ENV GODEBUG netdns=cgo
 
-# Allow forcing a specific lnd, taproot-assets, taprpc, and/or loop repo so that
-# commits referenced by LND_VERSION, TAPROOT_ASSETS_VERSION, TAPRPC_VERSION, and
-# LOOP_VERSION don't have to exist in the default repository. If any of these
-# build arguments are not defined, the build continues using the default
-# repository for that module. NOTE: If these arguments ARE defined then the
-# corresponding `_VERSION` argument MUST also be defined, otherwise the build
-# continues using the default repository defined for that module.
+# Allow forcing a specific lnd, taproot-assets, taprpc, loop, and/or faraday
+# repo so that commits referenced by LND_VERSION, TAPROOT_ASSETS_VERSION,
+# TAPRPC_VERSION, LOOP_VERSION, and FARADAY_VERSION don't have to exist in the
+# default repository. If any of these build arguments are not defined, the
+# build continues using the default repository for that module. NOTE: If these
+# arguments ARE defined then the corresponding `_VERSION` argument MUST also be
+# defined, otherwise the build continues using the default repository defined
+# for that module.
 ARG LND_REPO
 ARG TAPROOT_ASSETS_REPO
 ARG TAPRPC_REPO
 ARG LOOP_REPO
+ARG FARADAY_REPO
 
-# Allow forcing a specific lnd, taproot-assets, taprpc, and/or loop version
-# through a build argument.
+# Allow forcing a specific lnd, taproot-assets, taprpc, loop, and/or faraday
+# version through a build argument.
 # Please see https://go.dev/ref/mod#version-queries for the types of
 # queries that can be used to define a version.
 # If any of these build arguments are not defined then build uses the version
@@ -59,6 +61,7 @@ ARG LND_VERSION
 ARG TAPROOT_ASSETS_VERSION
 ARG TAPRPC_VERSION
 ARG LOOP_VERSION
+ARG FARADAY_VERSION
 
 # Need to restate this since running in a new container from above.
 ARG NO_UI
@@ -115,6 +118,16 @@ RUN --mount=type=cache,target=/go/pkg/mod \
       go mod edit -replace=github.com/lightninglabs/loop=$LOOP_REPO@$LOOP_VERSION; \
     else \
       go get -v github.com/lightninglabs/loop@$LOOP_VERSION; \
+    fi \
+    && go mod tidy; \
+  fi \
+  # If a custom faraday version is supplied, force it now.
+  && if [ -n "$FARADAY_VERSION" ]; then \
+    # If a custom faraday repo is supplied, force it now.
+    if [ -n "$FARADAY_REPO" ]; then \
+      go mod edit -replace=github.com/lightninglabs/faraday=$FARADAY_REPO@$FARADAY_VERSION; \
+    else \
+      go get -v github.com/lightninglabs/faraday@$FARADAY_VERSION; \
     fi \
     && go mod tidy; \
   fi \

--- a/docs/release-notes/release-notes-0.17.1.md
+++ b/docs/release-notes/release-notes-0.17.1.md
@@ -72,6 +72,12 @@
   runtimes. This represents a breaking change to the `NewPrivacyMapper` and
   `CryptoRandIntn` functions. The PR also introduced a `sync.Pool` for
   `*big.Int` to optimize allocations.
+* [Allow overriding faraday and frdrpc in
+  `dev.Dockerfile`](https://github.com/lightninglabs/lightning-terminal/pull/1299):
+  Added `FARADAY_REPO`/`FARADAY_VERSION` and `FRDRPC_REPO`/`FRDRPC_VERSION`
+  build arguments so dev images can be built against an arbitrary `faraday`
+  commit or fork, mirroring the existing overrides for `lnd`, `taproot-assets`,
+  `taprpc`, and `loop`.
 
 ## RPC Updates
 


### PR DESCRIPTION
Adds `FARADAY_REPO` and `FARADAY_VERSION` build args to `dev.Dockerfile`, mirroring the existing override blocks for `lnd`, `taproot-assets`, `taprpc`, and `loop`. With this, a `litd` dev image can be built against an arbitrary `faraday` commit (e.g. `master`) without editing `go.mod`.

Partially addresses #1249. The follow-up workflow change to actually run nightly builds against each daemon's master branch can land separately.

### Example

```
docker build -f dev.Dockerfile \
    --build-arg FARADAY_VERSION=master \
    .
```

### Notes

- No functional change unless `FARADAY_VERSION` is set; default builds use the `faraday` version pinned in `go.mod`.
- No release-notes entry — prior `dev.Dockerfile`-only commits (3c5ddb95, ad2d802b, c3ff3e91) didn't add one either.