### PR TITLE
subservers: report remote sub-server disconnects at runtime

### DIFF
--- a/docs/release-notes/release-notes-0.17.2.md
+++ b/docs/release-notes/release-notes-0.17.2.md
@@ -34,6 +34,13 @@
   while waiting, and aborts immediately if lnd stops or reports an error rather
   than always waiting out the full timeout.
 
+* [Report remote sub-server disconnects at
+  runtime](https://github.com/lightninglabs/lightning-terminal/pull/1373): In
+  remote mode, a sub-server that disconnected after startup was still reported as
+  running by the status server, so `litcli status` kept showing it as healthy.
+  litd now watches each remote sub-server's connection and updates its status
+  when it disconnects or recovers.
+
 ### Functional Changes/Additions
 
 ### Technical and Architectural Updates
@@ -60,3 +67,4 @@
 # Contributors (Alphabetical Order)
 
 * Elle Mouton
+* Vandit Singh

--- a/status/manager.go
+++ b/status/manager.go
@@ -275,7 +275,7 @@ func (s *Manager) SetErrored(name string, errStr string,
 		return
 	}
 
-	log.Errorf("could not start the %s sub-server: %s", name, errStr)
+	log.Errorf("The %s sub-server errored: %s", name, errStr)
 
 	ss.running = false
 	ss.err = errStr

--- a/subservers/manager.go
+++ b/subservers/manager.go
@@ -151,6 +151,19 @@ func (s *Manager) ConnectRemoteSubServers() {
 		}
 
 		s.statusServer.SetRunning(ss.Name())
+
+		// Watch the remote connection so a disconnect at runtime is
+		// reflected in the status server, not just a failure during
+		// startup.
+		name := ss.Name()
+		ss.watchRemoteConn(
+			func(err error) {
+				s.statusServer.SetErrored(name, err.Error())
+			},
+			func() {
+				s.statusServer.SetRunning(name)
+			},
+		)
 	}
 }
 
