### PR TITLE
docs: add sample-litd.conf and reference it in README

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -216,6 +216,26 @@ jobs:
         run: make sqlc-check
 
   ########################
+  # sample conf check
+  ########################
+  sample-conf-check:
+    name: Check sample-litd.conf is valid
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: ./.github/actions/setup-go
+        with:
+          go-version: '${{ env.GO_VERSION }}'
+
+      - name: check sample-litd.conf options
+        run: make sample-conf-check
+
+  ########################
   # lint code
   ########################
   lint:

--- a/Makefile
+++ b/Makefile
@@ -281,6 +281,15 @@ fmt: $(GOIMPORTS_BIN)
 	@$(call print, "Formatting source.")
 	gofmt -l -w -s $(GOFILES_NOVENDOR)
 
+sample-conf-check:
+	@$(call print, "Checking sample-litd.conf options are valid")
+	@HELP=$$(go run -tags="litd_no_ui $(LND_RELEASE_TAGS)" ./cmd/litd --help 2>&1 || true); \
+	FAILS=0; \
+	for OPT in $$(grep -E '^;[[:space:]]*[a-z][a-z0-9._-]+=' sample-litd.conf | sed -E 's/^;[[:space:]]*//' | cut -d= -f1); do \
+	    echo "$$HELP" | grep -qE -- "--$${OPT}[= ]" || { echo "Option '$$OPT' missing from litd --help"; FAILS=1; }; \
+	done; \
+	exit $$FAILS
+
 check-go-version-yaml:
 	@$(call print, "Checking for target Go version (v$(GO_VERSION)) in YAML files (*.yaml, *.yml)")
 	./scripts/check-go-version-yaml.sh $(GO_VERSION)
@@ -353,5 +362,5 @@ flakehunter-unit:
 	go-install go-install-noui go-install-cli app-build release go-release \
 	docker-release docker-tools scratch check unit unit-bench unit-cover unit-race \
 	clean-itest build-itest build-itest-binary itest-only itest \
-	itest-parallel flake-unit fmt lint \
+	itest-parallel flake-unit fmt lint sample-conf-check \
 	mod mod-check list rpc protos protos-check rpc-js-compile clean

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ configuration settings in `lnd.conf`. Note that any section headers (
 `[ Example ]`) in `lit.conf` should be removed or changed to comments (
 `# Example`).
 
+For a full reference of all litd-native configuration options with descriptions
+and defaults, see [`sample-litd.conf`](./sample-litd.conf) in this repository.
+
 ## Usage
 
 Read the [walkthrough](docs/WALKTHROUGH.md) document to learn more about how to

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Move all the configuration settings specific to LiT from `lnd.conf` to
 `lit.conf` and remove any previous LiT-specific customizations from the
 configuration settings in `lnd.conf`. Note that any section headers (
 `[ Example ]`) in `lit.conf` should be removed or changed to comments (
-`# Example`).
+`; Example`).
 
 For a full reference of all litd-native configuration options with descriptions
 and defaults, see [`sample-litd.conf`](./sample-litd.conf) in this repository.

