### PR TITLE
app: make build/.gitkeep postbuild step git-worktree friendly

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,7 @@
     "start": "BROWSER=none react-scripts start",
     "develop": "REACT_APP_USE_SAMPLE_DATA=true yarn start",
     "build": "react-scripts build",
-    "postbuild": "git restore build/.gitkeep",
+    "postbuild": "git restore build/.gitkeep 2>/dev/null || printf '# Keep directory in git.\\n' > build/.gitkeep",
     "test": "react-scripts test --env=jest-environment-jsdom --transformIgnorePatterns \"node_modules/(?!d3)/\"",
     "test:ci": "cross-env CI=true yarn test --coverage",
     "eject": "react-scripts eject",

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -16,6 +16,12 @@
 
 ### Bug Fixes
 
+* [Fix `dev.Dockerfile` build failure on git
+  worktree checkouts](https://github.com/lightninglabs/lightning-terminal/pull/1311):
+  The web UI `postbuild` step no longer aborts when the build context lacks a
+  reachable git directory, which previously broke `dev.Dockerfile` builds for
+  contributors using `git worktree`.
+
 * [Restore LNC session setup for mailbox
   links](https://github.com/lightninglabs/lightning-terminal/pull/1254):
   Mailbox-specific TLS transport credentials now allow mailbox links to proceed


### PR DESCRIPTION
Fixes #1022.

### Problem

When the working copy of `lightning-terminal` is a git worktree, the top-level `.git` is a file like `gitdir: ../.bare/worktrees/<name>` rather than a real `.git/` directory. Building with `dev.Dockerfile` then fails:

```
fatal: not a git repository: /go/src/github.com/lightninglabs/lightning-terminal/../.bare/worktrees/<name>
error Command failed with exit code 128.
```

This happens because `dev.Dockerfile` copies the working tree into the container with `COPY .`, but the path that the `.git` file points at lives outside the build context, so any git invocation inside the container errors out. The first git call inside the build comes from the `postbuild` script in `app/package.json`:

```json
"postbuild": "git restore build/.gitkeep",
```

That script aborts, `yarn build` fails, and the image build dies.

### Fix

Make the `postbuild` step tolerant of environments where git is not usable. `git restore` is still preferred — it preserves the exact byte contents from the index, including any line-ending normalisation the original [`app: use git restore to re-create .gitkeep file`](https://github.com/lightninglabs/lightning-terminal/commit/b66e46b8) commit was guarding against — and the fallback only kicks in when git cannot reach the worktree (which is exactly the case inside the dev image build):

```json
"postbuild": "git restore build/.gitkeep 2>/dev/null || printf '# Keep directory in git.\n' > build/.gitkeep"
```

### Verification

* On a normal checkout, `yarn --cwd app build` still restores `build/.gitkeep` from the index via `git restore` (the first branch of the `||`).
* In a directory where git cannot find a repository (e.g. a copy outside any git worktree, which mirrors the `dev.Dockerfile` situation), the second branch runs and writes the same content the file has at `HEAD`, so `git diff` is still clean once the file is back on the host.
