### PR TITLE
terminal, config: fix tapd startup deadlock, require an HTLC interceptor

### DIFF
--- a/config.go
+++ b/config.go
@@ -997,6 +997,21 @@ func loadConfigFile(preCfg *Config, interceptor signal.Interceptor) (*Config,
 			cfg.Lnd.ProtocolOptions.CustomMessage, lnwire.MsgError,
 		)
 
+		// tapd's RFQ subsystem enforces the agreed upon quote for asset
+		// HTLCs through lnd's HTLC interceptor. Whenever no interceptor
+		// is attached, lnd forwards HTLCs without any of those checks.
+		// That window is narrow, as tapd's aux traffic shaper blocks
+		// forwards until tapd is ready, but it is real: it exists
+		// whenever tapd has to re-establish its interception stream,
+		// and for the brief moment between tapd signalling readiness
+		// and its interceptor actually registering. We therefore
+		// require an interceptor to be present whenever tapd runs
+		// in-process, which makes lnd fail forwards back instead of
+		// forwarding them unchecked.
+		if cfg.TaprootAssetsMode == ModeIntegrated {
+			cfg.Lnd.RequireInterceptor = true
+		}
+
 		var err error
 		cfg.Lnd, err = lnd.ValidateConfig(
 			*cfg.Lnd, interceptor, fileParser, flagParser,

--- a/docs/release-notes/release-notes-0.17.5.md
+++ b/docs/release-notes/release-notes-0.17.5.md
@@ -1,0 +1,54 @@
+# Release Notes
+
+- [Lightning Terminal](#lightning-terminal)
+    - [Bug Fixes](#bug-fixes)
+    - [Functional Changes/Additions](#functional-changesadditions)
+    - [Technical and Architectural Updates](#technical-and-architectural-updates)
+- [Integrated Binary Updates](#integrated-binary-updates)
+    - [LND](#lnd)
+    - [Loop](#loop)
+    - [Pool](#pool)
+    - [Faraday](#faraday)
+    - [Taproot Assets](#taproot-assets)
+- [Contributors](#contributors-alphabetical-order)
+
+## Lightning Terminal
+
+### Bug Fixes
+
+* [Fix a startup deadlock when tapd runs in integrated
+  mode](https://github.com/lightninglabs/lightning-terminal/pull/1371):
+  litd waited for lnd to be fully synced to chain before starting any of its
+  sub-servers, but lnd only reports itself as synced once its blockbeat has
+  caught up, and block processing can be blocked on tapd's aux sweeper, which
+  only becomes available once tapd is started. With a channel being resolved on
+  chain, litd stalled for 60 seconds per block, and for as long as blocks kept
+  arriving faster than that, tapd never came up at all. Any channel triggers
+  this, not just asset channels. litd now starts tapd first, then waits for
+  lnd's chain sync, then starts the remaining sub-servers, so loop, pool and
+  faraday still start against a synced lnd. We additionally require an HTLC
+  interceptor to be attached whenever tapd runs in-process, so lnd fails
+  forwards back instead of forwarding them without any RFQ policy checks.
+
+### Functional Changes/Additions
+
+### Technical and Architectural Updates
+
+## RPC Updates
+
+## Integrated Binary Updates
+
+### LND
+
+### Loop
+
+### Pool
+
+### Faraday
+
+### Taproot Assets
+
+# Contributors (Alphabetical Order)
+
+* bitromortac
+* George Tsagkarelis

--- a/itest/litd_startup_stall_test.go
+++ b/itest/litd_startup_stall_test.go
@@ -1,0 +1,301 @@
+package itest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightninglabs/lightning-terminal/litrpc"
+	"github.com/lightninglabs/lightning-terminal/subservers"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// sweepMaturityBlocks is the number of blocks we mine while the node
+	// under test is stopped, so that the CSV lock on the commitment's
+	// to_local output has matured by the time the node comes back up. That
+	// makes lnd's TxPublisher attempt the sweep on the very first blockbeat
+	// after the restart, which is what reaches into tapd.
+	sweepMaturityBlocks = 10
+
+	// tapdStartupBudget is how long tapd may take to report itself as
+	// running after the restart. A healthy startup takes a few seconds. A
+	// startup that blocks on lnd's blockbeat dispatcher takes at least one
+	// DefaultProcessBlockTimeout, which is 60s in lnd v0.21, so this
+	// separates the two cleanly while leaving headroom for slow CI
+	// runners.
+	tapdStartupBudget = 45 * time.Second
+
+	// stallObservationWindow bounds how long we watch for tapd so that a
+	// stalled startup is measured and reported rather than just timing out
+	// at the budget above.
+	stallObservationWindow = 3 * time.Minute
+
+	// maxResolutionBlocks bounds how many blocks we mine to drive the force
+	// close to resolution. Each block gives the sweeper another blockbeat
+	// to retry on, so this also bounds how many retries we are willing to
+	// wait for.
+	maxResolutionBlocks = 15
+
+	// resolutionPollInterval is how long we wait for the channel to resolve
+	// after each block before mining the next one.
+	resolutionPollInterval = 5 * time.Second
+)
+
+// testTapdStartupStall asserts that litd brings tapd up promptly when lnd has
+// an unresolved on-chain contract at startup.
+//
+// With both lnd and tapd integrated, litd hands tapd's server to lnd as its
+// AuxSweeper before either is started. tapd's AuxSweeper answers
+// DeriveSweepAddr by sending on an unbuffered channel whose only receiver is
+// started by tapd itself, so any sweep attempted before tapd is started parks
+// the caller. The caller is lnd's TxPublisher, a blockbeat consumer, so the
+// parked sweep also stops lnd's blockbeat dispatcher from advancing. Because
+// the dispatcher serves height queries from the same goroutine that notifies
+// consumers, everything that asks lnd for its sync state blocks too, including
+// GetInfo. Nothing recovers until the dispatcher gives up on the consumer after
+// DefaultProcessBlockTimeout, so anything on the startup path that waits for
+// lnd's sync state before tapd runs costs a full 60s.
+//
+// Note that lnd asks every configured aux sweeper for an extra sweep output
+// regardless of whether any input carries assets, so a vanilla channel force
+// close is enough to reach into tapd here; no asset channel is needed.
+func testTapdStartupStall(ctx context.Context, net *NetworkHarness,
+	t *harnessTest) {
+
+	// Both nodes are dedicated to this test. The node under test is left
+	// with a deliberately unresolved force close, and its counterparty sees
+	// the same channel as pending, so neither role can be filled by the
+	// shared Alice/Bob pair without leaking that state into later tests.
+	node, err := net.NewNode(t.t, "Stalled", nil, false, true)
+	require.NoError(t.t, err)
+	defer shutdownAndAssert(net, t, node)
+
+	peer, err := net.NewNode(t.t, "StalledPeer", nil, false, true)
+	require.NoError(t.t, err)
+	defer shutdownAndAssert(net, t, peer)
+
+	const (
+		initialBalance = btcutil.SatoshiPerBitcoin
+		fundingAmt     = 1_000_000
+	)
+
+	net.SendCoins(t.t, initialBalance, node)
+	net.EnsureConnected(t.t, node, peer)
+
+	chanPoint := openChannelAndAssert(
+		t, net, node, peer, lntest.OpenChannelParams{
+			Amt: fundingAmt,
+		},
+	)
+
+	// We force close from our own side so that the commitment leaves us
+	// with a CSV locked to_local output. That output is the on-chain
+	// contract that makes lnd sweep, and therefore call into tapd's aux
+	// sweeper, while litd is still starting up.
+	_, closeTxid, err := net.CloseChannel(node, chanPoint, true)
+	require.NoError(t.t, err, "unable to force close channel")
+
+	// Confirm the commitment so that the CSV clock starts running, but
+	// leave the sweep itself unresolved.
+	block := mineBlocks(t, net, 1, 1)[0]
+	assertTxInBlock(t, block, closeTxid)
+
+	// Guard the precondition explicitly: with no contract to resolve there
+	// is nothing to reach into tapd and the assertion below would hold
+	// trivially, whether or not the startup path is correct.
+	err = wait.NoError(func() error {
+		resp, err := node.PendingChannels(
+			ctx, &lnrpc.PendingChannelsRequest{},
+		)
+		if err != nil {
+			return err
+		}
+
+		if len(resp.PendingForceClosingChannels) != 1 {
+			return fmt.Errorf("expected 1 pending force closing "+
+				"channel, got %d",
+				len(resp.PendingForceClosingChannels))
+		}
+
+		return nil
+	}, defaultTimeout)
+	require.NoError(t.t, err, "no pending force close to resolve")
+
+	// Stop the node, mature the sweep while it is down, then start it again
+	// without waiting for the startup to complete. The harness' own startup
+	// wait would itself block on the stall we are measuring, so we poll
+	// litd's status server instead.
+	err = net.RestartNodeNoUnlock(node, func() error {
+		net.Miner.GenerateBlocks(sweepMaturityBlocks)
+
+		return nil
+	}, false)
+	require.NoError(t.t, err, "unable to restart node")
+
+	// We skipped the harness' startup bookkeeping above, so it has to be
+	// restored before anything uses the node's clients again, and on the
+	// way out even if an assertion fails: the deferred shutdown needs a
+	// working client. Failures are only logged because this also runs
+	// while a failed assertion is already unwinding the test.
+	restored := false
+	restore := func() {
+		if restored {
+			return
+		}
+		restored = true
+
+		conn, err := node.ConnectRPC(true)
+		if err != nil {
+			t.t.Logf("could not reconnect to node: %v", err)
+
+			return
+		}
+
+		err = node.WaitUntilStarted(conn, stallObservationWindow)
+		if err != nil {
+			t.t.Logf("node did not finish starting up: %v", err)
+
+			return
+		}
+
+		if err := node.initLightningClient(conn); err != nil {
+			t.t.Logf("could not re-init lnd client: %v", err)
+		}
+	}
+	defer restore()
+
+	// Measure rather than just bound the startup, so that a stall shows up
+	// as a duration in the test output instead of an anonymous deadline.
+	elapsed := waitForSubServerRunning(
+		t, node, subservers.TAP, stallObservationWindow,
+	)
+	t.t.Logf("tapd reported running %v after the restart", elapsed)
+
+	require.Lessf(
+		t.t, elapsed, tapdStartupBudget, "tapd took %v to start, "+
+			"which means the startup waited for lnd's blockbeat "+
+			"dispatcher to give up on the sweep parked in tapd's "+
+			"unstarted aux sweeper; skipping the chain sync wait "+
+			"is not sufficient as long as anything that queries "+
+			"lnd's sync state runs before tapd is started",
+		elapsed,
+	)
+
+	// Starting promptly is only half of what we need. Any fix that keeps
+	// the startup moving by failing the aux call that arrived too early
+	// trades the stall for a failed sweep attempt, so the sweep has to be
+	// retried once tapd is up. Drive the force close all the way to
+	// resolution to prove that happens: a change that removed the stall by
+	// permanently failing the sweep would pass every assertion above.
+	restore()
+	assertForceCloseResolved(t, net, node)
+}
+
+// assertForceCloseResolved mines blocks until the node reports no pending force
+// closing channels, which means its commitment output was swept and confirmed.
+// Each block is a fresh blockbeat, so this doubles as a bounded wait for the
+// sweeper to retry an attempt that failed earlier.
+func assertForceCloseResolved(t *harnessTest, net *NetworkHarness,
+	node *HarnessNode) {
+
+	t.t.Helper()
+
+	// If the node's lnd client couldn't be restored after the restart,
+	// there is nothing we can assert against here. Fail with that, rather
+	// than panicking on a nil client while the test is already unwinding.
+	require.NotNil(
+		t.t, node.LightningClient, "node has no lnd client, it did "+
+			"not finish starting up",
+	)
+
+	ctx := context.Background()
+	resolved := func() bool {
+		resp, err := node.PendingChannels(
+			ctx, &lnrpc.PendingChannelsRequest{},
+		)
+		if err != nil {
+			return false
+		}
+
+		return len(resp.PendingForceClosingChannels) == 0
+	}
+
+	for i := 0; i < maxResolutionBlocks; i++ {
+		err := wait.Predicate(resolved, resolutionPollInterval)
+		if err == nil {
+			t.t.Logf("force close resolved after %d blocks", i)
+
+			return
+		}
+
+		net.Miner.GenerateBlocks(1)
+	}
+
+	t.Fatalf("force close still pending after %d blocks; the sweep was "+
+		"never retried successfully", maxResolutionBlocks)
+}
+
+// waitForSubServerRunning waits for litd to report the given sub-server as
+// running and returns how long that took. It talks to litd's status server,
+// which starts serving as soon as the litd RPC listener is up and therefore
+// stays reachable for the whole startup, including while a sub-server is still
+// waiting on lnd.
+func waitForSubServerRunning(t *harnessTest, node *HarnessNode, name string,
+	timeout time.Duration) time.Duration {
+
+	t.t.Helper()
+
+	// Reaching the status server at all is a precondition rather than the
+	// behaviour under test, so it gets its own budget and is not counted
+	// towards the measured startup time.
+	ctxt, cancel := context.WithTimeout(
+		context.Background(), defaultTimeout,
+	)
+	defer cancel()
+
+	rawConn, err := connectLitRPC(
+		ctxt, node.Cfg.LitAddr(), node.Cfg.LitTLSCertPath, "",
+	)
+	require.NoError(t.t, err, "unable to reach litd status server")
+	defer rawConn.Close()
+
+	litConn := litrpc.NewStatusClient(rawConn)
+
+	start := time.Now()
+	err = wait.NoError(func() error {
+		states, err := litConn.SubServerStatus(
+			context.Background(), &litrpc.SubServerStatusReq{},
+		)
+		if err != nil {
+			return err
+		}
+
+		// The sub-server is only registered with the status manager
+		// once litd gets that far, so a missing entry is just a state
+		// we have not reached yet.
+		state, ok := states.SubServers[name]
+		if !ok {
+			return fmt.Errorf("sub-server %s not registered yet",
+				name)
+		}
+
+		if !state.Running {
+			return fmt.Errorf("sub-server %s not running: "+
+				"err=%q, status=%q", name, state.Error,
+				state.CustomStatus)
+		}
+
+		return nil
+	}, timeout)
+	require.NoErrorf(
+		t.t, err, "sub-server %s did not start within %v", name,
+		timeout,
+	)
+
+	return time.Since(start)
+}

--- a/itest/litd_test_list_on_test.go
+++ b/itest/litd_test_list_on_test.go
@@ -43,4 +43,8 @@ var allTestCases = []*testCase{
 		name: "faraday forwarding ability",
 		test: testFaradayForwardingAbility,
 	},
+	{
+		name: "terminal tapd startup stall",
+		test: testTapdStartupStall,
+	},
 }

--- a/subservers/manager.go
+++ b/subservers/manager.go
@@ -103,17 +103,6 @@ func (s *Manager) GetServer(name string) (SubServer, bool) {
 	return ss.SubServer, true
 }
 
-// StartIntegratedServers starts all the manager's sub-servers that should be
-// started in integrated mode.
-func (s *Manager) StartIntegratedServers(lndClient lnrpc.LightningClient,
-	lndGrpc *lndclient.GrpcLndServices, withMacaroonService bool) {
-
-	s.StartTapd(lndClient, lndGrpc, withMacaroonService)
-	s.StartRemainingIntegratedServers(
-		lndClient, lndGrpc, withMacaroonService,
-	)
-}
-
 // StartTapd starts the tapd sub-server if it runs in integrated mode. tapd
 // provides lnd's aux components, and lnd's block processing can be blocked on
 // them: if a channel is being resolved on chain, the sweeper calls into tapd's

--- a/subservers/manager.go
+++ b/subservers/manager.go
@@ -108,29 +108,78 @@ func (s *Manager) GetServer(name string) (SubServer, bool) {
 func (s *Manager) StartIntegratedServers(lndClient lnrpc.LightningClient,
 	lndGrpc *lndclient.GrpcLndServices, withMacaroonService bool) {
 
+	s.StartTapd(lndClient, lndGrpc, withMacaroonService)
+	s.StartRemainingIntegratedServers(
+		lndClient, lndGrpc, withMacaroonService,
+	)
+}
+
+// StartTapd starts the tapd sub-server if it runs in integrated mode. tapd
+// provides lnd's aux components, and lnd's block processing can be blocked on
+// them: if a channel is being resolved on chain, the sweeper calls into tapd's
+// aux sweeper, which blocks until tapd is started. tapd therefore has to be
+// started before anything waits on lnd's chain state, which is why it is
+// started separately from the remaining sub-servers.
+func (s *Manager) StartTapd(lndClient lnrpc.LightningClient,
+	lndGrpc *lndclient.GrpcLndServices, withMacaroonService bool) {
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for _, ss := range s.servers {
-		if ss.Remote() {
-			continue
-		}
-
-		err := ss.startIntegrated(
-			lndClient, lndGrpc, withMacaroonService,
-			func(err error) {
-				s.statusServer.SetErrored(
-					ss.Name(), err.Error(),
-				)
-			},
-		)
-		if err != nil {
-			s.statusServer.SetErrored(ss.Name(), err.Error())
-			continue
-		}
-
-		s.statusServer.SetRunning(ss.Name())
+	tapd, ok := s.servers[TAP]
+	if !ok {
+		return
 	}
+
+	s.startIntegratedServer(tapd, lndClient, lndGrpc, withMacaroonService)
+}
+
+// StartRemainingIntegratedServers starts all the manager's sub-servers that
+// should be started in integrated mode, except for tapd, which is started
+// through StartTapd.
+func (s *Manager) StartRemainingIntegratedServers(
+	lndClient lnrpc.LightningClient, lndGrpc *lndclient.GrpcLndServices,
+	withMacaroonService bool) {
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for name, ss := range s.servers {
+		if name == TAP {
+			continue
+		}
+
+		s.startIntegratedServer(
+			ss, lndClient, lndGrpc, withMacaroonService,
+		)
+	}
+}
+
+// startIntegratedServer starts a single sub-server in integrated mode and
+// records the outcome with the status server. Remote sub-servers are skipped.
+//
+// NOTE: The caller must hold the manager's mutex.
+func (s *Manager) startIntegratedServer(ss *subServerWrapper,
+	lndClient lnrpc.LightningClient, lndGrpc *lndclient.GrpcLndServices,
+	withMacaroonService bool) {
+
+	if ss.Remote() {
+		return
+	}
+
+	err := ss.startIntegrated(
+		lndClient, lndGrpc, withMacaroonService,
+		func(err error) {
+			s.statusServer.SetErrored(ss.Name(), err.Error())
+		},
+	)
+	if err != nil {
+		s.statusServer.SetErrored(ss.Name(), err.Error())
+
+		return
+	}
+
+	s.statusServer.SetRunning(ss.Name())
 }
 
 // ConnectRemoteSubServers creates connections to all the manager's sub-servers

--- a/subservers/manager_test.go
+++ b/subservers/manager_test.go
@@ -1,0 +1,161 @@
+package subservers
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	restProxy "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/lightninglabs/lightning-terminal/status"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+)
+
+// fakeSubServer is a minimal SubServer implementation that records whether it
+// has been started.
+type fakeSubServer struct {
+	name string
+
+	mu      sync.Mutex
+	started bool
+}
+
+func (f *fakeSubServer) Name() string {
+	return f.name
+}
+
+func (f *fakeSubServer) Remote() bool {
+	return false
+}
+
+func (f *fakeSubServer) RemoteConfig() *RemoteDaemonConfig {
+	return nil
+}
+
+func (f *fakeSubServer) Start(_ lnrpc.LightningClient,
+	_ *lndclient.GrpcLndServices, _ bool) error {
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.started = true
+
+	return nil
+}
+
+func (f *fakeSubServer) Stop() error {
+	return nil
+}
+
+func (f *fakeSubServer) RegisterGrpcService(grpc.ServiceRegistrar) {}
+
+func (f *fakeSubServer) RegisterRestService(context.Context,
+	*restProxy.ServeMux, string, []grpc.DialOption) error {
+
+	return nil
+}
+
+func (f *fakeSubServer) ServerErrChan() chan error {
+	return nil
+}
+
+func (f *fakeSubServer) MacPath() string {
+	return ""
+}
+
+func (f *fakeSubServer) Permissions() map[string][]bakery.Op {
+	return nil
+}
+
+func (f *fakeSubServer) WhiteListedURLs() map[string]struct{} {
+	return nil
+}
+
+func (f *fakeSubServer) Impl() fn.Option[any] {
+	return fn.None[any]()
+}
+
+func (f *fakeSubServer) ValidateMacaroon(context.Context, []bakery.Op,
+	string) error {
+
+	return nil
+}
+
+func (f *fakeSubServer) isStarted() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.started
+}
+
+// newTestManager returns a manager with one fake sub-server for each of the
+// integrated daemons, along with the fakes so the test can inspect them.
+func newTestManager(t *testing.T) (*Manager, map[string]*fakeSubServer) {
+	t.Helper()
+
+	fakes := map[string]*fakeSubServer{
+		LOOP:    {name: LOOP},
+		POOL:    {name: POOL},
+		FARADAY: {name: FARADAY},
+		TAP:     {name: TAP},
+	}
+
+	servers := make(map[string]*subServerWrapper, len(fakes))
+	for name, fake := range fakes {
+		servers[name] = &subServerWrapper{SubServer: fake}
+	}
+
+	mgr := &Manager{
+		servers:      servers,
+		statusServer: status.NewStatusManager(),
+	}
+
+	return mgr, fakes
+}
+
+// TestStartTapdOnlyStartsTapd asserts that StartTapd starts the tapd
+// sub-server and nothing else.
+func TestStartTapdOnlyStartsTapd(t *testing.T) {
+	t.Parallel()
+
+	mgr, fakes := newTestManager(t)
+
+	mgr.StartTapd(nil, nil, false)
+
+	for name, fake := range fakes {
+		require.Equal(t, name == TAP, fake.isStarted(), name)
+	}
+}
+
+// TestStartTapdWithoutTapd asserts that StartTapd is a no-op if tapd isn't
+// part of the manager's sub-servers at all.
+func TestStartTapdWithoutTapd(t *testing.T) {
+	t.Parallel()
+
+	mgr, fakes := newTestManager(t)
+	delete(mgr.servers, TAP)
+
+	mgr.StartTapd(nil, nil, false)
+
+	for name, fake := range fakes {
+		require.False(t, fake.isStarted(), name)
+	}
+}
+
+// TestStartRemainingSkipsTapd asserts that StartRemainingIntegratedServers
+// starts every integrated sub-server except tapd.
+func TestStartRemainingSkipsTapd(t *testing.T) {
+	t.Parallel()
+
+	mgr, fakes := newTestManager(t)
+
+	mgr.StartRemainingIntegratedServers(nil, nil, false)
+
+	for name, fake := range fakes {
+		require.Equal(t, name != TAP, fake.isStarted(), name)
+	}
+}

--- a/terminal.go
+++ b/terminal.go
@@ -846,9 +846,24 @@ func (g *LightningTerminal) start(ctx context.Context) error {
 	g.statusMgr.SetRunning(subservers.LND)
 
 	// Both connection types are ready now, let's start our sub-servers if
-	// they should be started locally as an integrated service.
+	// they should be started locally as an integrated service. tapd goes
+	// first: it provides lnd's aux components, and lnd's block processing
+	// can be blocked on them until tapd is started. Only once tapd is up do
+	// we wait for lnd to be synced to chain, so that the remaining
+	// sub-servers still start against a synced lnd, as they did before.
 	createDefaultMacaroons := !g.cfg.statelessInitMode
-	g.subServerMgr.StartIntegratedServers(
+	g.subServerMgr.StartTapd(
+		g.basicClient, g.lndClient, createDefaultMacaroons,
+	)
+
+	if g.integratedTapd() {
+		if err := g.waitForChainSync(ctx); err != nil {
+			return fmt.Errorf("error waiting for lnd chain "+
+				"sync: %w", err)
+		}
+	}
+
+	g.subServerMgr.StartRemainingIntegratedServers(
 		g.basicClient, g.lndClient, createDefaultMacaroons,
 	)
 
@@ -1020,6 +1035,24 @@ func (g *LightningTerminal) setupFullLNDClient(ctx context.Context,
 	// so if we instruct the lndclient to wait for the wallet sync, we
 	// should be fully ready to start all our subservers. This will just
 	// block until lnd signals readiness.
+	//
+	// There is one exception to that: with both lnd and tapd running
+	// in-process, we must not wait for lnd to be synced to chain here. lnd
+	// only reports itself as synced once its blockbeat caught up, and block
+	// processing can be blocked on tapd's aux components. If for example a
+	// channel is being resolved on chain, the sweeper calls into tapd's aux
+	// sweeper, which blocks until tapd is started. As tapd is only started
+	// once we have the client below, waiting here stalls the startup until
+	// lnd gives up on the blocked consumer (60 seconds per block), and for
+	// as long as blocks keep arriving faster than that, we'd retry here
+	// without ever starting tapd. In that case we start tapd first and wait
+	// for the chain sync ourselves afterwards, see waitForChainSync.
+	blockUntilChainSynced := !g.integratedTapd()
+	if !blockUntilChainSynced {
+		log.Infof("Not waiting for lnd to be synced to chain yet, as " +
+			"tapd is running in integrated mode")
+	}
+
 	log.Infof("Connecting full lnd client")
 	for {
 		g.lndClient, err = lndclient.NewLndServices(
@@ -1037,7 +1070,7 @@ func (g *LightningTerminal) setupFullLNDClient(ctx context.Context,
 				RPCTimeout:            g.cfg.LndRPCTimeout,
 				ChainSyncPollInterval: g.cfg.LndConnectInterval,
 
-				BlockUntilChainSynced:   true,
+				BlockUntilChainSynced:   blockUntilChainSynced,
 				BlockUntilUnlocked:      true,
 				BlockUntilChainNotifier: true,
 			},
@@ -1087,6 +1120,48 @@ func (g *LightningTerminal) setupFullLNDClient(ctx context.Context,
 	}
 
 	return nil
+}
+
+// integratedTapd returns true if both lnd and tapd run in-process, which is
+// the only combination where tapd's aux components are wired into lnd.
+func (g *LightningTerminal) integratedTapd() bool {
+	return g.cfg.LndMode == ModeIntegrated &&
+		g.cfg.TaprootAssetsMode == ModeIntegrated
+}
+
+// waitForChainSync blocks until lnd reports itself as fully synced to its
+// chain backend, or until the context is canceled. It is the wait we skip in
+// setupFullLNDClient when tapd is integrated, performed once tapd is started
+// and lnd's block processing can no longer be blocked on it. Errors from
+// individual GetInfo calls are logged and retried, as the connection to lnd
+// has already been established at this point.
+func (g *LightningTerminal) waitForChainSync(ctx context.Context) error {
+	log.Infof("Waiting for lnd to be synced to chain")
+
+	for {
+		ctxt, cancel := context.WithTimeout(ctx, g.cfg.LndRPCTimeout)
+		info, err := g.basicClient.GetInfo(
+			ctxt, &lnrpc.GetInfoRequest{},
+		)
+		cancel()
+
+		switch {
+		case err != nil:
+			log.Warnf("Error querying lnd sync state, retrying "+
+				"in %v: %v", g.cfg.LndConnectInterval, err)
+
+		case info.SyncedToChain:
+			log.Infof("lnd is synced to chain")
+
+			return nil
+		}
+
+		select {
+		case <-time.After(g.cfg.LndConnectInterval):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 }
 
 // startInternalSubServers starts all Litd specific sub-servers.


### PR DESCRIPTION
## Description

Fixes a startup deadlock in integrated mode, and closes an HTLC forwarding gap while tapd's interceptor isn't attached.

- litd waited for lnd to be synced to chain before starting the sub-servers. lnd only reports synced once its blockbeat has caught up, and block processing can block on tapd's aux sweeper, which blocks until tapd starts, which only happened after that wait. With a channel being resolved on chain, litd stalled 60 seconds per block and tapd never came up. litd now starts tapd first, then waits for chain sync itself, then starts the remaining sub-servers, so loop, pool and faraday still start against a synced lnd.

- We set lnd's `requireinterceptor` when tapd runs in-process, so lnd fails forwards back rather than forwarding them with no RFQ policy check while tapd's interceptor isn't attached.

Both are gated on lnd *and* tapd being integrated.

### Reviewer notes

The first version skipped the chain sync wait outright, which let faraday, loop and pool start against a catching-up lnd. @bitromortac pointed out the narrower shape, and this version does that instead.

His prototype also gates lnd's sweeper on an explicit aux readiness signal. Once tapd is started before anything waits on the sync, the sweeper waits until tapd is up either way, so it isn't a dependency here and belongs in lnd on its own merits.

The itest is his.

`requireinterceptor` is independent of the startup shape. tapd registers its interception stream in a goroutine, so no start-time signal closes that gap, and it reopens whenever the stream is re-established.
