### PR TITLE
[sql-73] use `fillPlaceHolders` in `CountActions`

### DIFF
--- a/db/sqlc/actions_custom.go
+++ b/db/sqlc/actions_custom.go
@@ -85,7 +85,7 @@ func (q *Queries) CountActions(ctx context.Context,
 	arg ActionQueryParams) (int64, error) {
 
 	query, args := buildActionsQuery(arg, true)
-	row := q.db.QueryRowContext(ctx, query, args...)
+	row := q.db.QueryRowContext(ctx, fillPlaceHolders(query), args...)
 
 	var count int64
 	err := row.Scan(&count)

--- a/db/sqlcmig6/actions_custom.go
+++ b/db/sqlcmig6/actions_custom.go
@@ -85,7 +85,7 @@ func (q *Queries) CountActions(ctx context.Context,
 	arg ActionQueryParams) (int64, error) {
 
 	query, args := buildActionsQuery(arg, true)
-	row := q.db.QueryRowContext(ctx, query, args...)
+	row := q.db.QueryRowContext(ctx, fillPlaceHolders(query), args...)
 
 	var count int64
 	err := row.Scan(&count)


### PR DESCRIPTION
This PR addresses the following review comment for both the `sqlc` & `sqlcmig6` package: https://github.com/lightninglabs/lightning-terminal/pull/1307#discussion_r3240336006

Note that the base for this PR will be updated to `master` once #1308 has been merged. 