### PR TITLE
Bind session ID to presented macaroon

### DIFF
--- a/docs/release-notes/release-notes-0.17.3.md
+++ b/docs/release-notes/release-notes-0.17.3.md
@@ -16,15 +16,20 @@
 
 ### Bug Fixes
 
+* [Bind session ID to presented
+  macaroon](https://github.com/lightninglabs/lightning-terminal/pull/1387):
+  Firewall now verifies that the session ID supplied in gRPC metadata matches
+  the presented session macaroon.
+
 ### Functional Changes/Additions
 
 ### Technical and Architectural Updates
 
 ## RPC Updates
 
-[Inbound fees are passed
-through](https://github.com/lightninglabs/lightning-terminal/pull/1382) the
-privacy mapper for the FeeReport endpoint.
+* [Inbound fees are passed
+  through](https://github.com/lightninglabs/lightning-terminal/pull/1382) the
+  privacy mapper for the FeeReport endpoint.
 
 ## Integrated Binary Updates
 
@@ -41,3 +46,4 @@ privacy mapper for the FeeReport endpoint.
 # Contributors (Alphabetical Order)
 
 * bitromortac
+* ViktorT-11

--- a/firewall/privacy_mapper.go
+++ b/firewall/privacy_mapper.go
@@ -104,8 +104,14 @@ func (p *PrivacyMapper) Intercept(ctx context.Context,
 
 	ri, err := NewInfoFromRequest(req)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing incoming RPC middleware "+
-			"interception request: %v", err)
+		// We reject only the offending request here instead of
+		// returning a fatal error, since a malformed request can be
+		// triggered by any macaroon holder and must not tear down the
+		// interceptor.
+		return mid.RPCErrString(
+			req, "error parsing incoming RPC middleware "+
+				"interception request: %v", err,
+		)
 	}
 
 	sessionID, err := ri.SessionID.UnwrapOrErr(

--- a/firewall/privacy_mapper_test.go
+++ b/firewall/privacy_mapper_test.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightninglabs/lightning-terminal/firewalldb"
+	litmac "github.com/lightninglabs/lightning-terminal/macaroons"
 	"github.com/lightninglabs/lightning-terminal/session"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/rpcperms"
@@ -914,8 +916,14 @@ func TestPrivacyMapper(t *testing.T) {
 		},
 	}
 
+	// The macaroon must be a session macaroon, meaning its root key ID
+	// must encode the session ID, since the requests below carry the
+	// session ID in their gRPC metadata.
+	fixedSessionID := session.ID{0x01, 0x02, 0x03, 0x04}
+	rootKeyID := litmac.NewSuperMacaroonRootKeyID(fixedSessionID)
+
 	decodedID := &lnrpc.MacaroonId{
-		StorageId: []byte("123"),
+		StorageId: []byte(strconv.FormatUint(rootKeyID, 10)),
 	}
 	b, err := proto.Marshal(decodedID)
 	require.NoError(t, err)

--- a/firewall/request_info.go
+++ b/firewall/request_info.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/lightninglabs/lightning-terminal/accounts"
+	litmac "github.com/lightninglabs/lightning-terminal/macaroons"
 	"github.com/lightninglabs/lightning-terminal/session"
 	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -102,12 +103,27 @@ func NewInfoFromRequest(req *lnrpc.RPCMiddlewareRequest) (*RequestInfo, error) {
 	// If there is no macaroon in the request, then there is nothing left
 	// to parse.
 	if len(req.RawMacaroon) == 0 {
+		// A request that claims a session ID but presents no macaroon
+		// can never be bound to that session, so we reject it.
+		if ri.SessionID.IsSome() {
+			return nil, fmt.Errorf("session ID found in gRPC " +
+				"metadata but no macaroon present")
+		}
+
 		return ri, nil
 	}
 
 	ri.Macaroon = &macaroon.Macaroon{}
 	if err := ri.Macaroon.UnmarshalBinary(req.RawMacaroon); err != nil {
 		return nil, fmt.Errorf("error parsing macaroon: %v", err)
+	}
+
+	// The session ID transmitted via gRPC metadata is controlled by the
+	// client and must therefore never be trusted on its own. If one is
+	// set, the presented macaroon must be the session macaroon of that
+	// very session.
+	if err := bindSessionToMacaroon(ri.SessionID, ri.Macaroon); err != nil {
+		return nil, err
 	}
 
 	ri.Caveats = make([]string, len(ri.Macaroon.Caveats()))
@@ -149,6 +165,36 @@ func NewInfoFromRequest(req *lnrpc.RPCMiddlewareRequest) (*RequestInfo, error) {
 	}
 
 	return ri, nil
+}
+
+// bindSessionToMacaroon verifies that if a session ID is set, the given
+// macaroon is the session macaroon of that very session, meaning the session
+// ID encoded in the macaroon's root key ID matches the claimed session ID.
+func bindSessionToMacaroon(sessionID fn.Option[session.ID],
+	mac *macaroon.Macaroon) error {
+
+	if sessionID.IsNone() {
+		return nil
+	}
+
+	rootKeyID, err := litmac.RootKeyIDFromMacaroon(mac)
+	if err != nil {
+		return fmt.Errorf("error extracting root key ID from "+
+			"macaroon: %v", err)
+	}
+
+	if !litmac.IsSuperMacaroonRootKeyID(rootKeyID) {
+		return fmt.Errorf("macaroon with session ID in gRPC " +
+			"metadata is not a session macaroon")
+	}
+
+	macSessionID := session.IDFromMacRootKeyID(rootKeyID)
+	if macSessionID != sessionID.UnwrapOr(session.ID{}) {
+		return fmt.Errorf("session ID in gRPC metadata does not " +
+			"match the macaroon's session")
+	}
+
+	return nil
 }
 
 // String returns the string representation of the request info struct.

--- a/firewall/request_info_test.go
+++ b/firewall/request_info_test.go
@@ -1,0 +1,149 @@
+package firewall
+
+import (
+	"strconv"
+	"testing"
+
+	litmac "github.com/lightninglabs/lightning-terminal/macaroons"
+	"github.com/lightninglabs/lightning-terminal/session"
+	"github.com/lightningnetwork/lnd/fn"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon.v2"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+)
+
+// newMacaroonWithRootKeyID returns a macaroon that encodes the given root key
+// ID, the way macaroons baked by lnd do.
+func newMacaroonWithRootKeyID(t *testing.T,
+	rootKeyID uint64) *macaroon.Macaroon {
+
+	decodedID := &lnrpc.MacaroonId{
+		StorageId: []byte(strconv.FormatUint(rootKeyID, 10)),
+	}
+	idBytes, err := proto.Marshal(decodedID)
+	require.NoError(t, err)
+
+	rawID := make([]byte, len(idBytes)+1)
+	rawID[0] = byte(bakery.LatestVersion)
+	copy(rawID[1:], idBytes)
+
+	mac, err := macaroon.New([]byte("rootkey"), rawID, "", macaroon.V2)
+	require.NoError(t, err)
+
+	return mac
+}
+
+// newSessionMacaroon returns a macaroon that encodes the given session ID in
+// its root key ID, the way session macaroons baked by LiT do.
+func newSessionMacaroon(t *testing.T, id session.ID) *macaroon.Macaroon {
+	return newMacaroonWithRootKeyID(t, litmac.NewSuperMacaroonRootKeyID(id))
+}
+
+// newRequestFromMacaroon returns an RPC middleware interception request that
+// carries the given macaroon (which may be nil) and, if a session ID is
+// given, the session ID gRPC metadata.
+func newRequestFromMacaroon(t *testing.T, mac *macaroon.Macaroon,
+	sessionID fn.Option[session.ID]) *lnrpc.RPCMiddlewareRequest {
+
+	req := &lnrpc.RPCMiddlewareRequest{
+		RequestId: 1,
+		InterceptType: &lnrpc.RPCMiddlewareRequest_Request{
+			Request: &lnrpc.RPCMessage{
+				MethodFullUri: "/lnrpc.Lightning/GetInfo",
+			},
+		},
+	}
+
+	if mac != nil {
+		macBytes, err := mac.MarshalBinary()
+		require.NoError(t, err)
+
+		req.RawMacaroon = macBytes
+	}
+
+	sessionID.WhenSome(func(id session.ID) {
+		md := make(metadata.MD)
+		session.AddToGRPCMetadata(md, id)
+
+		req.MetadataPairs = make(map[string]*lnrpc.MetadataValues)
+		for k, vs := range md {
+			req.MetadataPairs[k] = &lnrpc.MetadataValues{
+				Values: vs,
+			}
+		}
+	})
+
+	return req
+}
+
+// TestNewInfoFromRequestSessionBinding tests that a session ID transmitted
+// via gRPC metadata is only accepted if the presented macaroon is the session
+// macaroon of that very session.
+func TestNewInfoFromRequestSessionBinding(t *testing.T) {
+	sessionID := session.ID{0x01, 0x02, 0x03, 0x04}
+	otherSessionID := session.ID{0x05, 0x06, 0x07, 0x08}
+
+	tests := []struct {
+		name        string
+		macaroon    *macaroon.Macaroon
+		sessionID   fn.Option[session.ID]
+		expectedErr string
+	}{
+		{
+			name:      "matching session ID",
+			macaroon:  newSessionMacaroon(t, sessionID),
+			sessionID: fn.Some(sessionID),
+		},
+		{
+			name:      "mismatched session ID",
+			macaroon:  newSessionMacaroon(t, sessionID),
+			sessionID: fn.Some(otherSessionID),
+			expectedErr: "does not match the macaroon's " +
+				"session",
+		},
+		{
+			name:        "non-session macaroon",
+			macaroon:    newMacaroonWithRootKeyID(t, 123),
+			sessionID:   fn.Some(sessionID),
+			expectedErr: "not a session macaroon",
+		},
+		{
+			name:        "no macaroon",
+			macaroon:    nil,
+			sessionID:   fn.Some(sessionID),
+			expectedErr: "no macaroon present",
+		},
+		{
+			name:      "no metadata with session macaroon",
+			macaroon:  newSessionMacaroon(t, sessionID),
+			sessionID: fn.None[session.ID](),
+		},
+		{
+			name:      "no metadata with non-session macaroon",
+			macaroon:  newMacaroonWithRootKeyID(t, 123),
+			sessionID: fn.None[session.ID](),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := newRequestFromMacaroon(
+				t, tc.macaroon, tc.sessionID,
+			)
+
+			ri, err := NewInfoFromRequest(req)
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+				require.Equal(t, tc.sessionID, ri.SessionID)
+
+				return
+			}
+
+			require.ErrorContains(t, err, tc.expectedErr)
+		})
+	}
+}

--- a/firewall/request_logger.go
+++ b/firewall/request_logger.go
@@ -133,8 +133,14 @@ func (r *RequestLogger) Intercept(ctx context.Context,
 
 	ri, err := NewInfoFromRequest(req)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing incoming RPC middleware "+
-			"interception request: %v", err)
+		// We reject only the offending request here instead of
+		// returning a fatal error, since a malformed request can be
+		// triggered by any macaroon holder and must not tear down the
+		// interceptor.
+		return mid.RPCErrString(
+			req, "error parsing incoming RPC middleware "+
+				"interception request: %v", err,
+		)
 	}
 
 	// If this request is for any URI in the uriSkipList map, then we do not

