### PR TITLE
accounts: add test coverage for checkLabel

### DIFF
--- a/accounts/store_test.go
+++ b/accounts/store_test.go
@@ -778,3 +778,61 @@ func TestLastInvoiceIndexes(t *testing.T) {
 	require.EqualValues(t, 7, add)
 	require.EqualValues(t, 99, settle)
 }
+
+// TestCheckLabel ensures that only labels that could be mistaken for a hex
+// encoded account ID are rejected, while all other labels (including the empty
+// label) are accepted.
+func TestCheckLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		label     string
+		expectErr bool
+	}{{
+		name:  "empty label is allowed",
+		label: "",
+	}, {
+		name:  "plain text label is allowed",
+		label: "my account",
+	}, {
+		name:  "short hex label is allowed",
+		label: "00112233",
+	}, {
+		name: "non-hex label with account ID length is allowed",
+		// 16 characters long, matching an encoded account ID, but not
+		// valid hex.
+		label: "zzzzzzzzzzzzzzzz",
+	}, {
+		name: "lowercase hex label with account ID length is rejected",
+		// 16 characters of valid hex, exactly the length of an encoded
+		// account ID.
+		label:     "0011223344556677",
+		expectErr: true,
+	}, {
+		name: "uppercase hex label with account ID length is rejected",
+		// hex.DecodeString also accepts uppercase digits, so this must
+		// be rejected as well.
+		label:     "00112233445566AA",
+		expectErr: true,
+	}}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := checkLabel(tc.label)
+			if tc.expectErr {
+				require.ErrorContains(
+					t, err, "is not allowed as it can be "+
+						"mistaken",
+				)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
### Change Description

`checkLabel` (in `accounts/interface.go`) rejects account labels that could be mistaken for a hex-encoded account ID, so the CLI can reliably tell labels and IDs apart. The helper had no dedicated unit test.

This adds a table-driven `TestCheckLabel` covering both branches:

- **Accepted:** empty label, plain-text label, short hex string, and a non-hex string that happens to be the length of an encoded account ID.
- **Rejected:** lower- and upper-case hex strings of exactly the encoded account-ID length (`hex.DecodeString` accepts uppercase, so that case is covered explicitly).

This fills the test-coverage gap left by the `checkLabel` validation discussed in the #1274 follow-ups (#1294). No behaviour change.

### Steps to Test

```
go test ./accounts/ -run TestCheckLabel -v
```

### Pull Request Checklist

- [x] Test coverage added.
- [x] Commits are signed (DCO).