### PR TITLE
build: bump sqldb/v2 to v2.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ env:
   # If you change this value, please change it in the following files as well:
   # /Dockerfile
   # /dev.Dockerfile
-  GO_VERSION: 1.25.10
+  GO_VERSION: 1.25.11
 
 jobs:
   ########################

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apk add --no-cache --update alpine-sdk \
 
 # The first stage is already done and all static assets should now be generated
 # in the app/build sub directory.
-FROM golang:1.25.10-alpine3.23@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 as golangbuilder
+FROM golang:1.25.11-alpine3.23@sha256:60e626bbde32def8694687d03536ea4341b19e5f068e9a630225a1dfbd0505c9 as golangbuilder
 
 # Instead of checking out from git again, we just copy the whole working
 # directory of the previous stage that includes the generated static assets.

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ PUBLIC_URL :=
 # GO_VERSION is the Go version used for the release build, docker files, and
 # GitHub Actions. This is the reference version for the project. All other Go
 # versions are checked against this version.
-GO_VERSION = 1.25.10
+GO_VERSION = 1.25.11
 
 LOOP_COMMIT := $(shell cat go.mod | \
 		grep $(LOOP_PKG) | \

--- a/accounts/store_sql.go
+++ b/accounts/store_sql.go
@@ -33,8 +33,6 @@ const (
 //
 //nolint:ll
 type SQLQueries interface {
-	sqldb.BaseQuerier
-
 	AddAccountInvoice(ctx context.Context, arg sqlc.AddAccountInvoiceParams) error
 	DeleteAccount(ctx context.Context, id int64) error
 	DeleteAccountPayment(ctx context.Context, arg sqlc.DeleteAccountPaymentParams) error
@@ -79,7 +77,7 @@ type SQLStore struct {
 	clock clock.Clock
 }
 
-type sqlQueriesExecutor[T sqldb.BaseQuerier] struct {
+type sqlQueriesExecutor[T any] struct {
 	*sqldb.TransactionExecutor[T]
 
 	SQLQueries

--- a/autopilotserverrpc/go.mod
+++ b/autopilotserverrpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/autopilotserverrpc
 
-go 1.25.10
+go 1.25.11
 
 require (
 	google.golang.org/grpc v1.79.3

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -37,6 +37,43 @@ const (
 	LatestDevMigrationVersion = 0
 )
 
+// MakeMigrationDescriptors returns the ordered migration descriptors for LiT's
+// production SQL schema.
+func MakeMigrationDescriptors() []sqldb.MigrationDescriptor {
+	return []sqldb.MigrationDescriptor{
+		{
+			Name:          "accounts",
+			Version:       1,
+			SchemaVersion: 1,
+		},
+		{
+			Name:          "sessions",
+			Version:       2,
+			SchemaVersion: 2,
+		},
+		{
+			Name:          "kvstores",
+			Version:       3,
+			SchemaVersion: 3,
+		},
+		{
+			Name:          "privacy_pairs",
+			Version:       4,
+			SchemaVersion: 4,
+		},
+		{
+			Name:          "actions",
+			Version:       5,
+			SchemaVersion: 5,
+		},
+		{
+			Name:          "kvdb_to_sql",
+			Version:       6,
+			SchemaVersion: 6,
+		},
+	}
+}
+
 // HasDevMigrations reports whether any dev SQL migration files are embedded in
 // the current build. This lets dev builds omit the separate dev migration set
 // cleanly when the directory exists but currently contains no migration files.
@@ -67,6 +104,7 @@ func MakeTestMigrationSets() []sqldb.MigrationSet {
 		//
 		// NOTE: This MUST be updated when a new migration is added.
 		LatestMigrationVersion: LatestMigrationVersion,
+		Descriptors:            MakeMigrationDescriptors(),
 
 		MakeProgrammaticMigrations: func(db *sqldb.BaseDB) (
 			map[uint]migrate.ProgrammaticMigrEntry, error) {

--- a/db/migsets/sql_migrations.go
+++ b/db/migsets/sql_migrations.go
@@ -35,6 +35,7 @@ func MakeMigrationSets(ctx context.Context, basicClient lnrpc.LightningClient,
 		//
 		// NOTE: This MUST be updated when a new migration is added.
 		LatestMigrationVersion: db.LatestMigrationVersion,
+		Descriptors:            db.MakeMigrationDescriptors(),
 
 		MakeProgrammaticMigrations: func(baseDB *sqldb.BaseDB) (
 			map[uint]migrate.ProgrammaticMigrEntry, error) {

--- a/db/migsets/sql_migrations_dev.go
+++ b/db/migsets/sql_migrations_dev.go
@@ -34,6 +34,7 @@ func MakeMigrationSets(ctx context.Context,
 		//
 		// NOTE: This MUST be updated when a new migration is added.
 		LatestMigrationVersion: db.LatestMigrationVersion,
+		Descriptors:            db.MakeMigrationDescriptors(),
 
 		MakeProgrammaticMigrations: func(baseDB *sqldb.BaseDB) (
 			map[uint]migrate.ProgrammaticMigrEntry, error) {

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -20,7 +20,7 @@ RUN cd /go/src/github.com/lightninglabs/lightning-terminal/app \
 
 # The first stage is already done and all static assets should now be generated
 # in the app/build sub directory.
-FROM golang:1.25.10-alpine3.23@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 as golangbuilder
+FROM golang:1.25.11-alpine3.23@sha256:60e626bbde32def8694687d03536ea4341b19e5f068e9a630225a1dfbd0505c9 as golangbuilder
 
 # Instead of checking out from git again, we just copy the whole working
 # directory of the previous stage that includes the generated static assets.

--- a/firewalldb/sql_store.go
+++ b/firewalldb/sql_store.go
@@ -20,8 +20,6 @@ type SQLSessionQueries interface {
 // SQLQueries is a subset of the sqlc.Queries interface that can be used to
 // interact with various firewalldb tables.
 type SQLQueries interface {
-	sqldb.BaseQuerier
-
 	SQLKVStoreQueries
 	SQLPrivacyPairQueries
 	SQLActionQueries
@@ -48,7 +46,7 @@ type SQLDB struct {
 	clock clock.Clock
 }
 
-type sqlQueriesExecutor[T sqldb.BaseQuerier] struct {
+type sqlQueriesExecutor[T any] struct {
 	*sqldb.TransactionExecutor[T]
 
 	SQLQueries

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/lightningnetwork/lnd/fn v1.2.5
 	github.com/lightningnetwork/lnd/fn/v2 v2.0.9
 	github.com/lightningnetwork/lnd/kvdb v1.4.16
-	github.com/lightningnetwork/lnd/sqldb/v2 v2.0.0-20260326184657-f7cc56305bae
+	github.com/lightningnetwork/lnd/sqldb/v2 v2.0.0
 	github.com/lightningnetwork/lnd/tlv v1.3.2
 	github.com/lightningnetwork/lnd/tor v1.1.7
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/btcsuite/btcd v0.25.1-0.20260310163610-1c55c7c18179

--- a/go.sum
+++ b/go.sum
@@ -1189,8 +1189,8 @@ github.com/lightningnetwork/lnd/queue v1.2.0 h1:sSrn+u84OLuOT/F+xGxgg8VfknXeIZEA
 github.com/lightningnetwork/lnd/queue v1.2.0/go.mod h1:qLNP0L3B7piRGvDyhAyJKic4xTt+Mw4D7mWrQeuAwxY=
 github.com/lightningnetwork/lnd/sqldb v1.0.13 h1:CcG9mrHNW/hIuZnqgosdiNmS7QhjSyfR/XkSFJB7EC8=
 github.com/lightningnetwork/lnd/sqldb v1.0.13/go.mod h1:ew3kMfknA0B4djTtrQSAkxvro+8+c++L8LuNaoT7GQA=
-github.com/lightningnetwork/lnd/sqldb/v2 v2.0.0-20260326184657-f7cc56305bae h1:ICRuZIkXed43iuqcJaayubPTcQolttttwNZFrapdwIo=
-github.com/lightningnetwork/lnd/sqldb/v2 v2.0.0-20260326184657-f7cc56305bae/go.mod h1:T2F1Sfb0oSpZyylIEE3ijiSejaXvIExER5xEdoe5wEE=
+github.com/lightningnetwork/lnd/sqldb/v2 v2.0.0 h1:c0tt+rlsXCPmPlw641ruOe+EmeyFPWmD+E4sONaj0lc=
+github.com/lightningnetwork/lnd/sqldb/v2 v2.0.0/go.mod h1:TyfjJz1iAKJA3uw3Tk7Mto0FJZY/MR5mAUc5qI80zB4=
 github.com/lightningnetwork/lnd/ticker v1.1.1 h1:J/b6N2hibFtC7JLV77ULQp++QLtCwT6ijJlbdiZFbSM=
 github.com/lightningnetwork/lnd/ticker v1.1.1/go.mod h1:waPTRAAcwtu7Ji3+3k+u/xH5GHovTsCoSVpho0KDvdA=
 github.com/lightningnetwork/lnd/tlv v1.3.2 h1:MO4FCk7F4k5xPMqVZF6Nb/kOpxlwPrUQpYjmyKny5s0=

--- a/litrpc/Dockerfile
+++ b/litrpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.10-bookworm@sha256:154bd7001b6eb339e88c964442c0ad6ed5e53f09844cc818a41ce4ecb3ce3b43
+FROM golang:1.25.11-bookworm@sha256:b96f24a8d7d010ea0acb9c3ba99064740f02b6b984612b28bd3c9c5ab9453e38
 
 RUN apt-get update && apt-get install -y \
   git \

--- a/litrpc/go.mod
+++ b/litrpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/litrpc
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.10-bookworm@sha256:154bd7001b6eb339e88c964442c0ad6ed5e53f09844cc818a41ce4ecb3ce3b43
+FROM golang:1.25.11-bookworm@sha256:b96f24a8d7d010ea0acb9c3ba99064740f02b6b984612b28bd3c9c5ab9453e38
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>
 

--- a/perms/go.mod
+++ b/perms/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/perms
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/btcsuite/btcd v0.25.1-0.20260310163610-1c55c7c18179

--- a/session/sql_store.go
+++ b/session/sql_store.go
@@ -24,8 +24,6 @@ import (
 //
 // nolint:ll
 type SQLQueries interface {
-	sqldb.BaseQuerier
-
 	GetAliasBySessionID(ctx context.Context, id int64) ([]byte, error)
 	GetSessionByID(ctx context.Context, id int64) (sqlc.Session, error)
 	GetSessionsInGroup(ctx context.Context, groupID sql.NullInt64) ([]sqlc.Session, error)
@@ -78,7 +76,7 @@ type SQLStore struct {
 	clock clock.Clock
 }
 
-type sqlQueriesExecutor[T sqldb.BaseQuerier] struct {
+type sqlQueriesExecutor[T any] struct {
 	*sqldb.TransactionExecutor[T]
 
 	SQLQueries

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.10-bookworm@sha256:154bd7001b6eb339e88c964442c0ad6ed5e53f09844cc818a41ce4ecb3ce3b43
+FROM golang:1.25.11-bookworm@sha256:b96f24a8d7d010ea0acb9c3ba99064740f02b6b984612b28bd3c9c5ab9453e38
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/tools
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/btcsuite/btcd v0.24.2

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/tools/linters
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/golangci/plugin-module-register v0.1.1


### PR DESCRIPTION
## Summary

Bumps `github.com/lightningnetwork/lnd/sqldb/v2` from the pseudo-version to the signed `v2.0.0` tag.

This also updates the local SQL store wrappers for the `sqldb/v2` executor API, which no longer exposes `BaseQuerier`, and adds migration descriptors required by the stricter migration set validation in `sqldb/v2.0.0`.

## Stacking

This branch is built on top of #1351, which bumps the project Go version to `1.25.11`. Once #1351 lands, this PR should only contain the sqldb-specific changes.

## Validation

- `go mod tidy`
- `go test ./accounts ./session ./firewalldb ./db/...`