--- a/firewall/rule_enforcer.go
+++ b/firewall/rule_enforcer.go
@@ -108,8 +108,14 @@ func (r *RuleEnforcer) Intercept(ctx context.Context,
 
 	ri, err := NewInfoFromRequest(req)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing incoming RPC middleware "+
-			"interception request: %v", err)
+		// We reject only the offending request here instead of
+		// returning a fatal error, since a malformed request can be
+		// triggered by any macaroon holder and must not tear down the
+		// interceptor.
+		return mid.RPCErrString(
+			req, "error parsing incoming RPC middleware "+
+				"interception request: %v", err,
+		)
 	}
 
 	if ri.Rules == nil {

--- a/firewall/rule_enforcer.go
+++ b/firewall/rule_enforcer.go
@@ -301,9 +301,13 @@ func (r *RuleEnforcer) handleRequest(ctx context.Context,
 func (r *RuleEnforcer) handleResponse(ctx context.Context,
 	ri *RequestInfo) (proto.Message, error) {
 
-	sessionID, err := session.IDFromMacaroon(ri.Macaroon)
+	// The session ID was bound to the presented macaroon when the request
+	// was parsed, so it can be trusted to identify the session.
+	sessionID, err := ri.SessionID.UnwrapOrErr(
+		fmt.Errorf("no session ID found in request info"),
+	)
 	if err != nil {
-		return nil, fmt.Errorf("could not extract ID from macaroon")
+		return nil, err
 	}
 
 	enforcers, err := r.collectEnforcers(ctx, ri, sessionID)
@@ -335,9 +339,13 @@ func (r *RuleEnforcer) handleResponse(ctx context.Context,
 func (r *RuleEnforcer) handleErrorResponse(ctx context.Context,
 	ri *RequestInfo) (error, error) {
 
-	sessionID, err := session.IDFromMacaroon(ri.Macaroon)
+	// The session ID was bound to the presented macaroon when the request
+	// was parsed, so it can be trusted to identify the session.
+	sessionID, err := ri.SessionID.UnwrapOrErr(
+		fmt.Errorf("no session ID found in request info"),
+	)
 	if err != nil {
-		return nil, fmt.Errorf("could not extract ID from macaroon")
+		return nil, err
 	}
 
 	enforcers, err := r.collectEnforcers(ctx, ri, sessionID)

--- a/macaroons/super_mac.go
+++ b/macaroons/super_mac.go
@@ -63,13 +63,13 @@ func IsSuperMacaroon(macHex string) bool {
 		return false
 	}
 
-	return isSuperMacaroonRootKeyID(rootKeyID)
+	return IsSuperMacaroonRootKeyID(rootKeyID)
 }
 
-// isSuperMacaroonRootKeyID returns true if the given macaroon root key ID (also
-// known as storage ID) is a super macaroon, which can be identified by its
-// first 4 bytes.
-func isSuperMacaroonRootKeyID(rootKeyID uint64) bool {
+// IsSuperMacaroonRootKeyID returns true if the given macaroon root key ID
+// (also known as storage ID) is a super macaroon, which can be identified by
+// its first 4 bytes.
+func IsSuperMacaroonRootKeyID(rootKeyID uint64) bool {
 	rootKeyBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(rootKeyBytes, rootKeyID)
 	return bytes.HasPrefix(rootKeyBytes, SuperMacaroonRootKeyPrefix[:])

--- a/macaroons/super_mac_test.go
+++ b/macaroons/super_mac_test.go
@@ -36,8 +36,8 @@ func TestSuperMacaroonRootKeyID(t *testing.T) {
 
 	someBytes := [4]byte{02, 03, 44, 88}
 	rootKeyID := NewSuperMacaroonRootKeyID(someBytes)
-	require.True(t, isSuperMacaroonRootKeyID(rootKeyID))
-	require.False(t, isSuperMacaroonRootKeyID(123))
+	require.True(t, IsSuperMacaroonRootKeyID(rootKeyID))
+	require.False(t, IsSuperMacaroonRootKeyID(123))
 }
 
 // TestIsSuperMacaroon tests that we can correctly identify an example super


### PR DESCRIPTION
This PR ensures that the firewall now verifies that the session ID supplied in gRPC metadata matches the presented session macaroon.