### PR TITLE
itest: fix flaky testRequestLoggerDisable node cleanup

### DIFF
--- a/itest/litd_firewall_test.go
+++ b/itest/litd_firewall_test.go
@@ -308,8 +308,9 @@ func testRequestLoggerDisable(ctx context.Context, net *NetworkHarness,
 		"--autopilot.disable",
 	)
 	require.NoError(t.t, err)
+	reqLogOnNode := node
 	defer func() {
-		_ = net.ShutdownNode(node)
+		_ = net.ShutdownNode(reqLogOnNode)
 	}()
 
 	rawConn, err = connectLitRPC(


### PR DESCRIPTION
This PR fixes the flaky integration test cleanup failure in `testRequestLoggerDisable` as seen in this CI run: https://github.com/lightninglabs/lightning-terminal/actions/runs/27935451542/job/82656246033?pr=1317