### PR TITLE
litcli: remove deprecated new_balance flag from update command

### DIFF
--- a/cmd/litcli/accounts.go
+++ b/cmd/litcli/accounts.go
@@ -146,10 +146,9 @@ var updateAccountCommand = cli.Command{
 	Name:      "update",
 	ShortName: "u",
 	Usage:     "Update an existing off-chain account.",
-	ArgsUsage: "[id | label] new_balance new_expiration_date",
+	ArgsUsage: "[id | label] new_expiration_date",
 	Description: "Updates an existing off-chain account and sets " +
-		"a new balance, new expiration date and " +
-		"optionally a new label.",
+		"a new expiration date and optionally a new label.",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: idName,
@@ -165,13 +164,6 @@ var updateAccountCommand = cli.Command{
 		cli.StringFlag{
 			Name:  "new_label",
 			Usage: "(optional) The new label of the account.",
-		},
-		cli.Int64Flag{
-			Name: "new_balance",
-			Usage: "(deprecated) The new balance of the account; " +
-				"-1 means do not update the balance.",
-			Value:  -1,
-			Hidden: true,
 		},
 		cli.Int64Flag{
 			Name: "new_expiration_date",
@@ -204,20 +196,8 @@ func updateAccount(cli *cli.Context) error {
 	}
 
 	var (
-		newBalance     int64
 		expirationDate int64
 	)
-	switch {
-	case cli.IsSet("new_balance"):
-		newBalance = cli.Int64("new_balance")
-	case args.Present():
-		newBalance, err = strconv.ParseInt(args.First(), 10, 64)
-		if err != nil {
-			return fmt.Errorf("unable to decode balance %v", err)
-		}
-		args = args.Tail()
-	}
-
 	switch {
 	case cli.IsSet("new_expiration_date"):
 		expirationDate = cli.Int64("new_expiration_date")
@@ -234,7 +214,7 @@ func updateAccount(cli *cli.Context) error {
 	req := &litrpc.UpdateAccountRequest{
 		Id:             id,
 		Label:          label,
-		AccountBalance: newBalance,
+		AccountBalance: -1,
 		ExpirationDate: expirationDate,
 		NewLabel:       cli.String("new_label"),
 	}

--- a/cmd/litcli/accounts.go
+++ b/cmd/litcli/accounts.go
@@ -146,7 +146,7 @@ var updateAccountCommand = cli.Command{
 	Name:      "update",
 	ShortName: "u",
 	Usage:     "Update an existing off-chain account.",
-	ArgsUsage: "[id | label] new_expiration_date",
+	ArgsUsage: "[id | label] [new_expiration_date]",
 	Description: "Updates an existing off-chain account and sets " +
 		"a new expiration date and optionally a new label.",
 	Flags: []cli.Flag{
@@ -167,10 +167,10 @@ var updateAccountCommand = cli.Command{
 		},
 		cli.Int64Flag{
 			Name: "new_expiration_date",
-			Usage: "The new expiration date of the account " +
-				"expressed in seconds since the unix epoch; " +
-				"-1 means do not update the expiration date; " +
-				"0 means it does not expire.",
+			Usage: "(optional) The new expiration date of " +
+				"the account expressed in seconds since the " +
+				"unix epoch; -1 means do not update the " +
+				"expiration date; 0 means it does not expire.",
 			Value: -1,
 		},
 	},
@@ -196,7 +196,7 @@ func updateAccount(cli *cli.Context) error {
 	}
 
 	var (
-		expirationDate int64
+		expirationDate int64 = -1
 	)
 	switch {
 	case cli.IsSet("new_expiration_date"):
@@ -209,6 +209,9 @@ func updateAccount(cli *cli.Context) error {
 			)
 		}
 		args = args.Tail()
+	}
+	if args.Present() {
+		return fmt.Errorf("too many arguments provided")
 	}
 
 	req := &litrpc.UpdateAccountRequest{

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -22,6 +22,11 @@
   without negotiated ALPN, restoring LNC session establishment and the
   `lnc_auth` flow after the `grpc-go` `v1.67.0` upgrade.
 
+* [Fix default account update expiration](https://github.com/lightninglabs/lightning-terminal/pull/1303):
+  Fixed a bug in the `litcli accounts update` command where omitting the new
+  expiration date would overwrite it to 0 (never expires). It now correctly
+  defaults to -1 (no change).
+
 ### Functional Changes/Additions
 
 * [Show asset information on
@@ -32,6 +37,12 @@
 * [Renaming off-chain accounts](https://github.com/lightninglabs/lightning-terminal/pull/1274):
   Added the ability to rename off-chain accounts using the `litcli accounts
   update` command with a new `--new_label` flag.
+
+* [Removal of deprecated `--new_balance`](https://github.com/lightninglabs/lightning-terminal/pull/1303):
+  Removed the deprecated `--new_balance` flag and positional parameter logic from
+  the `litcli accounts update` command. Users should instead use the
+  `litcli accounts update debit` and `litcli accounts update credit` commands
+  to modify an account's balance.
 
 ### Technical and Architectural Updates
 
@@ -52,4 +63,5 @@
 # Contributors (Alphabetical Order)
 
 * Boris Nagaev
+* Cyberguru1
 * darioAnongba


### PR DESCRIPTION
Closes https://github.com/lightninglabs/lightning-terminal/issues/1276

This PR fully removes the deprecated `--new_balance` flag and its corresponding backend sink from the `litcli accounts update` command.

Additionally, this addresses the safety defect related to initializing expiration date defaults to 0, which led to unintentional overwrites on updates as referenced in this comment: https://github.com/lightninglabs/lightning-terminal/pull/1274#discussion_r3167285301