### PR TITLE
docs: Add new release notes for `v0.17.1-alpha`

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -33,13 +33,6 @@
   expiration date would overwrite it to 0 (never expires). It now correctly
   defaults to -1 (no change).
 
-* [Gate wallet-ready status on lnd's actual RPC
-  readiness](https://github.com/lightninglabs/lightning-terminal/pull/1353):
-  Fixed a startup race where litd could report the LND sub-server as "Wallet
-  Ready" before lnd's RPC interceptor had actually left its
-  `WAITING_TO_START` state, so the very next call could still fail with
-  `rpc error: ... waiting to start`.
-
 ### Functional Changes/Additions
 
 * [Support for SQL database
@@ -99,10 +92,6 @@
   comma-separated lists, and mixed input.
 
 ### Technical and Architectural Updates
-
-* [Report litd's own version for `litd
-  -V`](https://github.com/lightninglabs/lightning-terminal/pull/1337): The `-V`
-  flag now prints litd's version instead of the integrated lnd version.
 
 ## RPC Updates
 

--- a/docs/release-notes/release-notes-0.17.1.md
+++ b/docs/release-notes/release-notes-0.17.1.md
@@ -16,9 +16,20 @@
 
 ### Bug Fixes
 
+* [Gate wallet-ready status on lnd's actual RPC
+  readiness](https://github.com/lightninglabs/lightning-terminal/pull/1353):
+  Fixed a startup race where litd could report the LND sub-server as "Wallet
+  Ready" before lnd's RPC interceptor had actually left its
+  `WAITING_TO_START` state, so the very next call could still fail with
+  `rpc error: ... waiting to start`.
+
 ### Functional Changes/Additions
 
 ### Technical and Architectural Updates
+
+* [Report litd's own version for `litd
+  -V`](https://github.com/lightninglabs/lightning-terminal/pull/1337): The `-V`
+  flag now prints litd's version instead of the integrated lnd version.
 
 ## RPC Updates
 
@@ -35,3 +46,6 @@
 ### Taproot Assets
 
 # Contributors (Alphabetical Order)
+
+* 0xfandom
+* bitromortac

--- a/docs/release-notes/release-notes-0.17.1.md
+++ b/docs/release-notes/release-notes-0.17.1.md
@@ -1,0 +1,37 @@
+# Release Notes
+
+- [Lightning Terminal](#lightning-terminal)
+    - [Bug Fixes](#bug-fixes)
+    - [Functional Changes/Additions](#functional-changesadditions)
+    - [Technical and Architectural Updates](#technical-and-architectural-updates)
+- [Integrated Binary Updates](#integrated-binary-updates)
+    - [LND](#lnd)
+    - [Loop](#loop)
+    - [Pool](#pool)
+    - [Faraday](#faraday)
+    - [Taproot Assets](#taproot-assets)
+- [Contributors](#contributors-alphabetical-order)
+
+## Lightning Terminal
+
+### Bug Fixes
+
+### Functional Changes/Additions
+
+### Technical and Architectural Updates
+
+## RPC Updates
+
+## Integrated Binary Updates
+
+### LND
+
+### Loop
+
+### Pool
+
+### Faraday
+
+### Taproot Assets
+
+# Contributors (Alphabetical Order)


### PR DESCRIPTION
This PR adds a release notes doc for `v0.17.1-alpha`, as we have many open PRs which still currently adds their respective release notes entry for the doc for `v0.17.0-alpha`, despite that release already being published.

We also move 2 entries that were accidentally merged to the doc for `v0.17.0-alpha` despite not being part of that release.  