--- a/sample-litd.conf
+++ b/sample-litd.conf
@@ -1,0 +1,372 @@
+; Sample configuration file for litd.
+;
+; The default location for this file is in ~/.lit/lit.conf on POSIX OSes,
+; %LOCALAPPDATA%/Lit/lit.conf on Windows,
+; ~/Library/Application Support/Lit/lit.conf on Mac OS.
+; The default location of this file can be overwritten by specifying the
+; --configfile= flag when starting litd.
+;
+; Boolean values can be specified as true/false or 1/0. Per default booleans
+; are always set to false.
+;
+; If only one value is specified for an option, then this is also the default
+; value used by litd. In case of multiple (example) values, the default is
+; explicitly mentioned. If the part after the equal sign is empty then litd has
+; no default for this option.
+;
+; NOTE: This file covers only litd-native options. For the configuration of
+; the integrated sub-daemons, refer to the respective sample configuration
+; files:
+;   - lnd:             https://github.com/lightningnetwork/lnd/blob/master/sample-lnd.conf
+;   - taproot-assets:  https://github.com/lightninglabs/taproot-assets/blob/main/sample-tapd.conf
+;   - loop:            https://github.com/lightninglabs/loop (see loopd --help)
+;   - pool:            https://github.com/lightninglabs/pool (see poold --help)
+;   - faraday:         https://github.com/lightninglabs/faraday (see faraday --help)
+;
+; When litd is running in integrated lnd mode, use --lnd.* flags for all lnd
+; settings (they map to the keys in sample-lnd.conf with the "lnd." prefix).
+; Similarly, use --taproot-assets.*, --loop.*, --pool.* and --faraday.* flags
+; for those daemons.
+;
+; NOTE: Unlike lnd's lnd.conf or tapd's tapd.conf, litd's lit.conf does NOT
+; support INI section headers (lines like "[Application Options]"). Use
+; comment lines (starting with ";") for grouping instead.
+
+; =============================================================================
+; Application Options
+; =============================================================================
+
+; The main litd host:port to listen on for incoming HTTP/2 connections. On this
+; port all gRPC services of all enabled daemons are exposed as well as REST (if
+; enablerest is set), grpc-web and the web UI itself.
+; httpslisten=127.0.0.1:8443
+
+; The host:port to listen on with TLS disabled. This is dangerous to enable as
+; credentials will be submitted without encryption. Should only be used in
+; combination with Tor hidden services or other external encryption.
+; insecure-httplisten=
+
+; Also allow REST requests to be made to the main HTTPS port configured above.
+; enablerest=false
+
+; Add an ip:port/hostname to allow cross origin access from. To allow all
+; origins, set as "*". Can be specified multiple times.
+; restcors=
+
+; The password that must be entered when using the web UI. Use a strong
+; password to protect your node from unauthorized access.
+; uipassword=
+
+; Same as uipassword but read the password from the specified file instead.
+; uipassword_file=
+
+; Same as uipassword but read the password from the specified environment
+; variable instead.
+; uipassword_env=
+
+; If set to true, no web UI will be served and the uipassword will not need to
+; be set. Useful for headless/API-only setups.
+; disableui=false
+
+; The main directory where litd looks for its configuration file and stores
+; data (TLS certificates, logs, macaroons) in remote lnd mode.
+; Default:
+;   lit-dir=~/.lit
+; Example:
+;   lit-dir=/home/user/.lit
+
+; Path to litd's configuration file.
+; configfile=~/.lit/lit.conf
+
+; Path to write the macaroon for litd's RPC and REST services if it doesn't
+; exist.
+; macaroonpath=~/.lit/mainnet/lit.macaroon
+
+; The network the UI and all its components run on.
+; Options: mainnet, testnet, testnet4, regtest, simnet, signet
+; network=mainnet
+
+; =============================================================================
+; Daemon Modes
+; =============================================================================
+
+; The mode to run lnd in. 'integrated' starts lnd alongside litd and stores
+; everything in lnd's main data directory (configure via --lnd.* flags).
+; 'remote' connects to an existing lnd node acting as a gRPC proxy (configure
+; via --remote.lnd.* flags).
+; Options: integrated, remote
+; lnd-mode=remote
+
+; The mode to run faraday in. 'integrated' (default) starts faraday alongside
+; litd. 'remote' connects to an existing faraday node. 'disable' skips faraday
+; entirely.
+; Options: integrated, remote, disable
+; faraday-mode=integrated
+
+; The mode to run loop in. 'integrated' (default) starts loopd alongside litd.
+; 'remote' connects to an existing loopd node. 'disable' skips loop entirely.
+; Options: integrated, remote, disable
+; loop-mode=integrated
+
+; The mode to run pool in. 'integrated' (default) starts poold alongside litd.
+; 'remote' connects to an existing poold node. 'disable' skips pool entirely.
+; Options: integrated, remote, disable
+; pool-mode=integrated
+
+; The mode to run taproot-assets in. 'integrated' (default) starts tapd
+; alongside litd. 'remote' connects to an existing tapd node. 'disable' skips
+; taproot-assets entirely.
+; Options: integrated, remote, disable
+; taproot-assets-mode=integrated
+
+; The timeout for RPC calls to lnd from other sub-servers (loop, pool, faraday,
+; taproot-assets). Increase this for slow lnd instances. Must not be set below
+; 30s to avoid stability issues.
+; lndrpctimeout=
+
+; The duration after which a new LNC session will be revoked if no connection
+; is made using the pairing phrase. This only applies to the first connection.
+; firstlncconndeadline=10m
+
+; Automatically approve a pending migration of legacy kvdb data to the
+; configured SQL backend without showing the interactive startup prompt.
+; The same behavior can also be triggered by setting the environment variable
+; LIT_AUTO_MIGRATE_TO_SQL=true.
+; auto-migrate-to-sql=false
+
+; The database backend to use for storing account, session and firewall data.
+; Options: bbolt, sqlite, postgres
+; databasebackend=sqlite
+
+; =============================================================================
+; TLS Configuration
+; =============================================================================
+
+; Path to write the self-signed TLS certificate for litd's RPC and REST proxy
+; service (used when letsencrypt is not enabled). Applies only to the
+; httpslisten port.
+; tlscertpath=~/.lit/tls.cert
+
+; Path to write the self-signed TLS private key for litd's RPC and REST proxy
+; service (used when letsencrypt is not enabled). Applies only to the
+; httpslisten port.
+; tlskeypath=~/.lit/tls.key
+
+; Adds an extra IP address to the generated litd TLS certificate. Can be
+; specified multiple times.
+; tlsextraip=
+
+; Adds an extra domain to the generated litd TLS certificate. Can be specified
+; multiple times.
+; tlsextradomain=
+
+; =============================================================================
+; Let's Encrypt (optional, replaces self-signed TLS)
+; =============================================================================
+
+; Use Let's Encrypt to obtain a valid TLS certificate for the UI instead of a
+; self-signed certificate. Port 80 must be free and reachable from the internet.
+; letsencrypt=false
+
+; The hostname to obtain a Let's Encrypt certificate for. Required when
+; letsencrypt=true.
+; letsencrypthost=
+
+; The directory where the Let's Encrypt library stores its key and certificate.
+; letsencryptdir=~/.lit/letsencrypt
+
+; The IP:port on which litd listens for Let's Encrypt HTTP-01 challenges.
+; Let's Encrypt always contacts port 80; use this option together with port
+; forwarding from port 80 if litd cannot bind to it directly.
+; letsencryptlisten=:80
+
+; =============================================================================
+; Remote Mode Options (used when lnd-mode=remote)
+; =============================================================================
+
+; Log directory for litd when running in remote lnd mode.
+; remote.lit-logdir=~/.lit/logs
+
+; Logging level for all litd subsystems in remote lnd mode.
+; {trace, debug, info, warn, error, critical}
+; You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the
+; log level for individual subsystems.
+; remote.lit-debuglevel=info
+
+; Maximum number of log files to keep (0 for no rotation). Deprecated: use
+; remote.lit-logging.file.max-files instead.
+; remote.lit-logging.file.max-files=10
+
+; Maximum log file size in MB. Deprecated: use
+; remote.lit-logging.file.max-file-size instead.
+; remote.lit-logging.file.max-file-size=20
+
+; ---- Remote lnd connection (required when lnd-mode=remote) ----
+
+; The host:port of the remote lnd node's gRPC server.
+; remote.lnd.rpcserver=localhost:10009
+
+; The full path to the remote lnd admin macaroon (or a custom baked macaroon
+; with all required permissions).
+; remote.lnd.macaroonpath=~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon
+
+; The full path to the remote lnd TLS certificate used for RPC verification.
+; remote.lnd.tlscertpath=~/.lnd/tls.cert
+
+; ---- Remote faraday connection (used when faraday-mode=remote) ----
+
+; The host:port of the remote faraday node's gRPC server.
+; remote.faraday.rpcserver=localhost:8465
+
+; The full path to the remote faraday macaroon.
+; remote.faraday.macaroonpath=
+
+; The full path to the remote faraday TLS certificate.
+; remote.faraday.tlscertpath=
+
+; ---- Remote loop connection (used when loop-mode=remote) ----
+
+; The host:port of the remote loopd node's gRPC server.
+; remote.loop.rpcserver=localhost:11010
+
+; The full path to the remote loopd macaroon.
+; remote.loop.macaroonpath=
+
+; The full path to the remote loopd TLS certificate.
+; remote.loop.tlscertpath=
+
+; ---- Remote pool connection (used when pool-mode=remote) ----
+
+; The host:port of the remote poold node's gRPC server.
+; remote.pool.rpcserver=localhost:12010
+
+; The full path to the remote poold macaroon.
+; remote.pool.macaroonpath=
+
+; The full path to the remote poold TLS certificate.
+; remote.pool.tlscertpath=
+
+; ---- Remote taproot-assets connection (used when taproot-assets-mode=remote) ----
+
+; The host:port of the remote tapd node's gRPC server.
+; remote.taproot-assets.rpcserver=localhost:10029
+
+; The full path to the remote tapd macaroon.
+; remote.taproot-assets.macaroonpath=
+
+; The full path to the remote tapd TLS certificate.
+; remote.taproot-assets.tlscertpath=
+
+; =============================================================================
+; SQLite (used when databasebackend=sqlite)
+; =============================================================================
+
+; Skip applying database schema migrations on startup.
+; sqlite.skipmigrations=false
+
+; Skip creating a backup of the database file before applying migrations.
+; sqlite.skipmigrationdbbackup=false
+
+; The full path to the SQLite database file.
+; sqlite.dbfile=~/.lit/mainnet/litd.db
+
+; =============================================================================
+; Postgres (used when databasebackend=postgres)
+; =============================================================================
+
+; Skip applying database schema migrations on startup.
+; postgres.skipmigrations=false
+
+; Database server hostname.
+; postgres.host=localhost
+
+; Database server port.
+; postgres.port=5432
+
+; Database user name.
+; postgres.user=
+
+; Database user's password.
+; postgres.password=
+
+; Database name to use.
+; postgres.dbname=
+
+; Maximum number of open connections to keep alive to the database server.
+; postgres.maxconnections=10
+
+; Maximum number of idle connections to keep in the connection pool.
+; postgres.maxidleconnections=
+
+; Maximum amount of time a connection can be reused before it is closed.
+; Valid time units are {s, m, h}.
+; postgres.connmaxlifetime=
+
+; Maximum amount of time a connection can be idle before it is closed.
+; Valid time units are {s, m, h}.
+; postgres.connmaxidletime=
+
+; Require SSL (mode: require) when connecting to the database server.
+; postgres.requiressl=false
+
+; =============================================================================
+; RPC Middleware
+; =============================================================================
+
+; Disable the RPC middleware interceptor. When disabled, litd's firewall rules
+; and request logging are also effectively disabled.
+; rpcmiddleware.disabled=false
+
+; The maximum time the RPC middleware is allowed to take to respond to each
+; intercepted RPC request before the request is rejected.
+; rpcmiddleware.intercept-timeout=2s
+
+; =============================================================================
+; Autopilot
+; =============================================================================
+
+; Disable the autopilot client. When disabled, Lit sessions that use autopilot
+; rules will not be able to communicate with the autopilot server.
+; autopilot.disable=false
+
+; The host:port of the autopilot server.
+; autopilot.address=
+
+; The host:port of a SOCKS proxy through which all connections to the autopilot
+; server will be established.
+; autopilot.proxy=
+
+; Disable TLS when connecting to the autopilot server. Should only be used for
+; testing.
+; autopilot.insecure=false
+
+; Path to the autopilot server's TLS certificate. Only needed if the server
+; uses a self-signed certificate.
+; autopilot.tlspath=
+
+; How often the client re-registers active autopilot sessions with the server
+; to confirm they are still live. Valid time units are {s, m, h}.
+; autopilot.pingcadence=1h
+
+; =============================================================================
+; Firewall
+; =============================================================================
+
+; Disable request logging completely. When set, autopilot.disable must also be
+; set. Improves performance by avoiding all logging overhead.
+; firewall.request-logger.disable=false
+
+; Set the request logger verbosity level.
+; Options: all, full, interceptor
+;   interceptor: only log requests that are intercepted by a middleware rule
+;   full:        log all requests including those not intercepted
+;   all:         log all requests with full request/response bodies
+; firewall.request-logger.level=interceptor
+
+; =============================================================================
+; Accounts
+; =============================================================================
+
+; Disable the accounts service. When disabled, litd will not track per-account
+; Lightning balances or enforce account spending limits.
+; accounts.disable=false

