### PR TITLE
ci: Check out repo before disk cleanup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,8 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: cleanup space
         uses: ./.github/actions/cleanup-space
   


### PR DESCRIPTION
This PR solves an issue where the docker cleanup step uses a repository-local composite action, which GitHub cannot resolve until actions/checkout has populated the runner workspace.