### PR TITLE
test: add coverage for normalizeVerString

### DIFF
--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,65 @@
+package terminal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNormalizeVerString ensures that normalizeVerString keeps only the
+// characters that are valid according to the semantic versioning guidelines
+// (those contained in semanticAlphabet) and strips everything else.
+func TestNormalizeVerString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{{
+		name:     "empty string",
+		input:    "",
+		expected: "",
+	}, {
+		name:     "already valid alphanumeric",
+		input:    "alpha1",
+		expected: "alpha1",
+	}, {
+		name:     "valid with hyphen and dot",
+		input:    "beta-rc.2",
+		expected: "beta-rc.2",
+	}, {
+		name:     "spaces are stripped",
+		input:    "hello world",
+		expected: "helloworld",
+	}, {
+		name: "disallowed punctuation is stripped",
+		// Underscore, plus and slash are not part of
+		// semanticAlphabet.
+		input:    "a_b+c/d",
+		expected: "abcd",
+	}, {
+		name:     "non-ascii runes are stripped",
+		input:    "café-αβ",
+		expected: "caf-",
+	}, {
+		name:     "all characters invalid",
+		input:    "@#$%^&*()",
+		expected: "",
+	}, {
+		name:     "full semver pre-release passes through",
+		input:    "0.17.0-alpha.rc1",
+		expected: "0.17.0-alpha.rc1",
+	}}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(
+				t, tc.expected, normalizeVerString(tc.input),
+			)
+		})
+	}
+}


### PR DESCRIPTION
### Change Description

`normalizeVerString` (in `version.go`) strips any character that isn't valid in a semantic-version pre-release / build-metadata string (i.e. not part of `semanticAlphabet`). It's used when building the version string but had no unit test.

This adds a table-driven `TestNormalizeVerString` covering:

- pass-through of already-valid strings (alphanumerics, `-`, `.`)
- stripping of spaces, disallowed punctuation (`_`, `+`, `/`), and non-ASCII runes
- empty and fully-invalid input

No behaviour change.

I've intentionally left out a release-notes entry since this is test-only and has no user-facing impact, matching the approach taken in #1334. Happy to add one if you'd prefer.

### Steps to Test

```
go test -tags="autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc neutrinorpc monitoring peersrpc kvdb_postgres kvdb_etcd kvdb_sqlite" . -run TestNormalizeVerString -v
```

### Pull Request Checklist

- [x] Test coverage added.
- [x] Commits are signed (DCO).