--- a/sample-litd.conf
+++ b/sample-litd.conf
@@ -193,12 +193,12 @@
 ; log level for individual subsystems.
 ; remote.lit-debuglevel=info
 
-; Maximum number of log files to keep (0 for no rotation). Deprecated: use
-; remote.lit-logging.file.max-files instead.
+; Maximum number of log files to keep (0 for no rotation).
+; The old option 'remote.lit-maxlogfiles' is deprecated.
 ; remote.lit-logging.file.max-files=10
 
-; Maximum log file size in MB. Deprecated: use
-; remote.lit-logging.file.max-file-size instead.
+; Maximum log file size in MB.
+; The old option 'remote.lit-maxlogfilesize' is deprecated.
 ; remote.lit-logging.file.max-file-size=20
 
 ; ---- Remote lnd connection (required when lnd-mode=remote) ----

--- a/sample-litd.conf
+++ b/sample-litd.conf
@@ -367,3 +367,4 @@
 ; Disable the accounts service. When disabled, litd will not track per-account
 ; Lightning balances or enforce account spending limits.
 ; accounts.disable=false
+; nonexistent-option=foo

--- a/sample-litd.conf
+++ b/sample-litd.conf
@@ -70,10 +70,7 @@
 
 ; The main directory where litd looks for its configuration file and stores
 ; data (TLS certificates, logs, macaroons) in remote lnd mode.
