### PR TITLE
Prepare for litd `v0.17.0-alpha.rc1` release

### DIFF
--- a/db/migsets/programmatic_migrations.go
+++ b/db/migsets/programmatic_migrations.go
@@ -152,10 +152,11 @@ func kvdbToSqlProgrammaticMigration(ctx context.Context,
 	// We'll fetch the macaroonIDList from `lnd` next. Note that since lnd's
 	// RPC servers may not have been fully started yet if the execution of
 	// accounts and session migration were really quick, we poll the request
-	// up to 10 times with a 0.5 second delay between the attempts. This
-	// should be a sufficient amount of time for the RPC servers to start.
+	// up to 120 times with a 0.5 second delay between the attempts. This
+	// should be a sufficient amount of time for the wallet to have been
+	// loaded and for the RPC servers to started.
 	const (
-		maxListMacaroonIDAttempts = 10
+		maxListMacaroonIDAttempts = 120
 		listMacaroonIDRetryDelay  = 500 * time.Millisecond
 	)
 

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -101,12 +101,6 @@
 ### Pool
 
 * Updated [`pool` to
-  `v0.7.0-beta`](https://github.com/lightninglabs/lightning-terminal/pull/1313),
-  which includes a fix for the auctioneer subscription stream silently
-  dying on EOF, jittered reconnect backoff, and a fix for stream
-  handling in the pending-open-channel consumer.
-
-* Updated [`pool` to
   `v0.7.1-beta`](https://github.com/lightninglabs/lightning-terminal/pull/1314),
   which includes a fix for `HandleServerShutdown` silently dropping
   every account after the first per-account re-subscribe failure on a

--- a/version.go
+++ b/version.go
@@ -34,12 +34,12 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn" +
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	appMajor uint = 0
-	appMinor uint = 16
-	appPatch uint = 1
+	appMinor uint = 17
+	appPatch uint = 0
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	appPreRelease = "alpha"
+	appPreRelease = "alpha.rc1"
 )
 
 // Version returns the application version as a properly formed string per the


### PR DESCRIPTION
Based on #1300.

This PR prepares litd for the `v0.17.0-alpha.rc1` release, and bumps `loop`.