### PR TITLE
firewall: map inbound fees for FeeReport endpoint

### DIFF
--- a/docs/release-notes/release-notes-0.17.3.md
+++ b/docs/release-notes/release-notes-0.17.3.md
@@ -1,0 +1,43 @@
+# Release Notes
+
+- [Lightning Terminal](#lightning-terminal)
+    - [Bug Fixes](#bug-fixes)
+    - [Functional Changes/Additions](#functional-changesadditions)
+    - [Technical and Architectural Updates](#technical-and-architectural-updates)
+- [Integrated Binary Updates](#integrated-binary-updates)
+    - [LND](#lnd)
+    - [Loop](#loop)
+    - [Pool](#pool)
+    - [Faraday](#faraday)
+    - [Taproot Assets](#taproot-assets)
+- [Contributors](#contributors-alphabetical-order)
+
+## Lightning Terminal
+
+### Bug Fixes
+
+### Functional Changes/Additions
+
+### Technical and Architectural Updates
+
+## RPC Updates
+
+[Inbound fees are passed
+through](https://github.com/lightninglabs/lightning-terminal/pull/1382) the
+privacy mapper for the FeeReport endpoint.
+
+## Integrated Binary Updates
+
+### LND
+
+### Loop
+
+### Pool
+
+### Faraday
+
+### Taproot Assets
+
+# Contributors (Alphabetical Order)
+
+* bitromortac

--- a/firewall/privacy_mapper.go
+++ b/firewall/privacy_mapper.go
@@ -524,12 +524,15 @@ func handleFeeReportResponse(db firewalldb.PrivacyMapDB,
 					}
 				}
 
+				// nolint:ll
 				chanFees[i] = &lnrpc.ChannelFeeReport{
-					ChanId:       chanID,
-					ChannelPoint: chanPoint,
-					BaseFeeMsat:  c.BaseFeeMsat,
-					FeePerMil:    c.FeePerMil,
-					FeeRate:      c.FeeRate,
+					ChanId:             chanID,
+					ChannelPoint:       chanPoint,
+					BaseFeeMsat:        c.BaseFeeMsat,
+					FeePerMil:          c.FeePerMil,
+					FeeRate:            c.FeeRate,
+					InboundBaseFeeMsat: c.InboundBaseFeeMsat,
+					InboundFeePerMil:   c.InboundFeePerMil,
 				}
 			}
 

--- a/firewall/privacy_mapper_test.go
+++ b/firewall/privacy_mapper_test.go
@@ -241,14 +241,27 @@ func TestPrivacyMapper(t *testing.T) {
 						ChannelPoint: outPoint(
 							clearTxID, 0,
 						),
+						BaseFeeMsat:        1_000,
+						FeePerMil:          250,
+						FeeRate:            0.00025,
+						InboundBaseFeeMsat: 500,
+						InboundFeePerMil:   100,
 					},
 					{
 						ChanId: 321,
 						ChannelPoint: outPoint(
 							clearTxID, 1,
 						),
+						BaseFeeMsat:        2_000,
+						FeePerMil:          300,
+						FeeRate:            0.0003,
+						InboundBaseFeeMsat: -500,
+						InboundFeePerMil:   -100,
 					},
 				},
+				DayFeeSum:   11,
+				WeekFeeSum:  22,
+				MonthFeeSum: 33,
 			},
 			expectedReplacement: &lnrpc.FeeReportResponse{
 				ChannelFees: []*lnrpc.ChannelFeeReport{
@@ -257,14 +270,27 @@ func TestPrivacyMapper(t *testing.T) {
 						ChannelPoint: outPoint(
 							obfusTxID0, obfusOut0,
 						),
+						BaseFeeMsat:        1_000,
+						FeePerMil:          250,
+						FeeRate:            0.00025,
+						InboundBaseFeeMsat: 500,
+						InboundFeePerMil:   100,
 					},
 					{
 						ChanId: 3446430762436373227,
 						ChannelPoint: outPoint(
 							obfusTxID1, obfusOut1,
 						),
+						BaseFeeMsat:        2_000,
+						FeePerMil:          300,
+						FeeRate:            0.0003,
+						InboundBaseFeeMsat: -500,
+						InboundFeePerMil:   -100,
 					},
 				},
+				DayFeeSum:   11,
+				WeekFeeSum:  22,
+				MonthFeeSum: 33,
 			},
 		},
 		{


### PR DESCRIPTION
This commit passes through inbound fees in the FeeReport privacy mapping in analogy to the outbound fees.