-; Default:
-;   lit-dir=~/.lit
-; Example:
-;   lit-dir=/home/user/.lit
+; lit-dir=~/.lit
 
 ; Path to litd's configuration file.
 ; configfile=~/.lit/lit.conf
@@ -122,7 +119,7 @@
 ; The timeout for RPC calls to lnd from other sub-servers (loop, pool, faraday,
 ; taproot-assets). Increase this for slow lnd instances. Must not be set below
 ; 30s to avoid stability issues.
-; lndrpctimeout=
+; lndrpctimeout=3m
 
 ; The duration after which a new LNC session will be revoked if no connection
 ; is made using the pairing phrase. This only applies to the first connection.

--- a/sample-litd.conf
+++ b/sample-litd.conf
@@ -367,4 +367,3 @@
 ; Disable the accounts service. When disabled, litd will not track per-account
 ; Lightning balances or enforce account spending limits.
 ; accounts.disable=false
-; nonexistent-option=foo


### PR DESCRIPTION
## What

Issue https://github.com/lightninglabs/lightning-terminal/issues/1098
Introduces `sample-litd.conf` — a comprehensive, well-commented configuration template for `litd` — and updates the README to point users to it.

## Why

There was no single reference file for `litd`-native configuration options. Users had to dig through `--help` output or source code to understand what settings exist, what they do, and what the defaults are. This fills that gap.

## Changes

- **`sample-litd.conf`** (new): 372-line annotated config covering application settings, TLS, Let's Encrypt, daemon modes, and more. Follows the same convention as `sample-lnd.conf` and `sample-tapd.conf` in the broader Lightning ecosystem.
- **`README.md`**: Adds a note directing users to `sample-litd.conf` as the canonical reference for litd-native config options, including descriptions and defaults.

> Note: This file intentionally covers only litd-native options. Sub-daemon configuration (lnd, taproot-assets, loop, pool, faraday) is delegated to their respective sample config files, with links provided inline.