### PR TITLE
litcli: drop unused flags from addinvoice command

### DIFF
--- a/cmd/litcli/ln.go
+++ b/cmd/litcli/ln.go
@@ -692,6 +692,41 @@ func payInvoice(cliCtx *cli.Context) error {
 	)
 }
 
+// addInvoiceUnsupportedFlags is the set of flags that are inherited from
+// lncli's addinvoice command but don't apply to Taproot Asset invoices. The
+// addInvoice action below never reads these, so we strip them to avoid
+// presenting options that have no effect.
+var addInvoiceUnsupportedFlags = map[string]struct{}{
+	// The final-hop CLTV delta isn't applied to asset invoices.
+	"cltv_expiry_delta": {},
+
+	// Blinded paths aren't supported for asset invoices; the relevant hop
+	// hints are added as part of the RFQ process instead.
+	"blind":                              {},
+	"min_real_blinded_hops":              {},
+	"num_blinded_hops":                   {},
+	"max_blinded_paths":                  {},
+	"blinded_path_omit_node":             {},
+	"blinded_path_incoming_channel_list": {},
+}
+
+// withoutUnsupportedAddInvoiceFlags returns the given flags with the ones that
+// don't apply to Taproot Asset invoices (see addInvoiceUnsupportedFlags)
+// removed.
+func withoutUnsupportedAddInvoiceFlags(flags []cli.Flag) []cli.Flag {
+	filtered := make([]cli.Flag, 0, len(flags))
+	for _, flag := range flags {
+		_, unsupported := addInvoiceUnsupportedFlags[flag.GetName()]
+		if unsupported {
+			continue
+		}
+
+		filtered = append(filtered, flag)
+	}
+
+	return filtered
+}
+
 var addInvoiceCommand = cli.Command{
 	Name:     "addinvoice",
 	Category: commands.AddInvoiceCommand.Category,
@@ -703,7 +738,9 @@ var addInvoiceCommand = cli.Command{
 	ArgsUsage: "[--asset_id=X | --group_key=X] --asset_amount=Y " +
 		"[--rfq_peer_pubkey=Z] ",
 	Flags: append(
-		commands.AddInvoiceCommand.Flags,
+		withoutUnsupportedAddInvoiceFlags(
+			commands.AddInvoiceCommand.Flags,
+		),
 		cli.StringFlag{
 			Name: "asset_id",
 			Usage: "the asset ID of the asset to receive; cannot " +

--- a/cmd/litcli/ln_test.go
+++ b/cmd/litcli/ln_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddInvoiceCommandFlags ensures that the litcli addinvoice command keeps
+// the flags its action actually reads (including the asset-specific ones it
+// adds) while dropping the inherited lncli flags that don't apply to Taproot
+// Asset invoices.
+func TestAddInvoiceCommandFlags(t *testing.T) {
+	t.Parallel()
+
+	flagNames := make(map[string]struct{})
+	for _, flag := range addInvoiceCommand.Flags {
+		flagNames[flag.GetName()] = struct{}{}
+	}
+
+	// Flags that the addInvoice action reads must remain available.
+	expected := []string{
+		"memo", "preimage", "amt", "amt_msat", "description_hash",
+		"fallback_addr", "expiry", "private", "amp",
+		"asset_id", "group_key", "asset_amount", "rfq_peer_pubkey",
+	}
+	for _, name := range expected {
+		_, ok := flagNames[name]
+		require.Truef(t, ok, "expected flag %q to be present", name)
+	}
+
+	// Flags that don't apply to asset invoices must be removed.
+	for name := range addInvoiceUnsupportedFlags {
+		_, ok := flagNames[name]
+		require.Falsef(t, ok, "expected flag %q to be removed", name)
+	}
+}

--- a/docs/release-notes/release-notes-0.17.1.md
+++ b/docs/release-notes/release-notes-0.17.1.md
@@ -41,6 +41,11 @@
   permanently, requiring a manual restart. The wait is now bounded by a
   configurable, generous timeout (`--lndreadytimeout`, defaulting to 10
   minutes) instead of a fixed attempt count.
+* [Hide unsupported flags from `litcli ln
+  addinvoice`](https://github.com/lightninglabs/lightning-terminal/pull/1335):
+  The `addinvoice` command no longer advertises the blinded-path flags or
+  `--cltv_expiry_delta`, which were inherited from `lncli` but have no effect on
+  Taproot Asset invoices.
 
 ### Functional Changes/Additions
 


### PR DESCRIPTION
### Change Description

Fixes #1121.

`litcli ln addinvoice` builds its flag set by appending the asset-specific flags onto `lncli`'s full `addinvoice` flag list. As a result, `litcli ln addinvoice -h` advertises a number of flags that the command's action never reads and that don't apply to Taproot Asset invoices.

This filters out the flags that are demonstrably unused by the `addInvoice` action:

- `cltv_expiry_delta`
- `blind`, `min_real_blinded_hops`, `num_blinded_hops`, `max_blinded_paths`, `blinded_path_omit_node`, `blinded_path_incoming_channel_list`

These are never referenced when building the `AddInvoiceRequest`, so removing them from the command only changes the help output, not behaviour. A test asserts the command keeps every flag the action consumes (including the asset flags) and drops the unsupported ones.

Note: `--private`, `--amp` and `--fallback_addr` are left in place for now since the action does pass them through to the RPC. If the Taproot Assets invoice path doesn't honour them either, they can be removed in a follow-up — happy to do that here too if preferred.

### Steps to Test

```
make build
./litcli-debug ln addinvoice -h
```

The blinded-path options and `--cltv_expiry_delta` should no longer be listed. Or run the unit test:

```
go test -tags="autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc neutrinorpc monitoring peersrpc kvdb_postgres kvdb_etcd kvdb_sqlite" ./cmd/litcli/ -run TestAddInvoiceCommandFlags -v
```

### Pull Request Checklist

- [x] Test coverage added.
- [x] Commits are signed (DCO).