### PR TITLE
version: bump version to `v0.17.2-alpha.docker`

### DIFF
--- a/version.go
+++ b/version.go
@@ -39,7 +39,7 @@ const (
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	appPreRelease = "alpha"
+	appPreRelease = "alpha-docker"
 )
 
 // Version returns the application version as a properly formed string per the


### PR DESCRIPTION
This PR bumps the version to `v0.17.2-alpha.docker` in the `v0_17_2-alpha_docker` branch.