### PR TITLE
go.mod: bump pool to v0.7.0-beta

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -45,6 +45,12 @@
 
 ### Pool
 
+* Updated [`pool` to
+  `v0.7.0-beta`](https://github.com/lightninglabs/lightning-terminal/pull/1313),
+  which includes a fix for the auctioneer subscription stream silently
+  dying on EOF, jittered reconnect backoff, and a fix for stream
+  handling in the pending-open-channel consumer.
+
 ### Faraday
 
 ### Taproot Assets

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/lightninglabs/loop v0.31.8-beta
 	github.com/lightninglabs/loop/looprpc v1.0.13
 	github.com/lightninglabs/loop/swapserverrpc v1.0.20
-	github.com/lightninglabs/pool v0.6.6-beta
+	github.com/lightninglabs/pool v0.7.0-beta
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.3
 	github.com/lightninglabs/pool/poolrpc v1.0.1
 	github.com/lightninglabs/taproot-assets v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -1150,8 +1150,8 @@ github.com/lightninglabs/neutrino v0.16.1 h1:5Kz4ToxncEVkpKC6fwUjXKtFKJhuxlG3sBB
 github.com/lightninglabs/neutrino v0.16.1/go.mod h1:L+5UAccpUdyM7yDgmQySgixf7xmwBgJtOfs/IP26jCs=
 github.com/lightninglabs/neutrino/cache v1.1.3 h1:rgnabC41W+XaPuBTQrdeFjFCCAVKh1yctAgmb3Se9zA=
 github.com/lightninglabs/neutrino/cache v1.1.3/go.mod h1:qxkJb+pUxR5p84jl5uIGFCR4dGdFkhNUwMSxw3EUWls=
-github.com/lightninglabs/pool v0.6.6-beta h1:4b5wdsA1YslDwhOwFPeNMOUzJ56qokN3raAdKicURe4=
-github.com/lightninglabs/pool v0.6.6-beta/go.mod h1:QJ23DPEmWbj+Ne0SzzxnwVdL2MFXImSB86E+5MyUtU4=
+github.com/lightninglabs/pool v0.7.0-beta h1:sL+eO5ndanViImSNCpkaHaJNNYzoViYHEPHcp0ORoIo=
+github.com/lightninglabs/pool v0.7.0-beta/go.mod h1:gjY25+1yTjhgPU9icz5yWrHkMOVBrFXZDHlCra4zMHQ=
 github.com/lightninglabs/pool/auctioneerrpc v1.1.3 h1:Di5Nf8Gll9wl6tbXsusGXj9e4yNsHvoJ0ssgoHyFXqY=
 github.com/lightninglabs/pool/auctioneerrpc v1.1.3/go.mod h1:N/X9SxrBCjquK8XkwSgk4qvGC2g8Dra9uiw5sXWmEl0=
 github.com/lightninglabs/pool/poolrpc v1.0.1 h1:XbNx28TYwEj/PVsnnF9TnveVCMCYfS1vVkcwz29vPmM=


### PR DESCRIPTION
In this PR, we bump the embedded `pool` dependency up to [`v0.7.0-beta`](https://github.com/lightninglabs/pool/releases/tag/v0.7.0-beta). The main motivation is to pull in two reliability fixes around the auctioneer subscription path that were causing the order subscribe stream to silently die after extended runtime.

The first fix is the EOF handling in the subscribe stream (lightninglabs/pool#518). Before, an EOF from the auctioneer would leave the client in a state where the gRPC connection looked healthy, but no further order updates would actually arrive. We now treat EOF the same as any other transient stream error and trigger a reconnect rather than swallowing it. The second piece (also lightninglabs/pool#518) adds jittered backoff on the reconnect path, which avoids the thundering-herd scenario where every connected trader retries at the same instant after the auctioneer comes back up from a brief restart.

The release also pulls in the stream handling fix in `consumePendingOpenChannels` (lightninglabs/pool#507) so we don't get stuck on pending channel finalization, plus the usual round of transitive dependency bumps (`go-viper/mapstructure/v2`, `opencontainers/runc`, `golang-jwt/jwt/v4`, `golang.org/x/net`).

The diff itself is minimal: just `go.mod`/`go.sum` and a one-bullet entry under `### Pool` in the upcoming `0.17.0` release notes.

## Test plan

- [x] `go build ./...` passes on the main lit module.
- [ ] CI passes.