### PR TITLE
docker: improve cleanup of docker space in CI

### DIFF
--- a/.github/actions/cleanup-space/action.yml
+++ b/.github/actions/cleanup-space/action.yml
@@ -1,0 +1,48 @@
+name: "Clean up runner disk space"
+description: "Removes large, non-essential toolsets to free up disk space."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Free up disk space
+      shell: bash
+      run: |
+        echo "Removing large toolsets to free up disk space..."
+        echo "Disk space before cleanup:"
+        df -h
+
+        # Remove large language/runtime toolsets that aren't needed for the
+        # Docker image build on the GitHub-hosted runner.
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/share/swift
+        sudo rm -rf /usr/local/julia*
+        sudo rm -rf /opt/hostedtoolcache
+
+        # Reclaim any Docker images that may already be present on the runner.
+        docker image prune -a -f || true
+
+        # Remove large apt packages and clean related caches.
+        sudo apt-get remove -y \
+          '^aspnetcore-.*' \
+          '^dotnet-.*' \
+          '^llvm-.*' \
+          'php.*' \
+          '^mongodb-.*' \
+          '^mysql-.*' \
+          azure-cli \
+          google-chrome-stable \
+          firefox \
+          powershell \
+          mono-devel \
+          libgl1-mesa-dri 2>/dev/null || true
+        sudo apt-get autoremove -y
+        sudo apt-get clean
+
+        # Remove additional large caches and tool directories.
+        sudo rm -rf /usr/local/share/boost
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
+        echo "Disk space after cleanup:"
+        df -h

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: cleanup space
-        run: rm -rf /opt/hostedtoolcache
+        uses: ./.github/actions/cleanup-space
   
       - name: Set up QEMU
         uses: lightninglabs/gh-actions/setup-qemu-action@2021.01.25.00


### PR DESCRIPTION
Mimic `lnd`s cleanup of docker space in CI by adding a new clean-space job which removes the same docker related artifacts as `lnd` does prior to running the rest of the docker.yml jobs.

Here's the `lnd` version of the file: https://github.com/lightningnetwork/lnd/blob/master/.github/actions/cleanup-space/action.yml