### PR TITLE
config: fix default remote lnd macaroon path on non-default networks

### DIFF
--- a/config.go
+++ b/config.go
@@ -1092,8 +1092,7 @@ func validateRemoteModeConfig(cfg *Config) error {
 
 		r.Lnd.MacaroonPath = filepath.Join(
 			defaultLndCfg.DataDir, defaultLndChainSubDir,
-			defaultLndChain, cfg.Network,
-			filepath.Base(defaultLndCfg.AdminMacPath),
+			defaultLndChain, cfg.Network, defaultLndMacaroon,
 		)
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/lightninglabs/lightning-terminal/db"
+	"github.com/lightningnetwork/lnd"
 	"github.com/stretchr/testify/require"
 )
 
@@ -148,4 +149,21 @@ func TestDontBlockPostgresOnlyStartup(t *testing.T) {
 			t.Context(), cfg, litDir,
 		),
 	)
+}
+
+// TestRemoteLndMacaroonPathForNonDefaultNetwork verifies that the default
+// remote lnd macaroon path is adjusted to the admin.macaroon file of the
+// selected network, and not to that network's directory itself.
+func TestRemoteLndMacaroonPathForNonDefaultNetwork(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Network = "regtest"
+	cfg.Remote.LitLogDir = t.TempDir()
+
+	require.NoError(t, validateRemoteModeConfig(cfg))
+
+	expectedPath := filepath.Join(
+		lnd.DefaultConfig().DataDir, "chain", "bitcoin", "regtest",
+		"admin.macaroon",
+	)
+	require.Equal(t, expectedPath, cfg.Remote.Lnd.MacaroonPath)
 }

--- a/docs/release-notes/release-notes-0.17.3.md
+++ b/docs/release-notes/release-notes-0.17.3.md
@@ -1,0 +1,47 @@
+# Release Notes
+
+- [Lightning Terminal](#lightning-terminal)
+    - [Bug Fixes](#bug-fixes)
+    - [Functional Changes/Additions](#functional-changesadditions)
+    - [Technical and Architectural Updates](#technical-and-architectural-updates)
+- [Integrated Binary Updates](#integrated-binary-updates)
+    - [LND](#lnd)
+    - [Loop](#loop)
+    - [Pool](#pool)
+    - [Faraday](#faraday)
+    - [Taproot Assets](#taproot-assets)
+- [Contributors](#contributors-alphabetical-order)
+
+## Lightning Terminal
+
+### Bug Fixes
+
+* [Fix the default remote lnd macaroon path on non-default
+  networks](https://github.com/lightninglabs/lightning-terminal/pull/1386):
+  In remote lnd mode, litd rewrites the default macaroon path when a
+  non-default `--network` is selected, so that `--network=regtest` alone is
+  enough. The file name was taken from `lnd.DefaultConfig().AdminMacPath`,
+  which lnd only populates in its own `ValidateConfig`, a step litd never runs
+  in remote mode. The resulting path was the network's chain directory rather
+  than the `admin.macaroon` file inside it, and startup failed with
+  `read .../chain/bitcoin/regtest: is a directory`.
+
+### Functional Changes/Additions
+
+### Technical and Architectural Updates
+
+## RPC Updates
+
+## Integrated Binary Updates
+
+### LND
+
+### Loop
+
+### Pool
+
+### Faraday
+
+### Taproot Assets
+
+# Contributors (Alphabetical Order)


### PR DESCRIPTION
Fixes #512.

### The bug

In remote-lnd mode, `validateRemoteModeConfig` rewrites the default macaroon
path when a non-default `--network` is selected, so that the user only has to
pass `--network=regtest` and everything else is implied:

```go
r.Lnd.MacaroonPath = filepath.Join(
        defaultLndCfg.DataDir, defaultLndChainSubDir,
        defaultLndChain, cfg.Network,
        filepath.Base(defaultLndCfg.AdminMacPath),
)
```

`defaultLndCfg` comes from `lnd.DefaultConfig()`, which never populates
`AdminMacPath` - lnd only fills that field in its own `ValidateConfig`, which
litd does not call in remote mode. So the last element is
`filepath.Base("")` == `"."`, and `filepath.Join` cleans the trailing `"."`
away. The computed path ends up being the network's chain *directory* rather
than the `admin.macaroon` *file* inside it, and startup fails with

```
error querying remote node: read /root/.lnd/data/chain/bitcoin/regtest: is a directory
```

Repro (no lnd needed, the path is already wrong before anything is read):

```
litd --lnd-mode=remote --network=regtest --remote.lnd.rpcserver=localhost:10009
```

@guggero diagnosed this exact line in the issue thread back in 2023, this just
implements it.

### The fix

`config.go` already has the `defaultLndMacaroon = "admin.macaroon"` constant a
few lines up, and already uses it to build `DefaultRemoteLndMacaroonPath` in
exactly the same shape. Using it here too makes the non-default-network path
the same expression as the default one, with the network swapped.

This restores the behaviour `docs/config-lnd-remote.md` already documents:
"either specify the `--network` flag and the `--tlscertpath` and
`--macaroonpath` are implied by looking inside the default directories for that
network".

### Testing

Added `TestRemoteLndMacaroonPathForNonDefaultNetwork` to `config_test.go`. It
fails on master with

```
expected: ".../data/chain/bitcoin/regtest/admin.macaroon"
actual  : ".../data/chain/bitcoin/regtest"
```

and passes with the fix. The rest of the root package's unit tests still pass.
The four Postgres-fixture tests need a Docker daemon I do not have locally, so
those were not exercised.

### Release notes

`v0.17.2-alpha` is already tagged, so I started
`docs/release-notes/release-notes-0.17.3.md` following the same pattern as
67412a8. Happy to rename it if the next release is not a patch bump.

---

Disclosure: I used Claude Code while working on this. The diagnosis, the fix and
the test are mine and I ran and verified them locally.

---
Used AI assistance on this; I reviewed and tested the change myself.