@@ -350,10 +363,8 @@ func (s *Manager) Stop() error {
 	defer s.mu.RUnlock()
 
 	for _, ss := range s.servers {
-		if ss.Remote() {
-			continue
-		}
-
+		// Remote sub-servers are torn down here too, so their
+		// connection and its runtime watcher stop as well.
 		err := ss.stop()
 		if err != nil {
 			log.Errorf("Error stopping %s: %v", ss.Name(), err)

--- a/subservers/subserver.go
+++ b/subservers/subserver.go
@@ -1,6 +1,7 @@
 package subservers
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 )
 
 const (
@@ -57,8 +59,10 @@ func (s *subServerWrapper) setStarted(started bool) {
 // stop the subServer by closing the connection to it if it is remote or by
 // stopping the integrated process.
 func (s *subServerWrapper) stop() error {
-	// If the sub-server has not yet started, then we can exit early.
-	if !s.started() {
+	// An integrated sub-server that never started has nothing to stop. A
+	// remote sub-server has no started flag, so always tear it down to
+	// close its connection and stop its connection watcher.
+	if !s.Remote() && !s.started() {
 		return nil
 	}
 
@@ -149,4 +153,73 @@ func (s *subServerWrapper) connectRemote() error {
 	s.remoteConn = conn
 
 	return nil
+}
+
+// watchRemoteConn watches the remote sub-server's connection and reports its
+// runtime health through the given callbacks. onError is called when the
+// connection is lost after startup and onRunning when it recovers, so the
+// status server reflects a runtime disconnect instead of keeping the
+// sub-server marked as running. The watcher stops when the sub-server is
+// stopped.
+func (s *subServerWrapper) watchRemoteConn(onError func(error),
+	onRunning func()) {
+
+	conn := s.remoteConn
+	if conn == nil {
+		return
+	}
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		// Cancel the state-change wait when the sub-server stops.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go func() {
+			select {
+			case <-s.quit:
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+
+		// errored holds the last state we reported so we only push a
+		// status change on an actual transition.
+		var errored bool
+		for {
+			state := conn.GetState()
+			switch state {
+			case connectivity.TransientFailure,
+				connectivity.Shutdown:
+
+				if !errored {
+					errored = true
+					onError(fmt.Errorf("remote sub-server "+
+						"(%s) is disconnected (%s)",
+						s.Name(), state))
+				}
+
+			case connectivity.Ready:
+				if errored {
+					errored = false
+					onRunning()
+				}
+
+			case connectivity.Idle:
+				// A gRPC connection only leaves the idle
+				// state when used, so nudge it to connect.
+				// This keeps the connection observable so a
+				// disconnect is detected even when no
+				// requests are in flight.
+				conn.Connect()
+			}
+
+			// Block until the connection state changes or the
+			// sub-server is stopped.
+			if !conn.WaitForStateChange(ctx, state) {
+				return
+			}
+		}
+	}()
 }

--- a/subservers/subserver_test.go
+++ b/subservers/subserver_test.go
@@ -1,0 +1,104 @@
+package subservers
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// nameOnlySubServer is a stub SubServer that only implements Name, which is the
+// only method watchRemoteConn relies on.
+type nameOnlySubServer struct {
+	SubServer
+
+	name string
+}
+
+func (n *nameOnlySubServer) Name() string {
+	return n.name
+}
+
+// TestWatchRemoteConn asserts that a remote sub-server's runtime disconnect and
+// recovery are reported through the status callbacks, so the status server no
+// longer keeps a sub-server marked as running after it disconnects.
+func TestWatchRemoteConn(t *testing.T) {
+	t.Parallel()
+
+	// Start a real gRPC server so the client connection has a backend to
+	// connect to.
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := lis.Addr().String()
+
+	srv := grpc.NewServer()
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+
+	conn, err := grpc.NewClient(
+		addr, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	ss := &subServerWrapper{
+		SubServer:  &nameOnlySubServer{name: "test"},
+		remoteConn: conn,
+		quit:       make(chan struct{}),
+	}
+
+	erroredChan := make(chan struct{}, 8)
+	runningChan := make(chan struct{}, 8)
+	ss.watchRemoteConn(
+		func(error) { erroredChan <- struct{}{} },
+		func() { runningChan <- struct{}{} },
+	)
+	defer func() {
+		close(ss.quit)
+		ss.wg.Wait()
+	}()
+
+	// Wait until the connection is ready so the watcher starts from a
+	// healthy state before we take the backend down.
+	require.Eventually(t, func() bool {
+		conn.Connect()
+		return conn.GetState() == connectivity.Ready
+	}, 10*time.Second, 50*time.Millisecond)
+
+	// Take the backend down: the watcher must report the disconnect.
+	// Stop also closes the listener it was serving on.
+	srv.Stop()
+
+	select {
+	case <-erroredChan:
+	case <-time.After(10 * time.Second):
+		t.Fatal("expected the disconnect to be reported")
+	}
+
+	// Bring the backend back on the same address: the watcher must report
+	// that the sub-server is running again.
+	var lis2 net.Listener
+	require.Eventually(t, func() bool {
+		lis2, err = net.Listen("tcp", addr)
+		return err == nil
+	}, 10*time.Second, 100*time.Millisecond)
+
+	srv2 := grpc.NewServer()
+	go func() {
+		_ = srv2.Serve(lis2)
+	}()
+	defer srv2.Stop()
+
+	select {
+	case <-runningChan:
+	case <-time.After(20 * time.Second):
+		t.Fatal("expected the recovery to be reported")
+	}
+}


### PR DESCRIPTION
### Change

In remote mode, a sub-server that disconnected after startup was still reported as `running` by the status server, so `litcli status` kept showing it as healthy. Only failures during startup were tracked; a disconnect at runtime was not.

This adds a watcher on each remote sub-server's gRPC connection. When the connection drops (`TransientFailure`/`Shutdown`) the sub-server is marked errored, and when it recovers (`Ready`) it is marked running again, so the status server reflects the real runtime state.

Two smaller things came along with it:
- `Manager.Stop` now also tears down remote sub-servers (it skipped them before), so the watcher and the remote connection are stopped on shutdown. The remote branch in `stop()` was effectively dead before, since remote servers never reached it.
- `status.SetErrored` logged "could not start the X sub-server", which is wrong for a runtime disconnect, so the log is now neutral.

Note: the watcher nudges an idle connection with `conn.Connect()` so a disconnect is still observed when no requests are in flight. That keeps the remote connection warm rather than letting it idle out, which is the trade-off for observability here.

### Scope

This is the first, smallest step towards #644, as suggested by @ViktorT-11: get the status reporting right before adding any reconnect/restart logic. It intentionally does not restart sub-servers or touch the lnd reconnect path.

Known gaps left as follow-ups:
- Integrated `pool`/`faraday` expose no runtime error channel, so their disconnects are still not tracked.
- Actually restarting the lnd-dependent sub-servers after a disconnect.
- A remote server that is already down at connect time is briefly shown as running until the first failure transition (the connection is dialled lazily).

### Testing

`TestWatchRemoteConn` starts a real gRPC backend, stops it, and asserts the disconnect is reported, then restarts it and asserts the recovery is reported.

Part of #644.
