### PR TITLE
[sql-72] Add `master` additions to migration code

### DIFF
--- a/accounts/sql_migration.go
+++ b/accounts/sql_migration.go
@@ -347,15 +347,23 @@ func getBBoltIndices(db kvdb.Backend) (uint64, uint64, error) {
 			return ErrAccountBucketNotFound
 		}
 
-		addValue = bucket.Get(lastAddIndexKey)
-		if len(addValue) == 0 {
+		av := bucket.Get(lastAddIndexKey)
+		if len(av) == 0 {
 			return ErrNoInvoiceIndexKnown
 		}
 
-		settleValue = bucket.Get(lastSettleIndexKey)
-		if len(settleValue) == 0 {
+		sv := bucket.Get(lastSettleIndexKey)
+		if len(sv) == 0 {
 			return ErrNoInvoiceIndexKnown
 		}
+
+		// Copy values since bbolt's Get returns slices into the
+		// mmap'd file, only valid within the transaction.
+		addValue = make([]byte, len(av))
+		copy(addValue, av)
+
+		settleValue = make([]byte, len(sv))
+		copy(settleValue, sv)
 
 		return nil
 	}, func() {

--- a/db/sqlcmig6/accounts.sql.go
+++ b/db/sqlcmig6/accounts.sql.go
@@ -427,6 +427,25 @@ func (q *Queries) UpdateAccountExpiry(ctx context.Context, arg UpdateAccountExpi
 	return id, err
 }
 
+const updateAccountLabel = `-- name: UpdateAccountLabel :one
+UPDATE accounts
+SET label = $1
+WHERE id = $2
+RETURNING id
+`
+
+type UpdateAccountLabelParams struct {
+	Label sql.NullString
+	ID    int64
+}
+
+func (q *Queries) UpdateAccountLabel(ctx context.Context, arg UpdateAccountLabelParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, updateAccountLabel, arg.Label, arg.ID)
+	var id int64
+	err := row.Scan(&id)
+	return id, err
+}
+
 const updateAccountLastUpdate = `-- name: UpdateAccountLastUpdate :one
 UPDATE accounts
 SET last_updated = $1

--- a/db/sqlcmig6/querier.go
+++ b/db/sqlcmig6/querier.go
@@ -70,6 +70,7 @@ type Querier interface {
 	UpdateAccountAliasForTests(ctx context.Context, arg UpdateAccountAliasForTestsParams) (int64, error)
 	UpdateAccountBalance(ctx context.Context, arg UpdateAccountBalanceParams) (int64, error)
 	UpdateAccountExpiry(ctx context.Context, arg UpdateAccountExpiryParams) (int64, error)
+	UpdateAccountLabel(ctx context.Context, arg UpdateAccountLabelParams) (int64, error)
 	UpdateAccountLastUpdate(ctx context.Context, arg UpdateAccountLastUpdateParams) (int64, error)
 	UpdateFeatureKVStoreRecord(ctx context.Context, arg UpdateFeatureKVStoreRecordParams) error
 	UpdateGlobalKVStoreRecord(ctx context.Context, arg UpdateGlobalKVStoreRecordParams) error


### PR DESCRIPTION
PRs #1274 & #1281 introduced changes to the parts of the database code which is replicated in the kvdb->SQL migration code.
This PR also introduces those changes to the migration code.

Note that this PR will be based on `master` instead once the #1308 has been merged.