### PR TITLE
build: bump go to v1.25.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ env:
   # If you change this value, please change it in the following files as well:
   # /Dockerfile
   # /dev.Dockerfile
-  GO_VERSION: 1.25.10
+  GO_VERSION: 1.25.11
 
 jobs:
   ########################

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apk add --no-cache --update alpine-sdk \
 
 # The first stage is already done and all static assets should now be generated
 # in the app/build sub directory.
-FROM golang:1.25.10-alpine3.23@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 as golangbuilder
+FROM golang:1.25.11-alpine3.23@sha256:60e626bbde32def8694687d03536ea4341b19e5f068e9a630225a1dfbd0505c9 as golangbuilder
 
 # Instead of checking out from git again, we just copy the whole working
 # directory of the previous stage that includes the generated static assets.

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ PUBLIC_URL :=
 # GO_VERSION is the Go version used for the release build, docker files, and
 # GitHub Actions. This is the reference version for the project. All other Go
 # versions are checked against this version.
-GO_VERSION = 1.25.10
+GO_VERSION = 1.25.11
 
 LOOP_COMMIT := $(shell cat go.mod | \
 		grep $(LOOP_PKG) | \

--- a/autopilotserverrpc/go.mod
+++ b/autopilotserverrpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/autopilotserverrpc
 
-go 1.25.10
+go 1.25.11
 
 require (
 	google.golang.org/grpc v1.79.3

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -20,7 +20,7 @@ RUN cd /go/src/github.com/lightninglabs/lightning-terminal/app \
 
 # The first stage is already done and all static assets should now be generated
 # in the app/build sub directory.
-FROM golang:1.25.10-alpine3.23@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 as golangbuilder
+FROM golang:1.25.11-alpine3.23@sha256:60e626bbde32def8694687d03536ea4341b19e5f068e9a630225a1dfbd0505c9 as golangbuilder
 
 # Instead of checking out from git again, we just copy the whole working
 # directory of the previous stage that includes the generated static assets.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/btcsuite/btcd v0.25.1-0.20260310163610-1c55c7c18179

--- a/litrpc/Dockerfile
+++ b/litrpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.10-bookworm@sha256:154bd7001b6eb339e88c964442c0ad6ed5e53f09844cc818a41ce4ecb3ce3b43
+FROM golang:1.25.11-bookworm@sha256:b96f24a8d7d010ea0acb9c3ba99064740f02b6b984612b28bd3c9c5ab9453e38
 
 RUN apt-get update && apt-get install -y \
   git \

--- a/litrpc/go.mod
+++ b/litrpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/litrpc
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.10-bookworm@sha256:154bd7001b6eb339e88c964442c0ad6ed5e53f09844cc818a41ce4ecb3ce3b43
+FROM golang:1.25.11-bookworm@sha256:b96f24a8d7d010ea0acb9c3ba99064740f02b6b984612b28bd3c9c5ab9453e38
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>
 

--- a/perms/go.mod
+++ b/perms/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/perms
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/btcsuite/btcd v0.25.1-0.20260310163610-1c55c7c18179

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.10-bookworm@sha256:154bd7001b6eb339e88c964442c0ad6ed5e53f09844cc818a41ce4ecb3ce3b43
+FROM golang:1.25.11-bookworm@sha256:b96f24a8d7d010ea0acb9c3ba99064740f02b6b984612b28bd3c9c5ab9453e38
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/tools
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/btcsuite/btcd v0.24.2

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lightning-terminal/tools/linters
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/golangci/plugin-module-register v0.1.1


### PR DESCRIPTION
## Summary

Bumps the project Go version from `1.25.10` to `1.25.11` across the root module, nested modules, CI workflow, release Makefile setting, and pinned Docker images.

The Docker base image digests were refreshed for:

- `golang:1.25.11-alpine3.23`
- `golang:1.25.11-bookworm`

## Validation

- `./scripts/check-go-version-yaml.sh 1.25.11`
- `./scripts/check-go-version-dockerfile.sh 1.25.11`
- `go mod tidy` in root, `autopilotserverrpc`, `litrpc`, `perms`, `tools`, and `tools/linters`
- `make lint`
