### PR TITLE
multi: don't fail startup when lnd takes a while to open its databases

### DIFF
--- a/config.go
+++ b/config.go
@@ -115,16 +115,17 @@ const (
 
 	defaultFirstLNCConnTimeout = 10 * time.Minute
 
-	// defaultLndReadyTimeout is the default maximum time that litd
-	// waits for lnd's RPC server to become ready. It currently applies
-	// to the one-time kvdb-to-SQL data migration, which must call into
-	// lnd's main RPC server (ListMacaroonIDs); that only becomes
-	// available once lnd reaches its "RPC active" state. On nodes with a
-	// large channel/graph state this can take well over a minute after
-	// the wallet is unlocked, and timing out aborts litd startup
-	// entirely (requiring a manual restart), so we default to a
-	// deliberately generous value that comfortably covers even large
-	// nodes.
+	// defaultLndReadyTimeout is the default maximum time that litd waits
+	// for lnd's RPC server to become ready. It applies both to the startup
+	// wait for lnd's RPC interceptor to leave WAITING_TO_START (which only
+	// happens once lnd has opened, and if necessary migrated, all of its
+	// databases) and to the one-time kvdb-to-SQL data migration, which
+	// must call into lnd's main RPC server (ListMacaroonIDs) and so needs
+	// lnd to have reached its "RPC active" state. On nodes with a large
+	// channel/graph state either can take many minutes, and timing out
+	// aborts litd startup entirely (requiring a manual restart), so we
+	// default to a deliberately generous value that comfortably covers
+	// even large nodes.
 	defaultLndReadyTimeout = 10 * time.Minute
 
 	// DatabaseBackendSqlite is the name of the SQLite database backend.
@@ -259,9 +260,10 @@ type Config struct {
 	autoMigrateKVDBApproved bool
 
 	// LndReadyTimeout is the maximum time that litd will wait for lnd's RPC
-	// server to become ready. This currently applies to the one-time
+	// server to become ready. This applies both to the startup wait for
+	// lnd's RPC interceptor to leave WAITING_TO_START and to the one-time
 	// kvdb-to-SQL data migration, which must call into lnd's RPC.
-	LndReadyTimeout time.Duration `long:"lndreadytimeout" description:"The maximum time that litd will wait for lnd's RPC server to become ready. This currently applies to the one-time migration of litd's legacy kvdb data to the configured SQL backend, which must call into lnd's RPC. On nodes with a large channel and graph state, lnd can take a while to start serving RPC calls after the wallet is unlocked; increase this value if startup fails with an error mentioning that lnd's 'RPC server is in the process of starting up'."`
+	LndReadyTimeout time.Duration `long:"lndreadytimeout" description:"The maximum time that litd will wait for lnd's RPC server to become ready. This applies to the startup wait for lnd to finish opening (and if necessary migrating) its databases, and to the one-time migration of litd's legacy kvdb data to the configured SQL backend, which must call into lnd's RPC. On nodes with a large channel and graph state, lnd can take many minutes to start serving RPC calls; increase this value if startup fails with an error mentioning that lnd's 'RPC interceptor did not leave WAITING_TO_START' or that lnd's 'RPC server is in the process of starting up'."`
 
 	// Sqlite holds the configuration options for a SQLite database
 	// backend.
@@ -721,10 +723,11 @@ func loadAndValidateConfig(ctx context.Context,
 			"to avoid problems", minimumRPCTimeout)
 	}
 
-	// The work that waits on lnd's readiness (currently the kvdb-to-SQL
-	// migration) cannot proceed without lnd, so a non-positive timeout
-	// would make it fail immediately on any node where lnd isn't
-	// instantly ready. Require a positive value.
+	// The work that waits on lnd's readiness (the startup wait for lnd's
+	// RPC interceptor and the kvdb-to-SQL migration) cannot proceed
+	// without lnd, so a non-positive timeout would make it fail
+	// immediately on any node where lnd isn't instantly ready. Require a
+	// positive value.
 	if cfg.LndReadyTimeout <= 0 {
 		return nil, fmt.Errorf("lndreadytimeout must be positive, got "+
 			"%v", cfg.LndReadyTimeout)

--- a/docs/release-notes/release-notes-0.17.2.md
+++ b/docs/release-notes/release-notes-0.17.2.md
@@ -1,0 +1,57 @@
+# Release Notes
+
+- [Lightning Terminal](#lightning-terminal)
+    - [Bug Fixes](#bug-fixes)
+    - [Functional Changes/Additions](#functional-changesadditions)
+    - [Technical and Architectural Updates](#technical-and-architectural-updates)
+- [Integrated Binary Updates](#integrated-binary-updates)
+    - [LND](#lnd)
+    - [Loop](#loop)
+    - [Pool](#pool)
+    - [Faraday](#faraday)
+    - [Taproot Assets](#taproot-assets)
+- [Contributors](#contributors-alphabetical-order)
+
+## Lightning Terminal
+
+### Bug Fixes
+
+* [Don't fail startup when lnd takes a while to open its
+  databases](https://github.com/lightninglabs/lightning-terminal/pull/1374):
+  Fixes a regression introduced in
+  [#1353](https://github.com/lightninglabs/lightning-terminal/pull/1353).
+  The startup wait for lnd's RPC interceptor to leave `WAITING_TO_START` was
+  bounded by a fixed 15 second timeout. That signal only clears once lnd has
+  completed its leader election and opened (and if necessary migrated) all of
+  its databases, which happens long after lnd's gRPC listener is bound and
+  which can legitimately take many minutes on nodes with a large channel and
+  graph state, or on the first startup after an lnd version bump that migrates
+  them. Affected nodes aborted litd startup with `lnd RPC not ready: lnd's RPC
+  interceptor did not leave WAITING_TO_START within 15s` and reported both the
+  `lit` and `lnd` sub-servers as errored, even though lnd itself was healthy
+  and still starting up normally. The wait is now bounded by the configurable
+  `--lndreadytimeout` (defaulting to 10 minutes) instead, logs its progress
+  while waiting, and aborts immediately if lnd stops or reports an error rather
+  than always waiting out the full timeout.
+
+### Functional Changes/Additions
+
+### Technical and Architectural Updates
+
+## RPC Updates
+
+## Integrated Binary Updates
+
+### LND
+
+### Loop
+
+### Pool
+
+### Faraday
+
+### Taproot Assets
+
+# Contributors (Alphabetical Order)
+
+* Elle Mouton

--- a/lnd_ready.go
+++ b/lnd_ready.go
@@ -16,13 +16,30 @@ import (
 // macaroon exists. This lets us distinguish lnd's gRPC listener merely being
 // bound (which is all readyChan/unlockChan guarantee) from lnd actually being
 // able to service non-State RPCs.
+//
+// Note that lnd only leaves WAITING_TO_START once it has completed its leader
+// election and opened (and if necessary migrated) all of its databases, all of
+// which happen well after the listener is bound. On nodes with a large channel
+// and graph state, or on the first startup after an lnd version bump that
+// migrates them, that can legitimately take many minutes. The timeout must
+// therefore be generous: it exists only to eventually surface a genuinely
+// stuck lnd, not to police a normal but slow startup. We additionally abort as
+// soon as lnd stops or reports an error, so a real failure is still surfaced
+// promptly rather than waiting out the full timeout.
 func waitForLndRPCReady(ctx context.Context, stateClient lnrpc.StateClient,
-	timeout time.Duration) error {
+	timeout time.Duration, lndQuit <-chan struct{},
+	errChan <-chan error) error {
 
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 
-	var lastErr error
+	logTicker := time.NewTicker(lndReadyLogInterval)
+	defer logTicker.Stop()
+
+	var (
+		startTime = time.Now()
+		lastErr   error
+	)
 
 	for {
 		resp, err := stateClient.GetState(ctx, &lnrpc.GetStateRequest{})
@@ -37,6 +54,14 @@ func waitForLndRPCReady(ctx context.Context, stateClient lnrpc.StateClient,
 		select {
 		case <-time.After(stateServicePollInterval):
 
+		case <-logTicker.C:
+			log.Infof("Still waiting for lnd's RPC interceptor to "+
+				"leave WAITING_TO_START (%v elapsed of a %v "+
+				"timeout, last error: %v); lnd is most likely "+
+				"still opening or migrating its databases",
+				time.Since(startTime).Truncate(time.Second),
+				timeout, lastErr)
+
 		case <-timer.C:
 			if lastErr != nil {
 				return fmt.Errorf("lnd's RPC interceptor "+
@@ -46,6 +71,15 @@ func waitForLndRPCReady(ctx context.Context, stateClient lnrpc.StateClient,
 
 			return fmt.Errorf("lnd's RPC interceptor did not "+
 				"leave WAITING_TO_START within %v", timeout)
+
+		case err := <-errChan:
+			return fmt.Errorf("error while waiting for lnd's RPC "+
+				"interceptor to leave WAITING_TO_START: %w",
+				err)
+
+		case <-lndQuit:
+			return fmt.Errorf("lnd stopped while waiting for its " +
+				"RPC interceptor to leave WAITING_TO_START")
 
 		case <-ctx.Done():
 			return ctx.Err()

--- a/lnd_ready_test.go
+++ b/lnd_ready_test.go
@@ -48,10 +48,28 @@ func TestWaitForLndRPCReady(t *testing.T) {
 		State: lnrpc.WalletState_WAITING_TO_START,
 	}
 
+	// stuckClient never leaves WAITING_TO_START, so any test using it only
+	// terminates via the timeout or one of the early-abort channels.
+	stuckClient := func() *fakeStateClient {
+		return &fakeStateClient{
+			responses: []*lnrpc.GetStateResponse{waitingResp},
+			errs:      []error{nil},
+		}
+	}
+
+	closedChan := func() chan struct{} {
+		c := make(chan struct{})
+		close(c)
+
+		return c
+	}
+
 	testCases := []struct {
 		name        string
 		client      *fakeStateClient
 		timeout     time.Duration
+		lndQuit     <-chan struct{}
+		errChan     <-chan error
 		expectError bool
 	}{
 		{
@@ -96,6 +114,29 @@ func TestWaitForLndRPCReady(t *testing.T) {
 			timeout:     300 * time.Millisecond,
 			expectError: true,
 		},
+		{
+			// A long timeout here proves that we abort on the
+			// lndQuit signal rather than waiting out the timer.
+			name:        "lnd stops while waiting",
+			client:      stuckClient(),
+			timeout:     time.Hour,
+			lndQuit:     closedChan(),
+			expectError: true,
+		},
+		{
+			// As above, but for an error surfacing on the error
+			// queue while we're still waiting.
+			name:    "error while waiting",
+			client:  stuckClient(),
+			timeout: time.Hour,
+			errChan: func() <-chan error {
+				c := make(chan error, 1)
+				c <- errors.New("lnd blew up")
+
+				return c
+			}(),
+			expectError: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -105,6 +146,7 @@ func TestWaitForLndRPCReady(t *testing.T) {
 
 			err := waitForLndRPCReady(
 				context.Background(), tc.client, tc.timeout,
+				tc.lndQuit, tc.errChan,
 			)
 
 			if tc.expectError {

--- a/terminal.go
+++ b/terminal.go
@@ -92,6 +92,16 @@ const (
 	// stateServicePollInterval is how often we poll lnd's StateService
 	// while waiting for its RPC interceptor to leave WAITING_TO_START.
 	stateServicePollInterval = 200 * time.Millisecond
+
+	// lndReadyLogInterval is how often we log while still waiting for
+	// lnd's RPC interceptor to leave WAITING_TO_START. lnd remains in that
+	// state for the entirety of its database open, which lnd itself warns
+	// "might take a few minutes" on large nodes, so without periodic
+	// feedback a perfectly healthy startup is indistinguishable from a
+	// hang. Chosen to be frequent enough to reassure an operator watching
+	// the logs, but rare enough not to drown out lnd's own migration
+	// progress logs over a multi-minute wait.
+	lndReadyLogInterval = 30 * time.Second
 )
 
 // restRegistration is a function type that represents a REST proxy
@@ -683,9 +693,16 @@ func (g *LightningTerminal) start(ctx context.Context) error {
 	// interceptor has advanced far enough to service non-State RPCs. Wait
 	// for that here so that the "Wallet Ready" status set below is not
 	// observed before it's actually true.
+	//
+	// The listener is bound long before lnd opens its databases, so this
+	// wait spans the entire (potentially very long) database open and
+	// migration. We therefore bound it by the same generous, configurable
+	// timeout that the other lnd-readiness wait uses, and abort early if
+	// lnd stops or errors out in the meantime.
 	lndStateClient := lnrpc.NewStateClient(g.lndConn)
 	if err := waitForLndRPCReady(
-		ctx, lndStateClient, defaultConnectTimeout,
+		ctx, lndStateClient, g.cfg.LndReadyTimeout, lndQuit,
+		g.errQueue.ChanOut(),
 	); err != nil {
 		g.statusMgr.SetErrored(
 			subservers.LND, "lnd RPC not ready: %v", err,


### PR DESCRIPTION
### Problem

Users on litd `v0.17.x` with `lnd v0.21.2` are seeing litd abort startup, with `/v1/status` reporting both the `lit` and `lnd` sub-servers as errored:

```
"lit": {
  "running": false,
  "error": "could not start Lit: lnd RPC not ready: lnd's RPC interceptor did not leave WAITING_TO_START within 15s"
},
"lnd": {
  "running": false,
  "error": "lnd RPC not ready: lnd's RPC interceptor did not leave WAITING_TO_START within 15s"
}
```

...on nodes where lnd is perfectly healthy and simply still starting up.

### Root cause

#1353 added a wait for lnd's RPC interceptor to leave `WAITING_TO_START`, bounded by `defaultConnectTimeout` (a fixed 15s). The premise was that once the `readyChan` signal we wait on just before it fires, lnd is nearly ready. It isn't.

`readyChan` is lnd's `lis.Ready`, closed in `startGrpcListen` as soon as the gRPC listener socket is bound. In `lnd.Main` that happens *before*:

1. leader election (if running with etcd clustering),
2. `implCfg.DatabaseBuilder.BuildDatabase` — the bbolt/channeldb open, channeldb migrations, graph cache population, and on 0.21 the kvdb-to-native-SQL migration,
3. `implCfg.BuildWalletConfig`, which is where `SetWalletNotCreated`/`SetWalletLocked` finally moves lnd out of `WAITING_TO_START`.

So the 15s budget has to cover lnd's entire database open — the step lnd itself warns "might take a few minutes" about. On nodes with a large channel and graph state, or on the first startup after a version bump that migrates them, blowing through 15s is the expected outcome, not a symptom of anything being wrong.

`defaultConnectTimeout` is also a gRPC dial timeout, shared with `lnd_connection.go` and `session_rpcserver.go`, so it was never an appropriate budget for a database migration and can't just be raised in place.

Note that this failure is not fatal to lnd — `start()` returning an error leaves the status server up and `lnd.Main` running — but litd abandons the rest of its startup, so the lnd clients, the accounts service, the session server, the firewall middleware and the integrated sub-servers never start.

### Fix

Bound the wait by the existing `--lndreadytimeout` instead, which already covers the other place we wait on lnd's readiness (the kvdb-to-SQL migration) and defaults to a generous 10 minutes. Its description is widened to cover both uses and to name both error strings, so the flag is greppable from either failure.

Two supporting changes so that a long timeout doesn't trade one bad failure mode for another:

- The wait now also selects on `lndQuit` and the error queue, matching the `waitForSignal` closure just below it. A genuinely dead lnd is surfaced immediately rather than after the full timeout.
- Progress is logged every 30s, so a slow-but-healthy startup is distinguishable from a hang in the logs.

### Testing

- Two new cases in `TestWaitForLndRPCReady` covering the early-abort paths, each with a 1 hour timeout so they fail if the abort doesn't work.
- Existing timeout and poll cases unchanged and still passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)