### PR TITLE
[sql-77] terminal: shut down LiT when declining the SQL migration prompt

### DIFF
--- a/migration_prompt.go
+++ b/migration_prompt.go
@@ -17,6 +17,10 @@ import (
 
 const autoMigrateKVDBEnvVar = "LIT_AUTO_MIGRATE_TO_SQL"
 
+var errKVDBToSQLMigrationDeclined = errors.New(
+	"manual confirmation declined",
+)
+
 var kvdbToSQLMigrationPromptLines = []string{
 	"",
 	"CAUTION: litd is about to migrate your existing data to a new SQL " +
@@ -175,8 +179,8 @@ func promptForKVDBToSQLMigrationConfirmation(input io.Reader,
 	}
 
 	if strings.TrimSpace(answer) != "yes" {
-		return errors.New("manual confirmation declined; refusing to " +
-			"continue kvdb-to-SQL migration")
+		return fmt.Errorf("%w; refusing to continue kvdb-to-SQL "+
+			"migration", errKVDBToSQLMigrationDeclined)
 	}
 
 	return nil

--- a/migration_prompt_test.go
+++ b/migration_prompt_test.go
@@ -58,7 +58,7 @@ func TestConfirmPendingKVDBToSQLMigration(t *testing.T) {
 				createActiveAccountsKVDB(t, dbDir)
 			},
 			input:     "no\n",
-			expectErr: "manual confirmation declined",
+			expectErr: errKVDBToSQLMigrationDeclined.Error(),
 		},
 		{
 			name: "skips prompt on auto migration config",

--- a/terminal.go
+++ b/terminal.go
@@ -405,6 +405,19 @@ func (g *LightningTerminal) Run(ctx context.Context) error {
 		g.statusMgr.SetErrored(
 			subservers.LIT, "could not start Lit: %v", startErr,
 		)
+
+		// If the user has declined the migration prompt, we shut down
+		// Lit fully, and do not keep the status server up and running.
+		// The motivation for this is that the error occurs prior to
+		// Lit being able to accept a `litcli stop` call. Users running
+		// in an env that can't easily kill the daemon therefore need to
+		// be able to shut it down by just declining the migration.
+		// Note that no sub-servers, including `lnd`, have been
+		// started/connected to when the migration prompt is shown. We
+		// can therefore safely shut Lit down without affecting them.
+		if errors.Is(startErr, errKVDBToSQLMigrationDeclined) {
+			shutdownInterceptor.RequestShutdown()
+		}
 	}
 
 	// Now block until we receive an error or the main shutdown


### PR DESCRIPTION
Treat a declined kvdb-to-SQL migration prompt as a startup-abort condition that shuts litd down fully. This prevents litd from leaving the status server running after the operator refuses the migration prompt.

The reason why this is motivated, is that `litd` at this stage of the startup process will not be ready to handle an `litcli stop` RPC call.