### PR TITLE
go.mod: bump pool to v0.7.1-beta

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -62,6 +62,12 @@
   dying on EOF, jittered reconnect backoff, and a fix for stream
   handling in the pending-open-channel consumer.
 
+* Updated [`pool` to
+  `v0.7.1-beta`](https://github.com/lightninglabs/lightning-terminal/pull/1314),
+  which includes a fix for `HandleServerShutdown` silently dropping
+  every account after the first per-account re-subscribe failure on a
+  reconnect.
+
 ### Faraday
 
 ### Taproot Assets

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/lightninglabs/loop v0.31.8-beta
 	github.com/lightninglabs/loop/looprpc v1.0.13
 	github.com/lightninglabs/loop/swapserverrpc v1.0.20
-	github.com/lightninglabs/pool v0.7.0-beta
+	github.com/lightninglabs/pool v0.7.1-beta
 	github.com/lightninglabs/pool/auctioneerrpc v1.1.3
 	github.com/lightninglabs/pool/poolrpc v1.0.1
 	github.com/lightninglabs/taproot-assets v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -1150,8 +1150,8 @@ github.com/lightninglabs/neutrino v0.16.1 h1:5Kz4ToxncEVkpKC6fwUjXKtFKJhuxlG3sBB
 github.com/lightninglabs/neutrino v0.16.1/go.mod h1:L+5UAccpUdyM7yDgmQySgixf7xmwBgJtOfs/IP26jCs=
 github.com/lightninglabs/neutrino/cache v1.1.3 h1:rgnabC41W+XaPuBTQrdeFjFCCAVKh1yctAgmb3Se9zA=
 github.com/lightninglabs/neutrino/cache v1.1.3/go.mod h1:qxkJb+pUxR5p84jl5uIGFCR4dGdFkhNUwMSxw3EUWls=
-github.com/lightninglabs/pool v0.7.0-beta h1:sL+eO5ndanViImSNCpkaHaJNNYzoViYHEPHcp0ORoIo=
-github.com/lightninglabs/pool v0.7.0-beta/go.mod h1:gjY25+1yTjhgPU9icz5yWrHkMOVBrFXZDHlCra4zMHQ=
+github.com/lightninglabs/pool v0.7.1-beta h1:sB7SeJ57Yc+5H5I+oKKPLCRx+eKjnqJRvBq8ZFVRhWg=
+github.com/lightninglabs/pool v0.7.1-beta/go.mod h1:gjY25+1yTjhgPU9icz5yWrHkMOVBrFXZDHlCra4zMHQ=
 github.com/lightninglabs/pool/auctioneerrpc v1.1.3 h1:Di5Nf8Gll9wl6tbXsusGXj9e4yNsHvoJ0ssgoHyFXqY=
 github.com/lightninglabs/pool/auctioneerrpc v1.1.3/go.mod h1:N/X9SxrBCjquK8XkwSgk4qvGC2g8Dra9uiw5sXWmEl0=
 github.com/lightninglabs/pool/poolrpc v1.0.1 h1:XbNx28TYwEj/PVsnnF9TnveVCMCYfS1vVkcwz29vPmM=


### PR DESCRIPTION
In this PR, we bump the embedded `pool` dependency up to [`v0.7.1-beta`](https://github.com/lightninglabs/pool/releases/tag/v0.7.1-beta). The motivation is a single auctioneer reliability fix that follows the same severity class as the EOF reconnect work we pulled in for `v0.7.0-beta`.

The fix is for `HandleServerShutdown` (lightninglabs/pool#521). Before, when the trader's subscription stream went down and the client tried to re-subscribe every account against the new stream, the loop bailed on the first per-account failure. Because the accounts were drained out of the in-memory `subscribedAccts` map *before* the loop ran, any account after the failing one in iteration order was silently lost. The trader looked healthy locally, but the auctioneer saw it as offline and filtered its orders at matching time until the process restarted. The symptom was also intermittent in practice, since Go's randomized map iteration meant the set of "survivors" changed between runs.

The new behavior is best-effort: per-account errors are logged with the trader key for operator visibility, every account still gets a re-subscribe attempt against the new stream, and the aggregated error is returned to the caller via `errors.Join` so the rpcserver still sees a non-nil signal when anything went wrong.

The diff itself is minimal: just `go.mod`/`go.sum` and a one-bullet entry under `### Pool` in the upcoming `0.17.0` release notes.

## Test plan

- [x] `go build .` on the main lit module is unaffected by the bump (pre-existing `perms/mock.go` lnd-API breakage is in a separate sub-module).
- [ ] CI passes.