### PR TITLE
config: make litd -V report litd version

### DIFF
--- a/config.go
+++ b/config.go
@@ -365,16 +365,12 @@ func loadAndValidateConfig(interceptor signal.Interceptor) (*Config, error) {
 		return nil, fmt.Errorf("error parsing flags: %w", err)
 	}
 
-	// Show the version and exit if the version flag was specified.
+	// Show the version and exit if the version flag was specified. This
+	// applies for both the `--version` and the `-V` flag.
 	appName := filepath.Base(os.Args[0])
 	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
-	if preCfg.ShowVersion {
+	if preCfg.ShowVersion || preCfg.Lnd.ShowVersion {
 		fmt.Println(appName, "version", RichVersion())
-		os.Exit(0)
-	}
-	if preCfg.Lnd.ShowVersion {
-		fmt.Println(appName, "version", build.Version(),
-			"commit="+build.Commit)
 		os.Exit(0)
 	}
 

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -35,6 +35,10 @@
 
 ### Technical and Architectural Updates
 
+* [Report litd's own version for `litd
+  -V`](https://github.com/lightninglabs/lightning-terminal/pull/1337): The `-V`
+  flag now prints litd's version instead of the integrated lnd version.
+
 ## RPC Updates
 
 ## Integrated Binary Updates


### PR DESCRIPTION
### Change Description

Fixes #1091.

`litd -V` reported the integrated **lnd** version rather than litd's own version. The `-V` / `--version` flag is inherited from lnd's embedded config (`preCfg.Lnd.ShowVersion`), and its handler printed `build.Version()` / `build.Commit` from `github.com/lightningnetwork/lnd/build`:

```go
if preCfg.Lnd.ShowVersion {
    fmt.Println(appName, "version", build.Version(), "commit="+build.Commit)
    os.Exit(0)
}
```

litd's own `--version` flag (`preCfg.ShowVersion`) already printed the correct value via `RichVersion()`. This consolidates both flags so either one reports litd's version, matching the behaviour agreed on in the issue thread.

### Steps to Test

```
make build
./litd-debug -V
./litd-debug --version
```

Both now print litd's version (e.g. `litd version 0.17.0-alpha.rc1 commit=... commit_hash=...`). Before this change `-V` printed lnd's version (e.g. `0.21.0-beta`).

### Pull Request Checklist

- [x] Verified by building `litd` and running both `-V` and `--version`.
- [x] Commits are signed (DCO).