### PR TITLE
terminal: default the signet autopilot server

### DIFF
--- a/docs/release-notes/release-notes-0.17.2.md
+++ b/docs/release-notes/release-notes-0.17.2.md
@@ -34,6 +34,13 @@
   while waiting, and aborts immediately if lnd stops or reports an error rather
   than always waiting out the full timeout.
 
+* [Default the signet autopilot
+  server](https://github.com/lightninglabs/lightning-terminal/pull/1377):
+  Starting `litd` with `--network=signet` failed with `no autopilot server
+  address specified`, because the autopilot address was only defaulted for
+  mainnet and testnet. Signet now defaults to the public signet autopilot
+  server, so a signet node starts without extra configuration.
+
 ### Functional Changes/Additions
 
 ### Technical and Architectural Updates
@@ -60,3 +67,4 @@
 # Contributors (Alphabetical Order)
 
 * Elle Mouton
+* Vandit Singh

--- a/terminal.go
+++ b/terminal.go
@@ -76,6 +76,7 @@ import (
 const (
 	MainnetServer = "autopilot.lightning.finance:12010"
 	TestnetServer = "test.autopilot.lightning.finance:12010"
+	SignetServer  = "signet.autopilot.lightning.finance:12010"
 
 	// lndWalletReadyStatus is a custom status that will be used with the
 	// LND subserver. If the subserver is in this state then it will allow
@@ -502,6 +503,8 @@ func (g *LightningTerminal) start(ctx context.Context) error {
 				g.cfg.Autopilot.Address = MainnetServer
 			case "testnet":
 				g.cfg.Autopilot.Address = TestnetServer
+			case "signet":
+				g.cfg.Autopilot.Address = SignetServer
 			default:
 				return errors.New("no autopilot server " +
 					"address specified")


### PR DESCRIPTION
Fixes #1348.

### Problem

Starting `litd` with `--network=signet` fails at startup:

```
[ERR] STAT: could not start Lit: no autopilot server address specified
```

In `start()`, the autopilot address is defaulted per network, but the switch only has cases for `mainnet` and `testnet`. `signet` is a valid `--network` choice, so it falls through to the `default` branch and returns the error. A signet user has to set `autopilot.disable=true` or configure `autopilot.address` by hand, which mainnet and testnet users do not.

### Fix

Add a `SignetServer` constant and a `case "signet"` to the switch, using the public signet autopilot server named in the issue (`signet.autopilot.lightning.finance:12010`). A signet node now starts and uses autopilot by default, the same as mainnet and testnet.

`testnet4`, `simnet` and `regtest` are left in the `default` branch on purpose, as they have no public autopilot server.

### Testing

Built the binary and ran `litd --network=signet` before and after the change:

- Before: startup fails with `no autopilot server address specified`.
- After: that error is gone and startup proceeds past the autopilot step.
